### PR TITLE
Resolve bare DID aliases for trust and cert lookups

### DIFF
--- a/crates/gitlawb-node/src/api/agents.rs
+++ b/crates/gitlawb-node/src/api/agents.rs
@@ -16,6 +16,29 @@ fn normalize_agent_did(did: &str) -> String {
     }
 }
 
+fn agent_key_segment(did: &str) -> &str {
+    did.split(':').next_back().unwrap_or(did)
+}
+
+async fn resolve_agent_did(state: &AppState, did: &str) -> Result<String> {
+    let normalized_did = normalize_agent_did(did);
+    if state.db.get_agent(&normalized_did).await?.is_some() {
+        return Ok(normalized_did);
+    }
+
+    let requested_key = agent_key_segment(&normalized_did);
+    let matching_agent = state
+        .db
+        .list_agents(None)
+        .await?
+        .into_iter()
+        .find(|agent| agent_key_segment(&agent.did).starts_with(requested_key));
+
+    Ok(matching_agent
+        .map(|agent| agent.did)
+        .unwrap_or(normalized_did))
+}
+
 #[derive(Debug, Serialize)]
 pub struct TrustResponse {
     pub did: String,
@@ -74,7 +97,7 @@ pub async fn show_agent(
     State(state): State<AppState>,
     Path(did): Path<String>,
 ) -> Result<(StatusCode, Json<AgentResponse>)> {
-    let normalized_did = normalize_agent_did(&did);
+    let normalized_did = resolve_agent_did(&state, &did).await?;
     let agent = state
         .db
         .get_agent(&normalized_did)
@@ -97,7 +120,7 @@ pub async fn get_trust(
     State(state): State<AppState>,
     Path(did): Path<String>,
 ) -> Result<Json<TrustResponse>> {
-    let normalized_did = normalize_agent_did(&did);
+    let normalized_did = resolve_agent_did(&state, &did).await?;
     let trust_score = state.db.get_trust_score(&normalized_did).await?;
     let push_count = state.db.get_push_count(&normalized_did).await?;
     let level = trust_level(trust_score);
@@ -112,7 +135,7 @@ pub async fn get_trust(
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_agent_did;
+    use super::{agent_key_segment, normalize_agent_did};
 
     #[test]
     fn normalize_agent_did_preserves_full_did() {
@@ -124,5 +147,11 @@ mod tests {
     #[test]
     fn normalize_agent_did_expands_bare_key() {
         assert_eq!(normalize_agent_did("z6MkExample"), "did:key:z6MkExample");
+    }
+
+    #[test]
+    fn agent_key_segment_extracts_did_key_material() {
+        assert_eq!(agent_key_segment("did:key:z6MkExample"), "z6MkExample");
+        assert_eq!(agent_key_segment("z6MkExample"), "z6MkExample");
     }
 }

--- a/crates/gitlawb-node/src/api/agents.rs
+++ b/crates/gitlawb-node/src/api/agents.rs
@@ -8,6 +8,14 @@ use serde::{Deserialize, Serialize};
 use crate::error::{AppError, Result};
 use crate::state::AppState;
 
+fn normalize_agent_did(did: &str) -> String {
+    if did.starts_with("did:") {
+        did.to_string()
+    } else {
+        format!("did:key:{did}")
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct TrustResponse {
     pub did: String,
@@ -66,11 +74,12 @@ pub async fn show_agent(
     State(state): State<AppState>,
     Path(did): Path<String>,
 ) -> Result<(StatusCode, Json<AgentResponse>)> {
+    let normalized_did = normalize_agent_did(&did);
     let agent = state
         .db
-        .get_agent(&did)
+        .get_agent(&normalized_did)
         .await?
-        .ok_or_else(|| AppError::NotFound(format!("agent {did} not found")))?;
+        .ok_or_else(|| AppError::NotFound(format!("agent {normalized_did} not found")))?;
     Ok((
         StatusCode::OK,
         Json(AgentResponse {
@@ -88,14 +97,32 @@ pub async fn get_trust(
     State(state): State<AppState>,
     Path(did): Path<String>,
 ) -> Result<Json<TrustResponse>> {
-    let trust_score = state.db.get_trust_score(&did).await?;
-    let push_count = state.db.get_push_count(&did).await?;
+    let normalized_did = normalize_agent_did(&did);
+    let trust_score = state.db.get_trust_score(&normalized_did).await?;
+    let push_count = state.db.get_push_count(&normalized_did).await?;
     let level = trust_level(trust_score);
 
     Ok(Json(TrustResponse {
-        did,
+        did: normalized_did,
         trust_score,
         push_count,
         level,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_agent_did;
+
+    #[test]
+    fn normalize_agent_did_preserves_full_did() {
+        let did = "did:key:z6MkExample";
+
+        assert_eq!(normalize_agent_did(did), did);
+    }
+
+    #[test]
+    fn normalize_agent_did_expands_bare_key() {
+        assert_eq!(normalize_agent_did("z6MkExample"), "did:key:z6MkExample");
+    }
 }

--- a/crates/gl/src/cert.rs
+++ b/crates/gl/src/cert.rs
@@ -7,6 +7,7 @@ use clap::{Args, Subcommand};
 use serde_json::Value;
 
 use crate::http::NodeClient;
+use crate::identity::load_keypair_from_dir;
 
 #[derive(Args)]
 pub struct CertArgs {
@@ -41,20 +42,25 @@ pub async fn run(args: CertArgs) -> Result<()> {
     }
 }
 
-/// Resolve "repo" into (owner, name) — if no slash, use the node's own DID short form.
+/// Resolve "repo" into (owner, name) using the caller's DID when no slash is given.
 async fn resolve_repo(repo: &str, node: &str) -> Result<(String, String)> {
     if let Some((owner, name)) = repo.split_once('/') {
         Ok((owner.to_string(), name.to_string()))
     } else {
-        let client = NodeClient::new(node, None);
-        let info: Value = client
-            .get("/")
-            .await?
-            .json()
-            .await
-            .context("failed to fetch node info")?;
-        let did = info["did"].as_str().context("node info missing 'did'")?;
-        let short = did.split(':').next_back().unwrap_or(did).to_string();
+        let short = if let Ok(kp) = load_keypair_from_dir(None) {
+            let did = kp.did().to_string();
+            did.split(':').next_back().unwrap_or(&did).to_string()
+        } else {
+            let client = NodeClient::new(node, None);
+            let info: Value = client
+                .get("/")
+                .await?
+                .json()
+                .await
+                .context("failed to fetch node info")?;
+            let did = info["did"].as_str().context("node info missing 'did'")?;
+            did.split(':').next_back().unwrap_or(did).to_string()
+        };
         Ok((short, repo.to_string()))
     }
 }
@@ -94,15 +100,16 @@ async fn cmd_show(repo: String, id: String, node: String) -> Result<()> {
     let (owner, name) = resolve_repo(&repo, &node).await?;
 
     let client = NodeClient::new(&node, None);
+    let id = resolve_cert_id(&client, &owner, &name, &id).await?;
 
     // Fetch the certificate
     let path = format!("/api/v1/repos/{owner}/{name}/certs/{id}");
-    let cert: Value = client
+    let resp = client
         .get(&path)
         .await?
-        .json()
-        .await
+        .error_for_status()
         .context("certificate not found")?;
+    let cert: Value = resp.json().await.context("certificate not found")?;
 
     let cert_id = cert["id"].as_str().unwrap_or("?");
     let ref_name = cert["ref_name"].as_str().unwrap_or("?");
@@ -154,4 +161,34 @@ async fn cmd_show(repo: String, id: String, node: String) -> Result<()> {
     println!("  Signature (base64url): {signature}");
 
     Ok(())
+}
+
+async fn resolve_cert_id(client: &NodeClient, owner: &str, name: &str, id: &str) -> Result<String> {
+    if id.len() >= 36 {
+        return Ok(id.to_string());
+    }
+
+    let path = format!("/api/v1/repos/{owner}/{name}/certs");
+    let resp: Value = client
+        .get(&path)
+        .await?
+        .error_for_status()
+        .context("failed to list certificates")?
+        .json()
+        .await
+        .context("failed to list certificates")?;
+
+    let certs = resp["certificates"].as_array().cloned().unwrap_or_default();
+    let matches: Vec<String> = certs
+        .iter()
+        .filter_map(|cert| cert["id"].as_str())
+        .filter(|cert_id| cert_id.starts_with(id))
+        .map(ToString::to_string)
+        .collect();
+
+    match matches.as_slice() {
+        [full_id] => Ok(full_id.to_string()),
+        [] => Ok(id.to_string()),
+        _ => anyhow::bail!("certificate prefix {id} matches multiple certificates"),
+    }
 }


### PR DESCRIPTION
## Summary
- normalize bare agent profile/trust identifiers like `z6MkpUq1...` to full `did:key:z6MkpUq1...` before trust lookup
- make `gl cert <repo>` resolve owner-less repo names against the caller DID instead of the node DID
- let `gl cert show` accept the short certificate ID printed by `gl cert list`

## Repro fixed
- `gl node trust did:key:z6MkpUq1Aw4mgNwwzhEd4f4eYvrUeizwmoT7NyiBx1e8Z9UY` => contributor trust with pushes
- `gl node trust z6MkpUq1Aw4mgNwwzhEd4f4eYvrUeizwmoT7NyiBx1e8Z9UY` previously showed newcomer/0 pushes
- `gl cert list agentbot-opensource` previously resolved to the node owner and printed `No ref certificates found`
- latest valid cert on the owner repo is `3686b1fe-afdf-428b-9fca-8745ad6f8a18` for `refs/heads/main` -> `3ac9fd6d8ca69337982c7bef212271d613fe8b56`

## Verification
- `cargo check -p gl`
- `cargo run -q -p gl -- cert list agentbot-opensource`
- `cargo run -q -p gl -- cert show agentbot-opensource 3686b1fe`
- `cargo check -p gitlawb-node`
- `cargo test -p gitlawb-node normalize_agent_did`