### PR TITLE
fix(doctor): detect git-remote-gitlawb.exe on Windows

### DIFF
--- a/crates/gl/src/doctor.rs
+++ b/crates/gl/src/doctor.rs
@@ -272,7 +272,13 @@ pub async fn run(args: DoctorArgs) -> Result<()> {
 /// Check if a binary name exists anywhere on PATH.
 fn which_in_path(name: &str) -> bool {
     std::env::var_os("PATH")
-        .map(|paths| std::env::split_paths(&paths).any(|dir| dir.join(name).exists()))
+        .map(|paths| {
+            std::env::split_paths(&paths).any(|dir| {
+                dir.join(name).exists()
+                    || (cfg!(target_os = "windows")
+                        && dir.join(format!("{name}.exe")).exists())
+            })
+        })
         .unwrap_or(false)
 }
 


### PR DESCRIPTION
## Summary

`gl doctor` was failing the `git-remote-gitlawb` check on Windows because `which_in_path()` only searched for the bare name without `.exe`. On Windows, executables have the `.exe` extension.

Fixed by adding a Windows-specific check for `{name}.exe` when the platform is Windows.

## Before
```
✗  git-remote-gitlawb        not found in PATH — gitlawb:// clone/push will not work
```

## After
```
✓  git-remote-gitlawb        found in PATH
```

## Test plan
- [x] Built `gl` from source on Windows x86_64
- [x] `gl doctor` now passes all 7 checks
- [x] Verified binary is correctly detected in `~/.local/bin/`

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)