### PR TITLE
Add rapybus-gitlawb.com as bootstrap peer

### DIFF
--- a/bootstrap-peers.json
+++ b/bootstrap-peers.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Canonical seed list for the Gitlawb network. Merged with GITLAWB_BOOTSTRAP_PEERS at startup. PRs to add public nodes welcome.",
   "version": 1,
-  "updated": "2026-04-29",
+  "updated": "2026-05-16",
   "peers": [
     {
       "name": "gitlawb",
@@ -10,6 +10,14 @@
       "http_url": "https://node.gitlawb.com",
       "p2p_multiaddr": null,
       "added": "2026-04-29"
+    },
+    {
+      "name": "rapybus-gitlawb",
+      "operator": "RapyBus S.A.C.",
+      "did": "did:key:z6MktERLyhFpjUyN7dnkf7CYY5RXKJ6BTZiKohoi37YVBS7R",
+      "http_url": "https://rapybus-gitlawb.com",
+      "p2p_multiaddr": null,
+      "added": "2026-05-16"
     }
   ]
 }


### PR DESCRIPTION
Adding our public node as a bootstrap peer.
  
  - Operator: RapyBus (Christopher Ebert)
  - URL: https://rapybus-gitlawb.com
  - DID: did:key:z6MktERLyhFpjUyN7dnkf7CYY5RXKJ6BTZiKohoi37YVBS7R
  - Health check: https://rapybus-gitlawb.com/health
  - Running: gitlawb-node v0.3.8 on AWS EC2 (always-on)