### PR TITLE
fix(infra): drop fly idle_timeout 600 -> 120

### DIFF
--- a/infra/fly/fly.toml
+++ b/infra/fly/fly.toml
@@ -30,7 +30,9 @@ primary_region = "iad"
     soft_limit = 400
 
   [http_service.http_options]
-    idle_timeout = 600
+    # 120s, not 600: long idle windows let hung clients pin Fly's connection
+    # slots (hard_limit) — root factor in the 2026-06-12 prod outage
+    idle_timeout = 120
 
 [[services]]
   protocol = "udp"


### PR DESCRIPTION
600s idle windows let hung clients pin Fly proxy connection slots up to hard_limit, which amplified the 2026-06-12 production outage. 120s was deployed there as the fix; carry it into the reference config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server connection handling configuration to improve service reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->