### PR TITLE
Fix/backport prod fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,6 +2232,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,6 +2807,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3260,6 +3296,7 @@ dependencies = [
  "hmac",
  "http-body-util",
  "libp2p-core",
+ "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
@@ -3463,6 +3500,52 @@ name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.2",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.2",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -3837,6 +3920,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.3",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3985,6 +4081,22 @@ dependencies = [
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
+dependencies = [
+ "async-trait",
+ "futures",
+ "hickory-resolver",
+ "libp2p-core",
+ "libp2p-identity",
+ "parking_lot",
+ "smallvec",
+ "tracing",
 ]
 
 [[package]]
@@ -4342,6 +4454,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4671,6 +4800,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4926,6 +5059,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -5373,6 +5512,12 @@ dependencies = [
  "web-sys",
  "webpki-roots 1.0.6",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
@@ -6402,6 +6547,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7179,6 +7330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7281,6 +7438,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/crates/gitlawb-node/Cargo.toml
+++ b/crates/gitlawb-node/Cargo.toml
@@ -65,6 +65,7 @@ alloy = { version = "1", default-features = false, features = [
     "network",
     "rpc-types-eth",
 ] }
+libp2p-dns = { version = "0.44.0", features = ["tokio"] }
 
 [dev-dependencies]
 mockito = "1"

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -214,6 +214,18 @@ pub struct NotifyRequest {
     pub ref_name: String,
     pub new_sha: String,
     pub node_did: String,
+    // Optional fields — older senders only included the four above. New
+    // senders include these so received_ref_updates has full provenance
+    // even when the libp2p mesh isn't delivering and the HTTP fallback
+    // is the only path that fired.
+    #[serde(default)]
+    pub pusher_did: Option<String>,
+    #[serde(default)]
+    pub old_sha: Option<String>,
+    #[serde(default)]
+    pub timestamp: Option<String>,
+    #[serde(default)]
+    pub cert_id: Option<String>,
 }
 
 pub async fn notify_sync(
@@ -248,6 +260,27 @@ pub async fn notify_sync(
         .db
         .enqueue_sync(&req.repo, &req.node_did, &req.ref_name, &req.new_sha, None)
         .await?;
+
+    // Mirror the gossipsub-receive handler: insert the same record we'd
+    // get from the libp2p path, so /api/v1/events/ref-updates reflects
+    // pushes that arrive over either transport.
+    let now = chrono::Utc::now().to_rfc3339();
+    let update = crate::db::ReceivedRefUpdate {
+        id: uuid::Uuid::new_v4().to_string(),
+        node_did: req.node_did.clone(),
+        pusher_did: req.pusher_did.clone().unwrap_or_default(),
+        repo: req.repo.clone(),
+        ref_name: req.ref_name.clone(),
+        old_sha: req.old_sha.clone().unwrap_or_default(),
+        new_sha: req.new_sha.clone(),
+        timestamp: req.timestamp.clone().unwrap_or_else(|| now.clone()),
+        cert_id: req.cert_id.clone(),
+        received_at: now,
+        from_peer: format!("http:{}", req.node_did),
+    };
+    if let Err(e) = state.db.insert_ref_update(&update).await {
+        tracing::warn!(err = %e, repo = %req.repo, "failed to insert ref-update from sync notify");
+    }
 
     tracing::info!(
         repo = %req.repo,

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -90,6 +90,23 @@ pub async fn announce(
         ));
     }
 
+    // Reject self-announcements: a peer row whose http_url is our own public
+    // URL makes the HTTP-notify path fan out to ourselves. Seen in prod when
+    // misconfigured dev nodes announce with their upstream's URL.
+    // prune_self_peers clears stale rows at boot; this stops new ones.
+    if let Some(self_url) = state.config.public_url.as_deref() {
+        if req.http_url.trim_end_matches('/') == self_url.trim_end_matches('/') {
+            return Err(AppError::BadRequest(
+                "http_url is this node's own public URL; refusing to register self as peer".into(),
+            ));
+        }
+    }
+    if announced_did.to_string() == state.node_did.to_string() {
+        return Err(AppError::BadRequest(
+            "did is this node's own DID; refusing to register self as peer".into(),
+        ));
+    }
+
     state.db.upsert_peer(&req.did, &req.http_url).await?;
 
     tracing::info!(did = %req.did, url = %req.http_url, "peer announced");
@@ -124,16 +141,30 @@ pub async fn trigger_sync(State(state): State<AppState>) -> Result<Json<serde_js
             continue;
         }
         let url = format!("{}/api/v1/repos", peer.http_url.trim_end_matches('/'));
-        let result =
-            tokio::time::timeout(std::time::Duration::from_secs(5), client.get(&url).send()).await;
-
-        let repos: Vec<serde_json::Value> = match result {
-            Ok(Ok(resp)) if resp.status().is_success() => {
-                peers_reached += 1;
-                resp.json().await.unwrap_or_default()
+        // 30s with the body read inside the timeout: 5s only covered the
+        // response headers, so canonical nodes serving large unpaginated repo
+        // lists (and transpacific round trips) aborted mid-body.
+        let result = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            let resp = client.get(&url).send().await?;
+            if !resp.status().is_success() {
+                return Err(anyhow::anyhow!("peer returned status {}", resp.status()));
             }
-            _ => {
-                tracing::warn!(peer = %peer.did, "trigger_sync: could not reach peer");
+            let repos: Vec<serde_json::Value> = resp.json().await?;
+            Ok::<_, anyhow::Error>(repos)
+        })
+        .await;
+
+        let repos = match result {
+            Ok(Ok(repos)) => {
+                peers_reached += 1;
+                repos
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(peer = %peer.did, err = %e, "trigger_sync: peer fetch failed");
+                continue;
+            }
+            Err(_) => {
+                tracing::warn!(peer = %peer.did, "trigger_sync: peer timed out");
                 continue;
             }
         };

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -852,7 +852,14 @@ impl Db {
             "WITH deduped AS (
                  SELECT DISTINCT ON (split_part(owner_did, ':', -1), name)
                      id, name, owner_did, description, is_public, default_branch,
-                     created_at, updated_at, disk_path, forked_from, machine_id
+                     created_at,
+                     -- group MAX, not the canonical row's own value: pushes that
+                     -- arrive via gossip touch only the mirror row, so the
+                     -- canonical updated_at goes stale
+                     MAX(updated_at) OVER (
+                         PARTITION BY split_part(owner_did, ':', -1), name
+                     ) AS updated_at,
+                     disk_path, forked_from, machine_id
                  FROM repos
                  WHERE ($1::text IS NULL OR owner_did = $1 OR owner_did LIKE '%:' || $1)
                  ORDER BY split_part(owner_did, ':', -1), name,

--- a/crates/gitlawb-node/src/p2p/mod.rs
+++ b/crates/gitlawb-node/src/p2p/mod.rs
@@ -228,9 +228,14 @@ pub async fn start(
         gossipsub,
         identify,
     };
-    let transport = libp2p_quic::tokio::Transport::new(libp2p_quic::Config::new(&local_key))
-        .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
-        .boxed();
+    // DNS wraps QUIC so multiaddrs like /dns6/<app>.internal/udp/…/quic-v1
+    // resolve at dial time. On Fly, peer nodes must dial each other over the
+    // private 6PN network via <app>.internal hostnames — dialing through the
+    // public anycast edge breaks the handshake (the proxy closes the
+    // connection mid-stream).
+    let quic = libp2p_quic::tokio::Transport::new(libp2p_quic::Config::new(&local_key))
+        .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)));
+    let transport = libp2p_dns::tokio::Transport::system(quic)?.boxed();
     let mut swarm = Swarm::new(
         transport,
         behaviour,
@@ -242,9 +247,17 @@ pub async fn start(
     let topic = gossipsub::IdentTopic::new(REF_UPDATES_TOPIC);
     swarm.behaviour_mut().gossipsub.subscribe(&topic)?;
 
-    // Listen
-    let listen_addr: Multiaddr = format!("/ip4/0.0.0.0/udp/{listen_port}/quic-v1").parse()?;
-    swarm.listen_on(listen_addr)?;
+    // Listen on both IPv4 (local/mDNS + any IPv4 dials) and IPv6 (required
+    // for Fly's 6PN inter-app network — <app>.internal DNS only returns AAAA
+    // records, so peers dial us via IPv6 and need a matching IPv6 socket).
+    let v4: Multiaddr = format!("/ip4/0.0.0.0/udp/{listen_port}/quic-v1").parse()?;
+    if let Err(e) = swarm.listen_on(v4) {
+        warn!(err = %e, "failed to listen on IPv4");
+    }
+    let v6: Multiaddr = format!("/ip6/::/udp/{listen_port}/quic-v1").parse()?;
+    if let Err(e) = swarm.listen_on(v6) {
+        warn!(err = %e, "failed to listen on IPv6");
+    }
 
     // Bootstrap Kademlia with known peers
     for addr in bootstrap_addrs {


### PR DESCRIPTION
## Summary

  Backports the remaining production fixes that landed on the monorepo node but never made it into this repo, closing out code parity ahead of the monorepo sunset. After this merges (together with #<blob-fix-PR>
  and the idle_timeout PR), the monorepo's node code is fully superseded and frozen.

  ### 1. `trigger_sync`: 30s timeout covering the body read (monorepo `8c2fe1b`)

  The 5s timeout only covered the response headers — the body read happened outside it, so large unpaginated repo lists from canonical nodes (and transpacific round trips) aborted mid-body. The timeout now wraps
  send + status check + body read, with distinct log lines for non-2xx responses vs timeouts.

  ### 2. `announce`: reject self-announcements (monorepo `c1dc33e`)

  A peer row whose `http_url` is our own public URL makes the HTTP-notify path fan out to ourselves — seen in production when misconfigured dev nodes announce with their upstream's URL. This repo already had the
  boot-time `prune_self_peers` and the skip-self check in the notify fanout; this adds the missing piece, rejecting them at the door (by public URL or own DID).

  ### 3. `list_all_repos_paged`: fresh timestamps across mirror rows (monorepo `ef21c75`)

  The `DISTINCT ON` dedupe here already collapses the canonical + mirror row pair per logical repo, but it reported the canonical row's own `updated_at` — and pushes arriving via gossip only touch the mirror row,
  so timestamps went stale. Now reports `MAX(updated_at)` over the group.

  ### 4. p2p: dual-stack QUIC listen + DNS multiaddr dialing (monorepo `9f875b6` + `267d371`, adapted from TCP to QUIC)

  - Listen on `/ip6/::` alongside `/ip4/0.0.0.0` — Fly's 6PN inter-app network is IPv6-only (`<app>.internal` resolves to AAAA records), so without an IPv6 socket peers on the private network can't reach us.
  - Wrap the QUIC transport in `libp2p-dns` so bootstrap multiaddrs can use `/dns6/<app>.internal/udp/<port>/quic-v1`. Dialing through the public anycast edge breaks the handshake when the proxy closes the
  connection mid-stream.

  **Deploy note:** Fly bootstrap multiaddrs should move to the `/dns6/<app>.internal/udp/<port>/quic-v1` form to take advantage of this. Likely relevant to the `connected_peers=0` issue seen in production.

  ### 5. HTTP notify records `received_ref_updates` (monorepo `087eeac`)

  A push propagated via the `/api/v1/sync/notify` HTTP fallback replicated the repo but left no trace in `received_ref_updates` — only the libp2p gossip path recorded it, so `/api/v1/events/ref-updates` went blind
  whenever the mesh wasn't delivering. The notify handler now inserts the same record, with new optional provenance fields (`pusher_did`, `old_sha`, `timestamp`, `cert_id`) that senders already include; older
  senders without them still work.

  ## Testing

  - `cargo fmt --check`, `cargo clippy -- -D warnings`, and all 88 tests pass
  - New `libp2p-dns = 0.44` dependency resolves cleanly against the existing libp2p 0.43-family crates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional metadata fields to peer notifications (pusher_did, old_sha, timestamp, cert_id)
  * Enabled DNS resolution for peer connections

* **Bug Fixes**
  * Prevents nodes from announcing themselves as peers
  * Improved IPv4/IPv6 network connectivity resilience

* **Improvements**
  * Extended peer fetch timeout from 5 seconds to 30 seconds
  * Fixed repo update timestamps in deduplicated results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->