### PR TITLE
fix(node): enforce path-scoped visibility on the REST read API

### DIFF
--- a/crates/gitlawb-node/src/api/changelog.rs
+++ b/crates/gitlawb-node/src/api/changelog.rs
@@ -4,8 +4,8 @@ use axum::extract::{Extension, Path, Query, State};
 use axum::Json;
 use serde::Deserialize;
 
-use crate::error::{AppError, Result};
 use crate::auth::AuthenticatedDid;
+use crate::error::{AppError, Result};
 use crate::git::store;
 use crate::state::AppState;
 

--- a/crates/gitlawb-node/src/api/changelog.rs
+++ b/crates/gitlawb-node/src/api/changelog.rs
@@ -1,10 +1,11 @@
 //! Changelog endpoint — unified timeline of commits, merged PRs, and closed issues.
 
-use axum::extract::{Path, Query, State};
+use axum::extract::{Extension, Path, Query, State};
 use axum::Json;
 use serde::Deserialize;
 
 use crate::error::{AppError, Result};
+use crate::auth::AuthenticatedDid;
 use crate::git::store;
 use crate::state::AppState;
 
@@ -27,12 +28,11 @@ pub async fn get_changelog(
     State(state): State<AppState>,
     Path((owner, repo)): Path<(String, String)>,
     Query(query): Query<ChangelogQuery>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<serde_json::Value>> {
-    let record = state
-        .db
-        .get_repo(&owner, &repo)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{repo}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &repo, caller, "/").await?;
 
     let limit = query.limit.min(100);
 

--- a/crates/gitlawb-node/src/api/mod.rs
+++ b/crates/gitlawb-node/src/api/mod.rs
@@ -1,3 +1,8 @@
+use crate::db::{RepoRecord, VisibilityRule};
+use crate::error::{AppError, Result};
+use crate::state::AppState;
+use crate::visibility::{visibility_check, Decision};
+
 pub mod agents;
 pub mod arweave;
 pub mod bounties;
@@ -19,3 +24,32 @@ pub mod stars;
 pub mod tasks;
 pub mod visibility;
 pub mod webhooks;
+
+/// Resolve a repo for a read request and enforce path-scoped visibility.
+///
+/// Returns 404 (`RepoNotFound`) if the repo does not exist or the caller may not
+/// read `path`, using the same opaque response the git serve path returns so
+/// existence is not confirmed. Returns the record and its visibility rules so a
+/// content handler can apply an extra per-path check without a second DB query.
+///
+/// Callers pass `"/"` for repo-level reads (listings); content endpoints pass the
+/// specific path so a withheld subtree is denied even on an otherwise-public repo.
+pub(crate) async fn authorize_repo_read(
+    state: &AppState,
+    owner: &str,
+    name: &str,
+    caller: Option<&str>,
+    path: &str,
+) -> Result<(RepoRecord, Vec<VisibilityRule>)> {
+    let record = state
+        .db
+        .get_repo(owner, name)
+        .await?
+        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    let rules = state.db.list_visibility_rules(&record.id).await?;
+    if visibility_check(&rules, record.is_public, &record.owner_did, caller, path) == Decision::Deny
+    {
+        return Err(AppError::RepoNotFound(format!("{owner}/{name}")));
+    }
+    Ok((record, rules))
+}

--- a/crates/gitlawb-node/src/api/pulls.rs
+++ b/crates/gitlawb-node/src/api/pulls.rs
@@ -340,12 +340,11 @@ pub async fn create_review(
 pub async fn list_reviews(
     State(state): State<AppState>,
     Path((owner, name, number)): Path<(String, String, i64)>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<serde_json::Value>> {
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, caller, "/").await?;
 
     let pr = state
         .db
@@ -399,12 +398,11 @@ pub async fn create_comment(
 pub async fn list_comments(
     State(state): State<AppState>,
     Path((owner, name, number)): Path<(String, String, i64)>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<serde_json::Value>> {
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, caller, "/").await?;
 
     let pr = state
         .db

--- a/crates/gitlawb-node/src/api/pulls.rs
+++ b/crates/gitlawb-node/src/api/pulls.rs
@@ -101,12 +101,11 @@ pub async fn create_pr(
 pub async fn list_prs(
     State(state): State<AppState>,
     Path((owner, name)): Path<(String, String)>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<serde_json::Value>> {
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, caller, "/").await?;
 
     let prs = state.db.list_prs(&record.id).await?;
     Ok(Json(
@@ -118,12 +117,11 @@ pub async fn list_prs(
 pub async fn get_pr(
     State(state): State<AppState>,
     Path((owner, name, number)): Path<(String, String, i64)>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<PullRequest>> {
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, caller, "/").await?;
 
     let pr = state
         .db
@@ -138,12 +136,11 @@ pub async fn get_pr(
 pub async fn get_pr_diff(
     State(state): State<AppState>,
     Path((owner, name, number)): Path<(String, String, i64)>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<serde_json::Value>> {
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (record, rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, caller, "/").await?;
 
     let pr = state
         .db
@@ -156,6 +153,25 @@ pub async fn get_pr_diff(
         .acquire(&record.owner_did, &record.name)
         .await
         .map_err(|e| AppError::Git(e.to_string()))?;
+
+    // Withhold the entire diff if it touches a path the caller cannot read, so a
+    // PR diff cannot leak private-subtree content of an otherwise-public repo.
+    let touched = store::branch_diff_names(&disk_path, &pr.target_branch, &pr.source_branch)
+        .map_err(|e| AppError::Git(e.to_string()))?;
+    for p in &touched {
+        let gate = format!("/{}", p.trim_start_matches('/'));
+        if crate::visibility::visibility_check(
+            &rules,
+            record.is_public,
+            &record.owner_did,
+            caller,
+            &gate,
+        ) == crate::visibility::Decision::Deny
+        {
+            return Err(AppError::NotFound(format!("PR #{number} not found")));
+        }
+    }
+
     let diff = store::branch_diff(&disk_path, &pr.target_branch, &pr.source_branch)
         .map_err(|e| AppError::Git(e.to_string()))?;
 

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -186,12 +186,11 @@ pub async fn list_repos(
 pub async fn get_repo(
     State(state): State<AppState>,
     Path((owner, name)): Path<(String, String)>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<RepoResponse>> {
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, caller, "/").await?;
     let count = state.db.count_stars(&record.id).await.unwrap_or(0);
     Ok(Json(to_response(&record, &state, count)))
 }
@@ -200,12 +199,11 @@ pub async fn get_repo(
 pub async fn list_commits(
     State(state): State<AppState>,
     Path((owner, name)): Path<(String, String)>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<serde_json::Value>> {
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, caller, "/").await?;
 
     let disk_path = state
         .repo_store
@@ -222,6 +220,7 @@ pub async fn list_commits(
 pub async fn get_blob(
     State(state): State<AppState>,
     Path((owner, name, file_path)): Path<(String, String, String)>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Response> {
     use axum::http::header;
     use axum::response::IntoResponse;
@@ -238,11 +237,10 @@ pub async fn get_blob(
         return Err(AppError::BadRequest("invalid file path".into()));
     }
 
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let gate_path = format!("/{file_path}");
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, caller, &gate_path).await?;
 
     let disk_path = state
         .repo_store
@@ -283,12 +281,11 @@ pub async fn get_blob(
 pub async fn get_tree_root(
     State(state): State<AppState>,
     Path((owner, name)): Path<(String, String)>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<serde_json::Value>> {
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, caller, "/").await?;
 
     let disk_path = state
         .repo_store
@@ -305,12 +302,11 @@ pub async fn get_tree_root(
 pub async fn get_tree(
     State(state): State<AppState>,
     Path((owner, name, tree_path)): Path<(String, String, String)>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<serde_json::Value>> {
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, caller, "/").await?;
 
     let disk_path = state
         .repo_store
@@ -916,12 +912,11 @@ pub async fn git_receive_pack(
 pub async fn list_refs(
     State(state): State<AppState>,
     Path((owner, repo)): Path<(String, String)>,
+    auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<serde_json::Value>> {
-    let _record = state
-        .db
-        .get_repo(&owner, &repo)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{repo}")))?;
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (_record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &repo, caller, "/").await?;
 
     let repo_slug = format!("{owner}/{repo}");
     let refs = state.db.list_branch_cids(&repo_slug).await?;

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -1019,11 +1019,10 @@ pub async fn fork_repo(
     Path((owner, name)): Path<(String, String)>,
     Json(req): Json<ForkRepoRequest>,
 ) -> Result<(StatusCode, Json<RepoResponse>)> {
-    let source = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    // Enforce read visibility on the source before cloning: an unauthorized
+    // caller must not be able to fork (full mirror) a repo they cannot read.
+    let (source, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, Some(auth.0.as_str()), "/").await?;
 
     let fork_name = req.name.unwrap_or_else(|| source.name.clone());
     let forker_did = auth.0;

--- a/crates/gitlawb-node/src/git/store.rs
+++ b/crates/gitlawb-node/src/git/store.rs
@@ -314,6 +314,30 @@ pub fn branch_diff(repo_path: &Path, target_branch: &str, source_branch: &str) -
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+/// The repo-relative paths changed by `git diff target...source` (the same range
+/// as `branch_diff`). Used to enforce per-path visibility on a PR diff: if the
+/// caller cannot read one of these paths, the diff is withheld.
+pub fn branch_diff_names(
+    repo_path: &Path,
+    target_branch: &str,
+    source_branch: &str,
+) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args([
+            "diff",
+            "--name-only",
+            &format!("{target_branch}...{source_branch}"),
+        ])
+        .current_dir(repo_path)
+        .output()
+        .context("failed to run git diff --name-only")?;
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect())
+}
+
 /// Merge source_branch into target_branch in a bare repo using a temporary worktree.
 /// Returns the new merge commit hash.
 pub fn merge_branch(
@@ -398,4 +422,54 @@ pub fn repo_disk_path(repos_dir: &Path, owner_did: &str, repo_name: &str) -> Pat
     // Sanitize the DID for use as a directory name
     let owner_slug = owner_did.replace([':', '/'], "_");
     repos_dir.join(owner_slug).join(format!("{repo_name}.git"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::branch_diff_names;
+    use std::path::Path;
+    use std::process::Command;
+
+    #[test]
+    fn branch_diff_names_lists_changed_paths() {
+        let td = tempfile::TempDir::new().unwrap();
+        let work: &Path = td.path();
+        let g = |args: &[&str]| {
+            assert!(Command::new("git")
+                .args(args)
+                .current_dir(work)
+                .status()
+                .unwrap()
+                .success());
+        };
+        g(&["init", "-q"]);
+        g(&["config", "user.email", "t@t"]);
+        g(&["config", "user.name", "t"]);
+        std::fs::write(work.join("base.txt"), b"base\n").unwrap();
+        g(&["add", "."]);
+        g(&["commit", "-qm", "base"]);
+        let main = {
+            let o = Command::new("git")
+                .args(["symbolic-ref", "--short", "HEAD"])
+                .current_dir(work)
+                .output()
+                .unwrap();
+            String::from_utf8_lossy(&o.stdout).trim().to_string()
+        };
+        g(&["checkout", "-q", "-b", "feature"]);
+        std::fs::create_dir_all(work.join("secret")).unwrap();
+        std::fs::write(work.join("secret/x.txt"), b"secret\n").unwrap();
+        g(&["add", "."]);
+        g(&["commit", "-qm", "feat"]);
+
+        let names = branch_diff_names(work, &main, "feature").unwrap();
+        assert!(
+            names.iter().any(|p| p == "secret/x.txt"),
+            "expected secret/x.txt in changed paths, got {names:?}"
+        );
+        assert!(
+            !names.iter().any(|p| p == "base.txt"),
+            "unchanged file must not appear: {names:?}"
+        );
+    }
 }

--- a/crates/gitlawb-node/src/git/store.rs
+++ b/crates/gitlawb-node/src/git/store.rs
@@ -331,6 +331,10 @@ pub fn branch_diff_names(
         .current_dir(repo_path)
         .output()
         .context("failed to run git diff --name-only")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git diff --name-only failed: {stderr}");
+    }
     Ok(String::from_utf8_lossy(&output.stdout)
         .lines()
         .filter(|l| !l.is_empty())

--- a/crates/gitlawb-node/src/git/store.rs
+++ b/crates/gitlawb-node/src/git/store.rs
@@ -326,6 +326,7 @@ pub fn branch_diff_names(
         .args([
             "diff",
             "--name-only",
+            "-z",
             &format!("{target_branch}...{source_branch}"),
         ])
         .current_dir(repo_path)
@@ -335,10 +336,14 @@ pub fn branch_diff_names(
         let stderr = String::from_utf8_lossy(&output.stderr);
         bail!("git diff --name-only failed: {stderr}");
     }
-    Ok(String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(|l| l.to_string())
+    // Split on NUL (`-z`) so paths containing newlines keep their exact bytes;
+    // `--name-only` without `-z` would quote/escape such paths and they would no
+    // longer match the visibility globs in get_pr_diff, leaking the diff.
+    Ok(output
+        .stdout
+        .split(|b| *b == b'\0')
+        .filter(|s| !s.is_empty())
+        .map(|s| String::from_utf8_lossy(s).into_owned())
         .collect())
 }
 

--- a/crates/gitlawb-node/src/server.rs
+++ b/crates/gitlawb-node/src/server.rs
@@ -342,7 +342,8 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/api/v1/repos/{owner}/{repo}/replicas",
             get(replicas::list_replicas),
-        );
+        )
+        .layer(middleware::from_fn(auth::optional_signature));
 
     // git-upload-pack (clone/fetch) — same raised body limit as receive-pack so
     // large pack responses from the server don't get truncated on the client side.


### PR DESCRIPTION
The git smart-HTTP and replication paths enforce path-scoped visibility, but the REST read endpoints never did. They look up the repo and read straight from disk with no visibility check, so a private repository, and a private subtree of a public repository, are served to anyone.

The clearest case:

```
GET /api/v1/repos/{owner}/{repo}/blob/secret/.env   ->  200, cleartext
```

`get_pr_diff` is the same story for diffs. This predates the visibility work (`get_blob` goes back to the initial release), so it is a live hole on `main` today, not something introduced by the in-flight subtree work. It does, however, make that work moot, which is why it is worth fixing on its own.

## What this does

Adds a single `authorize_repo_read` gate (resolve repo, load rules, `visibility_check`, 404 on deny) and routes every repo-scoped read handler through it: blob, tree, commits, refs, changelog, pulls, PR diff, and repo metadata. The 404 matches what the git path returns on a denied read, so existence is not confirmed either.

- `get_blob` gates at the requested file path, so a withheld subtree file and any file in a fully-private repo both return 404, while the owner and listed readers still get them.
- `get_pr_diff` withholds the whole diff if it touches any path the caller cannot read, via a new `store::branch_diff_names`. Whole-diff denial rather than per-hunk redaction keeps it simple and safe; finer redaction can come later if wanted.
- Listings (tree, commits, refs) are gated at the repo root only, which keeps them consistent with mode B: the git protocol already exposes tree and commit SHAs, only blob content is withheld.
- The read routes get the `optional_signature` layer so an authorized reader can authenticate over REST, the same way the git read routes already do. Anonymous reads of public repos are unaffected.

## Not covered here

`list_repos` / `list_federated_repos` enumerate repos and need per-row filtering, a different mechanism. They leak private-repo existence and should be a separate change.

## Testing

`cargo build` and `cargo test -p gitlawb-node --bin gitlawb-node` pass. `store::branch_diff_names` has a unit test; the gate decision itself is covered by the existing `visibility` unit tests. There is no HTTP-level test harness in this crate, so endpoint-level integration tests would be a follow-up.

Closes #51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional HTTP-signature authentication for public repository read endpoints.
  * Branch-diff path detection to determine which file changes are visible.

* **Security**
  * Repository read operations now enforce per-path visibility before returning data.
  * Pull request diffs and changelogs hide changes that include inaccessible paths; forking checks source repo readability.

* **Tests**
  * Added unit test for branch-diff path detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->