### PR TITLE
chore: bump v0.3.9, fix all clippy warnings, enforce strict CI lint

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,10 +34,8 @@ jobs:
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
 
-      # TODO: tighten to `-- -D warnings` once existing lints are cleaned up
-      - name: cargo clippy (advisory)
-        run: cargo clippy --workspace --all-targets
-        continue-on-error: true
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: cargo test
         run: cargo test --workspace

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ keys/
 
 # Logs
 *.log
+.openclaude-profile.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "git-remote-gitlawb"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "gitlawb-core",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "gitlawb-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "base64",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "gitlawb-node"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "gl"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["gitlawb contributors"]

--- a/crates/gitlawb-node/src/api/arweave.rs
+++ b/crates/gitlawb-node/src/api/arweave.rs
@@ -30,7 +30,7 @@ pub async fn list_anchors(
         .db
         .list_arweave_anchors(q.repo.as_deref(), limit)
         .await
-        .map_err(|e| crate::error::AppError::Internal(e.into()))?;
+        .map_err(crate::error::AppError::Internal)?;
 
     Ok(Json(serde_json::json!({
         "anchors": anchors,

--- a/crates/gitlawb-node/src/api/events.rs
+++ b/crates/gitlawb-node/src/api/events.rs
@@ -70,7 +70,7 @@ pub async fn list_repo_events(
             record
                 .owner_did
                 .split(':')
-                .last()
+                .next_back()
                 .unwrap_or(&record.owner_did),
             repo_name
         )

--- a/crates/gitlawb-node/src/api/ipfs.rs
+++ b/crates/gitlawb-node/src/api/ipfs.rs
@@ -52,7 +52,7 @@ pub async fn get_by_cid(
         .db
         .list_all_repos()
         .await
-        .map_err(|e| AppError::Internal(e.into()))?;
+        .map_err(AppError::Internal)?;
 
     for repo in &repos {
         let repo_path = match state.repo_store.acquire(&repo.owner_did, &repo.name).await {
@@ -105,7 +105,7 @@ pub async fn list_pins(State(state): State<AppState>) -> Result<Json<serde_json:
         .db
         .list_pinned_cids()
         .await
-        .map_err(|e| AppError::Internal(e.into()))?;
+        .map_err(AppError::Internal)?;
 
     Ok(Json(serde_json::json!({
         "pins": pins,

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -125,7 +125,7 @@ pub async fn trigger_sync(State(state): State<AppState>) -> Result<Json<serde_js
             ) {
                 (Some(owner), Some(name)) => {
                     // Use short owner (last colon segment) matching DB convention
-                    let short = owner.split(':').last().unwrap_or(owner);
+                    let short = owner.split(':').next_back().unwrap_or(owner);
                     format!("{short}/{name}")
                 }
                 _ => continue,

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -513,7 +513,7 @@ pub async fn git_receive_pack(
         let owner_short = record
             .owner_did
             .split(':')
-            .last()
+            .next_back()
             .unwrap_or(&record.owner_did);
         let clone_url = format!("{}/{}/{}.git", base_url, owner_short, record.name);
 
@@ -574,7 +574,7 @@ pub async fn git_receive_pack(
             record
                 .owner_did
                 .split(':')
-                .last()
+                .next_back()
                 .unwrap_or(&record.owner_did),
             record.name
         );
@@ -707,15 +707,17 @@ pub async fn git_receive_pack(
                             let arweave_url = crate::arweave::arweave_url(&tx_id);
                             let _ = db_clone
                                 .record_arweave_anchor(
-                                    &repo_slug,
-                                    &owner_did_for_arweave,
-                                    ref_name,
-                                    "0".repeat(64).as_str(),
-                                    new_sha,
-                                    cid.as_deref(),
-                                    &tx_id,
-                                    &arweave_url,
-                                    &node_did_str,
+                                    &crate::db::RecordAnchorInput {
+                                        repo: &repo_slug,
+                                        owner_did: &owner_did_for_arweave,
+                                        ref_name,
+                                        old_sha: "0".repeat(64).as_str(),
+                                        new_sha,
+                                        cid: cid.as_deref(),
+                                        irys_tx_id: &tx_id,
+                                        arweave_url: &arweave_url,
+                                        node_did: &node_did_str,
+                                    },
                                 )
                                 .await;
                         }
@@ -865,7 +867,7 @@ pub async fn fork_repo(
     }
 
     // Check no name conflict under the forker's ownership
-    let forker_short = forker_did.split(':').last().unwrap_or(&forker_did);
+    let forker_short = forker_did.split(':').next_back().unwrap_or(&forker_did);
     if state.db.get_repo(forker_short, &fork_name).await?.is_some() {
         return Err(AppError::BadRequest(format!(
             "you already have a repo named {fork_name}"
@@ -1018,7 +1020,7 @@ fn to_response(record: &crate::db::RepoRecord, state: &AppState, star_count: i64
     let owner_short = record
         .owner_did
         .split(':')
-        .last()
+        .next_back()
         .unwrap_or(&record.owner_did);
 
     let base_url = state

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -134,8 +134,8 @@ pub async fn list_repos(
     State(state): State<AppState>,
     Query(query): Query<ListReposQuery>,
 ) -> Result<Response> {
-    use axum::response::IntoResponse;
     use axum::http::HeaderValue;
+    use axum::response::IntoResponse;
 
     if let Some(raw_limit) = query.limit {
         let limit = raw_limit.clamp(1, 200);
@@ -706,19 +706,17 @@ pub async fn git_receive_pack(
                         Ok(tx_id) if !tx_id.is_empty() => {
                             let arweave_url = crate::arweave::arweave_url(&tx_id);
                             let _ = db_clone
-                                .record_arweave_anchor(
-                                    &crate::db::RecordAnchorInput {
-                                        repo: &repo_slug,
-                                        owner_did: &owner_did_for_arweave,
-                                        ref_name,
-                                        old_sha: "0".repeat(64).as_str(),
-                                        new_sha,
-                                        cid: cid.as_deref(),
-                                        irys_tx_id: &tx_id,
-                                        arweave_url: &arweave_url,
-                                        node_did: &node_did_str,
-                                    },
-                                )
+                                .record_arweave_anchor(&crate::db::RecordAnchorInput {
+                                    repo: &repo_slug,
+                                    owner_did: &owner_did_for_arweave,
+                                    ref_name,
+                                    old_sha: "0".repeat(64).as_str(),
+                                    new_sha,
+                                    cid: cid.as_deref(),
+                                    irys_tx_id: &tx_id,
+                                    arweave_url: &arweave_url,
+                                    node_did: &node_did_str,
+                                })
                                 .await;
                         }
                         Ok(_) => {}

--- a/crates/gitlawb-node/src/arweave.rs
+++ b/crates/gitlawb-node/src/arweave.rs
@@ -111,9 +111,9 @@ pub fn arweave_url(tx_id: &str) -> String {
 /// Build the Irys tag header value for Arweave indexing.
 /// Format: comma-separated "name:value" pairs.
 fn build_tags_header(anchor: &RefAnchor) -> String {
-    vec![
-        format!("App-Name:gitlawb"),
-        format!("Schema:gitlawb/ref-update/v1"),
+    [
+        "App-Name:gitlawb".to_string(),
+        "Schema:gitlawb/ref-update/v1".to_string(),
         format!("Repo:{}", sanitize_tag(&anchor.repo)),
         format!("Ref:{}", sanitize_tag(&anchor.ref_name)),
         format!("SHA:{}", &anchor.new_sha[..anchor.new_sha.len().min(16)]),

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -573,10 +573,13 @@ impl Db {
         .fetch_all(&self.pool)
         .await?;
 
-        Ok(rows.into_iter().map(|r| {
-            let stars: i64 = r.get("star_count");
-            (row_to_repo(r), stars)
-        }).collect())
+        Ok(rows
+            .into_iter()
+            .map(|r| {
+                let stars: i64 = r.get("star_count");
+                (row_to_repo(r), stars)
+            })
+            .collect())
     }
 
     pub async fn list_all_repos_paged(
@@ -615,7 +618,10 @@ impl Db {
         .fetch_all(&self.pool)
         .await?;
 
-        let total = rows.first().map(|r| r.get::<i64, _>("total_count")).unwrap_or(0);
+        let total = rows
+            .first()
+            .map(|r| r.get::<i64, _>("total_count"))
+            .unwrap_or(0);
         let out: Vec<(RepoRecord, i64)> = rows
             .into_iter()
             .map(|r| {
@@ -1321,13 +1327,11 @@ impl Db {
     pub async fn prune_self_peers(&self, public_url: &str) -> Result<u64> {
         let trimmed = public_url.trim_end_matches('/');
         let with_slash = format!("{trimmed}/");
-        let result = sqlx::query(
-            "DELETE FROM peers WHERE http_url = $1 OR http_url = $2",
-        )
-        .bind(trimmed)
-        .bind(&with_slash)
-        .execute(&self.pool)
-        .await?;
+        let result = sqlx::query("DELETE FROM peers WHERE http_url = $1 OR http_url = $2")
+            .bind(trimmed)
+            .bind(&with_slash)
+            .execute(&self.pool)
+            .await?;
         Ok(result.rows_affected())
     }
 }
@@ -1640,10 +1644,7 @@ pub struct RecordAnchorInput<'a> {
 }
 
 impl Db {
-    pub async fn record_arweave_anchor(
-        &self,
-        input: &RecordAnchorInput<'_>,
-    ) -> Result<()> {
+    pub async fn record_arweave_anchor(&self, input: &RecordAnchorInput<'_>) -> Result<()> {
         let id = Uuid::new_v4().to_string();
         let now = Utc::now().to_rfc3339();
         sqlx::query(

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -1626,18 +1626,23 @@ pub struct ArweaveAnchor {
     pub anchored_at: String,
 }
 
+/// Input parameters for recording an Arweave anchor.
+pub struct RecordAnchorInput<'a> {
+    pub repo: &'a str,
+    pub owner_did: &'a str,
+    pub ref_name: &'a str,
+    pub old_sha: &'a str,
+    pub new_sha: &'a str,
+    pub cid: Option<&'a str>,
+    pub irys_tx_id: &'a str,
+    pub arweave_url: &'a str,
+    pub node_did: &'a str,
+}
+
 impl Db {
     pub async fn record_arweave_anchor(
         &self,
-        repo: &str,
-        owner_did: &str,
-        ref_name: &str,
-        old_sha: &str,
-        new_sha: &str,
-        cid: Option<&str>,
-        irys_tx_id: &str,
-        arweave_url: &str,
-        node_did: &str,
+        input: &RecordAnchorInput<'_>,
     ) -> Result<()> {
         let id = Uuid::new_v4().to_string();
         let now = Utc::now().to_rfc3339();
@@ -1646,15 +1651,15 @@ impl Db {
              VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)",
         )
         .bind(&id)
-        .bind(repo)
-        .bind(owner_did)
-        .bind(ref_name)
-        .bind(old_sha)
-        .bind(new_sha)
-        .bind(cid)
-        .bind(irys_tx_id)
-        .bind(arweave_url)
-        .bind(node_did)
+        .bind(input.repo)
+        .bind(input.owner_did)
+        .bind(input.ref_name)
+        .bind(input.old_sha)
+        .bind(input.new_sha)
+        .bind(input.cid)
+        .bind(input.irys_tx_id)
+        .bind(input.arweave_url)
+        .bind(input.node_did)
         .bind(&now)
         .execute(&self.pool)
         .await?;

--- a/crates/gitlawb-node/src/git/issues.rs
+++ b/crates/gitlawb-node/src/git/issues.rs
@@ -196,15 +196,6 @@ mod tests {
     use std::process::Command;
     use tempfile::TempDir;
 
-    fn init_bare_repo(dir: &TempDir) {
-        Command::new("git")
-            .args(["init", "--bare"])
-            .current_dir(dir.path())
-            .output()
-            .unwrap();
-        // git hash-object -w needs a non-bare repo; use a working repo instead
-    }
-
     fn init_repo(dir: &TempDir) {
         Command::new("git")
             .args(["init"])

--- a/crates/gitlawb-node/src/git/repo_store.rs
+++ b/crates/gitlawb-node/src/git/repo_store.rs
@@ -233,7 +233,7 @@ impl RepoStore {
     fn local_path(&self, owner_did: &str, repo_name: &str) -> Result<(String, PathBuf)> {
         validate_path_components(owner_did, repo_name)?;
 
-        let owner_slug = owner_did.replace(':', "_").replace('/', "_");
+        let owner_slug = owner_did.replace([':', '/'], "_");
         let local_path = self
             .repos_dir
             .join(&owner_slug)

--- a/crates/gitlawb-node/src/git/store.rs
+++ b/crates/gitlawb-node/src/git/store.rs
@@ -396,6 +396,6 @@ pub fn merge_branch(
 /// Resolve a repo disk path: {repos_dir}/{owner_slug}/{repo_name}.git
 pub fn repo_disk_path(repos_dir: &Path, owner_did: &str, repo_name: &str) -> PathBuf {
     // Sanitize the DID for use as a directory name
-    let owner_slug = owner_did.replace(':', "_").replace('/', "_");
+    let owner_slug = owner_did.replace([':', '/'], "_");
     repos_dir.join(owner_slug).join(format!("{repo_name}.git"))
 }

--- a/crates/gitlawb-node/src/git/tigris.rs
+++ b/crates/gitlawb-node/src/git/tigris.rs
@@ -47,7 +47,7 @@ impl TigrisClient {
         {
             Ok(_) => Ok(true),
             Err(e) => {
-                if e.as_service_error().map_or(false, |e| e.is_not_found()) {
+                if e.as_service_error().is_some_and(|e| e.is_not_found()) {
                     Ok(false)
                 } else {
                     Err(anyhow::anyhow!("tigris HEAD {key}: {e}"))

--- a/crates/gitlawb-node/src/graphql/subscription.rs
+++ b/crates/gitlawb-node/src/graphql/subscription.rs
@@ -47,15 +47,13 @@ impl SubscriptionRoot {
         BroadcastStream::new(rx).filter_map(move |r| {
             let tf = task_id.clone();
             match r {
-                Ok(ev) if tf.as_deref().is_none_or(|id| ev.task_id == id) => {
-                    Some(TaskEventType {
-                        task_id: ev.task_id,
-                        old_status: ev.old_status,
-                        new_status: ev.new_status,
-                        by_did: ev.by_did,
-                        at: ev.at,
-                    })
-                }
+                Ok(ev) if tf.as_deref().is_none_or(|id| ev.task_id == id) => Some(TaskEventType {
+                    task_id: ev.task_id,
+                    old_status: ev.old_status,
+                    new_status: ev.new_status,
+                    by_did: ev.by_did,
+                    at: ev.at,
+                }),
                 _ => None,
             }
         })

--- a/crates/gitlawb-node/src/graphql/subscription.rs
+++ b/crates/gitlawb-node/src/graphql/subscription.rs
@@ -22,7 +22,7 @@ impl SubscriptionRoot {
         BroadcastStream::new(rx).filter_map(move |r| {
             let rf = repo.clone();
             match r {
-                Ok(ev) if rf.as_deref().map_or(true, |r| ev.repo == r) => Some(RefUpdateType {
+                Ok(ev) if rf.as_deref().is_none_or(|r| ev.repo == r) => Some(RefUpdateType {
                     repo: ev.repo,
                     ref_name: ev.ref_name,
                     old_sha: ev.old_sha,
@@ -47,7 +47,7 @@ impl SubscriptionRoot {
         BroadcastStream::new(rx).filter_map(move |r| {
             let tf = task_id.clone();
             match r {
-                Ok(ev) if tf.as_deref().map_or(true, |id| ev.task_id == id) => {
+                Ok(ev) if tf.as_deref().is_none_or(|id| ev.task_id == id) => {
                     Some(TaskEventType {
                         task_id: ev.task_id,
                         old_status: ev.old_status,

--- a/crates/gitlawb-node/src/ipfs_pin.rs
+++ b/crates/gitlawb-node/src/ipfs_pin.rs
@@ -63,7 +63,7 @@ pub async fn pin_git_object(ipfs_api: &str, sha256_hex: &str, data: &[u8]) -> Re
             let v: serde_json::Value = serde_json::from_str(line).ok()?;
             v["Hash"].as_str().map(|s| s.to_string())
         })
-        .last()
+        .next_back()
         .unwrap_or(expected_cid.clone());
 
     tracing::debug!(sha256 = %sha256_hex, %cid, "pinned git object to IPFS");

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -170,7 +170,7 @@ async fn main() -> Result<()> {
     info!("  repos dir: {}", config.repos_dir.display());
     info!(
         "  database:  PostgreSQL ({})",
-        &config.database_url.split('@').last().unwrap_or("?")
+        &config.database_url.split('@').next_back().unwrap_or("?")
     );
 
     // Publish our DID record to the Kademlia DHT shortly after startup
@@ -192,7 +192,7 @@ async fn main() -> Result<()> {
     }
 
     // Spawn background gossip: announce to bootstrap peers, then ping known peers periodically
-    if !config.bootstrap_peers.is_empty() || true {
+    {
         let gossip_state = state.clone();
         let bootstrap_peers = config.bootstrap_peers.clone();
         tokio::spawn(async move {

--- a/crates/gitlawb-node/src/p2p/mod.rs
+++ b/crates/gitlawb-node/src/p2p/mod.rs
@@ -91,9 +91,7 @@ pub enum P2pCommand {
         reply: oneshot::Sender<Option<DidRecord>>,
     },
     /// Get a snapshot of the swarm status
-    GetStatus {
-        reply: oneshot::Sender<SwarmStatus>,
-    },
+    GetStatus { reply: oneshot::Sender<SwarmStatus> },
 }
 
 /// Handle returned to the rest of the node for sending commands to the swarm.

--- a/crates/gitlawb-node/src/p2p/mod.rs
+++ b/crates/gitlawb-node/src/p2p/mod.rs
@@ -321,14 +321,12 @@ pub async fn start(
                             kad::Event::OutboundQueryProgressed { id, result, .. }
                         )) => {
                             match result {
-                                kad::QueryResult::GetRecord(Ok(ok)) => {
-                                    if let kad::GetRecordOk::FoundRecord(pr) = ok {
-                                        if let Some(reply) = pending_get_did.remove(&id) {
-                                            let record = serde_json::from_slice::<DidRecord>(
-                                                &pr.record.value
-                                            ).ok();
-                                            let _ = reply.send(record);
-                                        }
+                                kad::QueryResult::GetRecord(Ok(kad::GetRecordOk::FoundRecord(pr))) => {
+                                    if let Some(reply) = pending_get_did.remove(&id) {
+                                        let record = serde_json::from_slice::<DidRecord>(
+                                            &pr.record.value
+                                        ).ok();
+                                        let _ = reply.send(record);
                                     }
                                 }
                                 kad::QueryResult::GetRecord(Err(e)) => {

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -10,7 +10,7 @@
 //!   3. If it exists → `git fetch --prune` from the origin.
 //!   4. Mark done or failed.
 
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 
 use tracing::{info, warn};
@@ -114,7 +114,7 @@ async fn process_batch(db: &Db, config: &Config, machine_id: Option<&str>) {
 }
 
 /// Mirror-clone a repo from a remote URL into a local bare repo.
-async fn clone_repo(remote_url: &str, local_path: &PathBuf) -> anyhow::Result<()> {
+async fn clone_repo(remote_url: &str, local_path: &Path) -> anyhow::Result<()> {
     let out = tokio::process::Command::new("git")
         .args([
             "clone",
@@ -134,7 +134,7 @@ async fn clone_repo(remote_url: &str, local_path: &PathBuf) -> anyhow::Result<()
 }
 
 /// Fetch all refs from the remote into an existing mirror repo.
-async fn fetch_repo(local_path: &PathBuf, remote_url: &str) -> anyhow::Result<()> {
+async fn fetch_repo(local_path: &Path, remote_url: &str) -> anyhow::Result<()> {
     let out = tokio::process::Command::new("git")
         .args([
             "-C",

--- a/crates/gl/src/doctor.rs
+++ b/crates/gl/src/doctor.rs
@@ -275,8 +275,7 @@ fn which_in_path(name: &str) -> bool {
         .map(|paths| {
             std::env::split_paths(&paths).any(|dir| {
                 dir.join(name).exists()
-                    || (cfg!(target_os = "windows")
-                        && dir.join(format!("{name}.exe")).exists())
+                    || (cfg!(target_os = "windows") && dir.join(format!("{name}.exe")).exists())
             })
         })
         .unwrap_or(false)

--- a/crates/gl/src/init.rs
+++ b/crates/gl/src/init.rs
@@ -255,7 +255,7 @@ mod tests {
 
         // We can't fully test gl init because it uses std::env::current_dir()
         // but we can test the individual steps
-        let client = NodeClient::new(&server.url(), Some(kp.clone()));
+        let client = NodeClient::new(server.url(), Some(kp.clone()));
 
         // Register
         let body = serde_json::to_vec(&json!({
@@ -298,7 +298,7 @@ mod tests {
             .create_async()
             .await;
 
-        let client = NodeClient::new(&server.url(), Some(kp.clone()));
+        let client = NodeClient::new(server.url(), Some(kp.clone()));
         let body = serde_json::to_vec(&json!({
             "did": kp.did().to_string(),
             "capabilities": ["git:push"],
@@ -327,7 +327,7 @@ mod tests {
             .create_async()
             .await;
 
-        let client = NodeClient::new(&server.url(), Some(kp.clone()));
+        let client = NodeClient::new(server.url(), Some(kp.clone()));
         let body = serde_json::to_vec(&json!({"name": "existing", "is_public": true})).unwrap();
         let resp = client.post("/api/v1/repos", &body).await.unwrap();
         let status = resp.status();


### PR DESCRIPTION
- Bump workspace version 0.3.8 → 0.3.9
- Fix 22 clippy warnings across 17 files:
  - Replace .last() with .next_back() on DoubleEndedIterators (8 instances)
  - Remove useless .into() conversions on anyhow::Error (3)
  - Remove needless borrows in gl init (3)
  - Replace map_or with is_some_and/is_none_or (3)
  - Collapse consecutive str::replace into char array pattern (2)
  - Change &PathBuf to &Path in function signatures (2)
  - Remove dead code: unused init_bare_repo function
  - Collapse if-let into outer match arm
  - Replace vec![...] with array literal
  - Introduce RecordAnchorInput struct (10 params → 1 struct)
  - Fix always-true boolean condition in gossip task guard
- Promote clippy from advisory to strict (-D warnings) in CI