### PR TITLE
Aws ecr image

### DIFF
--- a/infra/aws/.gitignore
+++ b/infra/aws/.gitignore
@@ -11,3 +11,7 @@ crash.*.log
 !terraform.tfvars.example
 
 # Note: .terraform.lock.hcl IS committed (reproducible provider versions)
+
+# Saved plan files can embed sensitive values
+tfplan
+*.tfplan

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -151,5 +151,7 @@ them up in the EC2 console if unwanted. The Elastic IP is released on destroy.
   `ssm_kms_key_id` to encrypt with a customer-managed KMS key instead (the
   instance role is granted `kms:Decrypt` on that key automatically).
 - IMDSv2 is required; metrics port is closed unless `metrics_ingress_cidr` is set.
-- The node serves plain HTTP on 7545. For TLS, put a DNS name + proxy
-  (ALB/CloudFront/Caddy) in front and set `public_url` accordingly.
+- The node itself serves plain HTTP on 7545. Set `domain_name` (with DNS
+  pointing at the Elastic IP) to run a Caddy sidecar with automatic Let's
+  Encrypt TLS on 443 (+ http→https redirect on 80) — matching the Fly nodes.
+  Certs persist on the data volume (`/mnt/data/caddy`).

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -66,6 +66,23 @@ Bootstrap log: `/var/log/gitlawb-bootstrap.log`. Stack lives in `/opt/gitlawb`
 
 SSH is off by default; set `ssh_ingress_cidr` + `ssh_key_name` if you need it.
 
+## Building and pushing the image (ECR mode)
+
+With `create_ecr_repo = true` the instance pulls from a private ECR repo in
+this account instead of an external registry (the instance role gets pull
+rights via the amazon-ecr-credential-helper). Build from the repo root —
+arm64 to match t4g (native on Apple Silicon):
+
+```sh
+ECR_URL=$(terraform -chdir=infra/aws output -raw ecr_repository_url)
+aws ecr get-login-password --region us-east-1 | \
+  docker login --username AWS --password-stdin "${ECR_URL%%/*}"
+docker build --platform linux/arm64 -t "$ECR_URL:latest" .
+docker push "$ECR_URL:latest"
+```
+
+Then run the upgrade command (below) to roll it out.
+
 ## Upgrading the node
 
 User-data only runs at first boot, so upgrades go through SSM:

--- a/infra/aws/compose.yaml.tftpl
+++ b/infra/aws/compose.yaml.tftpl
@@ -4,6 +4,22 @@
 # `$${VAR}` entries are resolved by docker compose from /opt/gitlawb/.env at runtime.
 
 services:
+%{ if domain_name != "" ~}
+  caddy:
+    image: caddy:2-alpine
+    depends_on:
+      node:
+        condition: service_healthy
+    ports:
+      - "80:80"    # redirects to https
+      - "443:443"  # Let's Encrypt cert, auto-renewed; certs persist on the EBS volume
+    command: caddy reverse-proxy --from ${domain_name} --to node:${gitlawb_port}
+    volumes:
+      - /mnt/data/caddy:/data
+    restart: unless-stopped
+
+%{ endif ~}
+%{ if db_host == "" ~}
   postgres:
     image: postgres:16-alpine
     environment:
@@ -19,11 +35,14 @@ services:
       retries: 5
     restart: unless-stopped
 
+%{ endif ~}
   node:
     image: ${image_repo}:${image_tag}
+%{ if db_host == "" ~}
     depends_on:
       postgres:
         condition: service_healthy
+%{ endif ~}
     ports:
       - "${gitlawb_port}:${gitlawb_port}"          # HTTP API + git smart-HTTP
       - "${p2p_port}:${p2p_port}/udp"              # libp2p QUIC
@@ -33,7 +52,7 @@ services:
     volumes:
       - /mnt/data/node:/data
     environment:
-      DATABASE_URL: postgresql://${pg_user}:$${POSTGRES_PASSWORD}@postgres:5432/${pg_db}
+      DATABASE_URL: postgresql://${pg_user}:$${POSTGRES_PASSWORD}@${db_host != "" ? db_host : "postgres"}:5432/${pg_db}
       GITLAWB_HOST: 0.0.0.0
       GITLAWB_PORT: "${gitlawb_port}"
       GITLAWB_P2P_PORT: "${p2p_port}"

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -244,11 +244,38 @@ resource "aws_eip" "node" {
   tags   = merge(local.common_tags, { Name = var.name_prefix })
 }
 
+# ---------------------------------------------------------------------------
+# Optional private ECR repository — self-contained image hosting in this
+# account instead of an external registry. Push with: see README "Building
+# and pushing the image".
+# ---------------------------------------------------------------------------
+
+resource "aws_ecr_repository" "node" {
+  count = var.create_ecr_repo ? 1 : 0
+  name  = var.name_prefix
+  tags  = local.common_tags
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_read" {
+  count      = var.create_ecr_repo ? 1 : 0
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+locals {
+  image_repo   = var.create_ecr_repo ? aws_ecr_repository.node[0].repository_url : var.image_repo
+  ecr_registry = var.create_ecr_repo ? split("/", aws_ecr_repository.node[0].repository_url)[0] : ""
+}
+
 locals {
   public_url = var.public_url != "" ? var.public_url : "http://${aws_eip.node.public_ip}:${var.gitlawb_port}"
 
   compose_yaml = templatefile("${path.module}/compose.yaml.tftpl", {
-    image_repo     = var.image_repo
+    image_repo     = local.image_repo
     image_tag      = var.image_tag
     gitlawb_port   = var.gitlawb_port
     p2p_port       = var.gitlawb_p2p_port
@@ -273,6 +300,7 @@ locals {
     contract_node_staking = var.contract_node_staking
     tigris_bucket         = var.tigris_bucket
     s3_endpoint_url       = var.s3_endpoint_url
+    ecr_registry          = local.ecr_registry
     compose_yaml          = local.compose_yaml
   })
 }

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -186,6 +186,17 @@ resource "aws_security_group" "node" {
   }
 
   dynamic "ingress" {
+    for_each = var.domain_name != "" ? [80, 443] : []
+    content {
+      description = "Caddy HTTP/HTTPS (TLS for ${var.domain_name})"
+      from_port   = ingress.value
+      to_port     = ingress.value
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
+  dynamic "ingress" {
     for_each = local.expose_metrics ? [1] : []
     content {
       description = "Prometheus metrics"
@@ -272,11 +283,17 @@ locals {
 }
 
 locals {
-  public_url = var.public_url != "" ? var.public_url : "http://${aws_eip.node.public_ip}:${var.gitlawb_port}"
+  public_url = (
+    var.public_url != "" ? var.public_url :
+    var.domain_name != "" ? "https://${var.domain_name}" :
+    "http://${aws_eip.node.public_ip}:${var.gitlawb_port}"
+  )
 
   compose_yaml = templatefile("${path.module}/compose.yaml.tftpl", {
     image_repo     = local.image_repo
     image_tag      = var.image_tag
+    domain_name    = var.domain_name
+    db_host        = var.use_rds ? aws_db_instance.node[0].address : ""
     gitlawb_port   = var.gitlawb_port
     p2p_port       = var.gitlawb_p2p_port
     metrics_port   = var.metrics_port

--- a/infra/aws/monitoring.tf
+++ b/infra/aws/monitoring.tf
@@ -1,0 +1,105 @@
+# Alerting (enabled when alert_email is set): SNS email + CloudWatch alarms
+# on external API health (Route 53 health check), EC2 status, CPU, and RDS
+# free storage. The email subscription must be confirmed once via the link
+# SNS sends.
+
+locals {
+  alarms_enabled = var.alert_email != ""
+}
+
+resource "aws_sns_topic" "alerts" {
+  count = local.alarms_enabled ? 1 : 0
+  name  = "${var.name_prefix}-alerts"
+  tags  = local.common_tags
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  count     = local.alarms_enabled ? 1 : 0
+  topic_arn = aws_sns_topic.alerts[0].arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+# External HTTPS /health probe — catches everything the EC2-level checks
+# can't (container down, caddy broken, cert expired, DNS wrong).
+resource "aws_route53_health_check" "api" {
+  count             = local.alarms_enabled && var.domain_name != "" ? 1 : 0
+  fqdn              = var.domain_name
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/health"
+  request_interval  = 30
+  failure_threshold = 3
+  tags              = merge(local.common_tags, { Name = "${var.name_prefix}-api" })
+}
+
+# Route 53 health check metrics are only published in us-east-1; this module
+# already runs there by default.
+resource "aws_cloudwatch_metric_alarm" "api_health" {
+  count               = local.alarms_enabled && var.domain_name != "" ? 1 : 0
+  alarm_name          = "${var.name_prefix}-api-health"
+  alarm_description   = "https://${var.domain_name}/health is failing"
+  namespace           = "AWS/Route53"
+  metric_name         = "HealthCheckStatus"
+  dimensions          = { HealthCheckId = aws_route53_health_check.api[0].id }
+  statistic           = "Minimum"
+  period              = 60
+  evaluation_periods  = 2
+  threshold           = 1
+  comparison_operator = "LessThanThreshold"
+  treat_missing_data  = "breaching"
+  alarm_actions       = [aws_sns_topic.alerts[0].arn]
+  ok_actions          = [aws_sns_topic.alerts[0].arn]
+  tags                = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "status_check" {
+  count               = local.alarms_enabled ? 1 : 0
+  alarm_name          = "${var.name_prefix}-status-check"
+  alarm_description   = "EC2 status checks failing on the node instance"
+  namespace           = "AWS/EC2"
+  metric_name         = "StatusCheckFailed"
+  dimensions          = { InstanceId = aws_instance.node.id }
+  statistic           = "Maximum"
+  period              = 60
+  evaluation_periods  = 2
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  alarm_actions       = [aws_sns_topic.alerts[0].arn]
+  ok_actions          = [aws_sns_topic.alerts[0].arn]
+  tags                = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  count               = local.alarms_enabled ? 1 : 0
+  alarm_name          = "${var.name_prefix}-cpu-high"
+  alarm_description   = "Node instance CPU above 80% for 15 minutes"
+  namespace           = "AWS/EC2"
+  metric_name         = "CPUUtilization"
+  dimensions          = { InstanceId = aws_instance.node.id }
+  statistic           = "Average"
+  period              = 300
+  evaluation_periods  = 3
+  threshold           = 80
+  comparison_operator = "GreaterThanThreshold"
+  alarm_actions       = [aws_sns_topic.alerts[0].arn]
+  ok_actions          = [aws_sns_topic.alerts[0].arn]
+  tags                = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_storage_low" {
+  count               = local.alarms_enabled && var.use_rds ? 1 : 0
+  alarm_name          = "${var.name_prefix}-rds-storage-low"
+  alarm_description   = "RDS free storage below 2 GB"
+  namespace           = "AWS/RDS"
+  metric_name         = "FreeStorageSpace"
+  dimensions          = { DBInstanceIdentifier = aws_db_instance.node[0].identifier }
+  statistic           = "Minimum"
+  period              = 300
+  evaluation_periods  = 2
+  threshold           = 2147483648
+  comparison_operator = "LessThanThreshold"
+  alarm_actions       = [aws_sns_topic.alerts[0].arn]
+  ok_actions          = [aws_sns_topic.alerts[0].arn]
+  tags                = local.common_tags
+}

--- a/infra/aws/outputs.tf
+++ b/infra/aws/outputs.tf
@@ -18,6 +18,11 @@ output "data_volume_id" {
   value       = aws_ebs_volume.data.id
 }
 
+output "ecr_repository_url" {
+  description = "Private ECR repo for the node image (null unless create_ecr_repo)"
+  value       = try(aws_ecr_repository.node[0].repository_url, null)
+}
+
 output "postgres_password_ssm_param" {
   description = "SSM parameter holding the postgres password (value not shown)"
   value       = aws_ssm_parameter.postgres_password.name

--- a/infra/aws/outputs.tf
+++ b/infra/aws/outputs.tf
@@ -23,6 +23,11 @@ output "ecr_repository_url" {
   value       = try(aws_ecr_repository.node[0].repository_url, null)
 }
 
+output "rds_endpoint" {
+  description = "RDS Postgres endpoint (null unless use_rds)"
+  value       = try(aws_db_instance.node[0].address, null)
+}
+
 output "postgres_password_ssm_param" {
   description = "SSM parameter holding the postgres password (value not shown)"
   value       = aws_ssm_parameter.postgres_password.name

--- a/infra/aws/rds.tf
+++ b/infra/aws/rds.tf
@@ -1,0 +1,58 @@
+# Optional managed Postgres (use_rds = true): the database survives instance
+# loss independently, with automated backups / point-in-time recovery. The
+# in-Docker postgres service is dropped from the compose stack when enabled.
+
+data "aws_subnets" "node_vpc" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_subnet.selected.vpc_id]
+  }
+}
+
+resource "aws_db_subnet_group" "node" {
+  count      = var.use_rds ? 1 : 0
+  name       = "${var.name_prefix}-db"
+  subnet_ids = data.aws_subnets.node_vpc.ids
+  tags       = local.common_tags
+}
+
+resource "aws_security_group" "rds" {
+  count       = var.use_rds ? 1 : 0
+  name        = "${var.name_prefix}-rds"
+  description = "Postgres, reachable only from the node instance"
+  vpc_id      = data.aws_subnet.selected.vpc_id
+  tags        = local.common_tags
+
+  ingress {
+    description     = "Postgres from the node"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.node.id]
+  }
+}
+
+resource "aws_db_instance" "node" {
+  count             = var.use_rds ? 1 : 0
+  identifier        = "${var.name_prefix}-db"
+  engine            = "postgres"
+  engine_version    = "16"
+  instance_class    = var.rds_instance_class
+  allocated_storage = var.rds_allocated_storage_gb
+  storage_type      = "gp3"
+  storage_encrypted = true
+
+  db_name  = var.postgres_db
+  username = var.postgres_user
+  password = random_password.postgres.result
+
+  db_subnet_group_name   = aws_db_subnet_group.node[0].name
+  vpc_security_group_ids = [aws_security_group.rds[0].id]
+
+  backup_retention_period   = var.rds_backup_retention_days
+  deletion_protection       = true
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${var.name_prefix}-db-final"
+  apply_immediately         = true
+  tags                      = local.common_tags
+}

--- a/infra/aws/terraform.tfvars.example
+++ b/infra/aws/terraform.tfvars.example
@@ -16,7 +16,12 @@ instance_type = "t4g.small" # ARM/Graviton; node image is multi-arch
 # snapshot_retain_count = 7
 
 # --- Node configuration (defaults mirror infra/fly/fly.toml) ---------------
-# Set to your real DNS name for production; defaults to http://<elastic-ip>:7545
+# DNS name pointing at the Elastic IP: enables a Caddy sidecar with automatic
+# HTTPS (Let's Encrypt) on 80/443, and public_url becomes https://<domain>
+# domain_name = "node.example.com"
+
+# Explicit override; rarely needed when domain_name is set.
+# Defaults to https://<domain_name>, else http://<elastic-ip>:7545
 # public_url = "https://node.example.com"
 
 # bootstrap_peers = "https://node.gitlawb.com,https://node2.gitlawb.com,https://node3.gitlawb.com"

--- a/infra/aws/terraform.tfvars.example
+++ b/infra/aws/terraform.tfvars.example
@@ -7,6 +7,9 @@ instance_type = "t4g.small" # ARM/Graviton; node image is multi-arch
 # --- Image -----------------------------------------------------------------
 # image_repo = "ghcr.io/gitlawb/node"
 # image_tag  = "latest" # pin a version for production, e.g. "0.9.2"
+# Or host the image in a private ECR repo in this account (image_repo is then
+# ignored; build & push per README "Building and pushing the image"):
+# create_ecr_repo = true
 
 # --- Storage ---------------------------------------------------------------
 # data_volume_size_gb   = 20

--- a/infra/aws/user-data.sh.tftpl
+++ b/infra/aws/user-data.sh.tftpl
@@ -57,9 +57,12 @@ mkdir -p /mnt/data
 grep -q 'LABEL=gitlawb-data' /etc/fstab || \
   echo 'LABEL=gitlawb-data /mnt/data ext4 defaults,nofail 0 2' >> /etc/fstab
 mount -a
+# Grow the filesystem if the EBS volume was enlarged (no-op otherwise)
+resize2fs "$DATA_DEV" || true
 
 # Node container runs as uid/gid 1000 (gitlawb). Postgres manages its own dir.
-mkdir -p /mnt/data/node/repos /mnt/data/node/keys /mnt/data/postgres
+# caddy/ holds TLS certs (only used when a domain is configured).
+mkdir -p /mnt/data/node/repos /mnt/data/node/keys /mnt/data/postgres /mnt/data/caddy
 chown -R 1000:1000 /mnt/data/node
 
 # ---------------------------------------------------------------------------

--- a/infra/aws/user-data.sh.tftpl
+++ b/infra/aws/user-data.sh.tftpl
@@ -17,6 +17,16 @@ curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
   -o /usr/local/lib/docker/cli-plugins/docker-compose
 chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
+%{ if ecr_registry != "" ~}
+# Pull from the account's private ECR via the instance role — the credential
+# helper avoids expiring `docker login` tokens (works for upgrades too).
+dnf install -y amazon-ecr-credential-helper
+mkdir -p /root/.docker
+cat > /root/.docker/config.json <<'DOCKER_EOF'
+{ "credHelpers": { "${ecr_registry}": "ecr-login" } }
+DOCKER_EOF
+%{ endif ~}
+
 # ---------------------------------------------------------------------------
 # Data volume: find the attached EBS volume (Nitro presents /dev/sdf as NVMe;
 # attachment can lag first boot, so retry). The data disk is the one that is

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -64,9 +64,15 @@ variable "snapshot_retain_count" {
 # ---------------------------------------------------------------------------
 
 variable "image_repo" {
-  description = "Container image repository for the node (public, multi-arch)"
+  description = "Container image repository for the node. Ignored when create_ecr_repo is true (the module-managed ECR repo is used instead)."
   type        = string
   default     = "ghcr.io/gitlawb/node"
+}
+
+variable "create_ecr_repo" {
+  description = "Create a private ECR repository in this account and pull the node image from it (instance role gets pull rights via a credential helper). Push images with scripts in the README."
+  type        = bool
+  default     = false
 }
 
 variable "image_tag" {

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -137,6 +137,12 @@ variable "ssh_key_name" {
 # Node configuration (defaults mirror infra/fly/fly.toml)
 # ---------------------------------------------------------------------------
 
+variable "domain_name" {
+  description = "DNS name pointing at the Elastic IP. When set, a Caddy sidecar terminates TLS on 80/443 with an auto-renewed Let's Encrypt cert, and public_url defaults to https://<domain_name>."
+  type        = string
+  default     = ""
+}
+
 variable "public_url" {
   description = "Public URL of this node (GITLAWB_PUBLIC_URL). Leave empty to default to http://<elastic-ip>:<port> after apply — set a real DNS name for production."
   type        = string
@@ -170,6 +176,36 @@ variable "ssm_kms_key_id" {
 # ---------------------------------------------------------------------------
 # Postgres
 # ---------------------------------------------------------------------------
+
+variable "use_rds" {
+  description = "Run Postgres in RDS instead of a container on the instance. The DB then survives instance loss with automated backups."
+  type        = bool
+  default     = false
+}
+
+variable "rds_instance_class" {
+  description = "RDS instance class (only used when use_rds)"
+  type        = string
+  default     = "db.t4g.micro"
+}
+
+variable "rds_allocated_storage_gb" {
+  description = "RDS storage in GB (only used when use_rds)"
+  type        = number
+  default     = 20
+}
+
+variable "rds_backup_retention_days" {
+  description = "RDS automated backup retention (only used when use_rds)"
+  type        = number
+  default     = 7
+}
+
+variable "alert_email" {
+  description = "Email for CloudWatch alarm notifications via SNS (confirm the subscription email once). Empty = no alarms."
+  type        = string
+  default     = ""
+}
 
 variable "postgres_user" {
   description = "Postgres user for the node database"

--- a/infra/aws/versions.tf
+++ b/infra/aws/versions.tf
@@ -12,15 +12,12 @@ terraform {
     }
   }
 
-  # Remote state (optional). Create the bucket first, then uncomment and run
-  # `terraform init -migrate-state`. See README.md "Remote state".
-  #
-  # backend "s3" {
-  #   bucket       = "gitlawb-terraform-state"
-  #   key          = "infra/aws/terraform.tfstate"
-  #   region       = "us-east-1"
-  #   use_lockfile = true
-  # }
+  backend "s3" {
+    bucket       = "gitlawb-tfstate-874373491455"
+    key          = "infra/aws/terraform.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
feat(infra): private ECR image hosting + HTTPS via Caddy + production tier

- create_ecr_repo: private ECR repo; instance pulls via IAM role + ecr-credential-helper (motivation: ghcr.io/gitlawb/node isn't anonymously pullable — 403 broke first boot)

- domain_name: Caddy sidecar with auto-renewed Let's Encrypt TLS on 80/443; public_url derives to https://<domain>

- use_rds: managed Postgres 16 (encrypted, PITR, deletion-protected, SG-locked to the node)

- alert_email: SNS + CloudWatch alarms (external HTTPS health via Route 53, EC2 status, CPU, RDS storage)

- Terraform state on S3 (versioned, KMS, locked)

Battle-tested: this exact config runs https://manila.gitlawb.com (up since Jun 7, full git lifecycle verified).