### PR TITLE
ci: harden PR pipeline (audit, MSRV, beta matrix, release + docker smoke)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,37 @@
+# cargo-audit configuration.
+#
+# cargo-audit reads its config from .cargo/audit.toml (relative to the working
+# directory) or ~/.cargo/audit.toml. It does NOT read a repo-root audit.toml,
+# and there is no CLI flag to point at a config file (`-f` is the lockfile path).
+# This file lives at .cargo/audit.toml for that reason.
+#
+# The audit job stays hard-fail: only the advisories explicitly listed below are
+# suppressed, so any NEW advisory still breaks CI. Each entry below has no
+# available upstream fix; everything fixable is fixed in Cargo.lock instead.
+#
+# Tracking: the hickory ignores are reachable accepted risk. A scheduled re-check
+# (.github/workflows/audit-schedule.yml) runs without these ignores and fails if
+# the lockfile moves off the pinned vulnerable versions while the ignores remain.
+
+[advisories]
+ignore = [
+    # hickory-proto 0.25.2 (pulled by libp2p-dns 0.44 -> hickory-resolver 0.25).
+    # REACHABLE: the node wraps its QUIC transport in the system DNS resolver
+    # (crates/gitlawb-node/src/p2p/mod.rs:238), so a malicious DNS response can
+    # trigger these DoS paths. No fix is available: the latest libp2p-dns on
+    # crates.io is 0.44 and pins hickory 0.25; the fix requires hickory >=0.26.1.
+    # REMOVE both once libp2p-dns ships a release using hickory 0.26 (verified
+    # 2026-06-21: cargo update -p hickory-proto locks 0 packages; still 0.25.2).
+    "RUSTSEC-2026-0118", # hickory NSEC3 closest-encloser unbounded loop
+    "RUSTSEC-2026-0119", # hickory O(n^2) name-compression CPU exhaustion
+
+    # rsa 0.9.10 (Marvin timing sidechannel). Present in Cargo.lock because sqlx
+    # resolves sqlx-mysql unconditionally, and sqlx-mysql depends on rsa. cargo
+    # audit scans the lockfile, so it flags rsa even though it is NOT linked into
+    # our binary: sqlx is built postgres-only (crates/gitlawb-node/Cargo.toml),
+    # so the MySQL RSA auth path is never compiled and there is no RSA oracle to
+    # attack. No upstream fix exists regardless. REMOVE this ignore if sqlx is
+    # ever built with the `mysql` feature, or any other consumer of rsa enters
+    # the build, at which point it becomes a real reachable advisory.
+    "RUSTSEC-2023-0071", # rsa Marvin attack (no fix; not linked in our build)
+]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -22,6 +22,7 @@ ignore = [
     # crates.io is 0.44 and pins hickory 0.25; the fix requires hickory >=0.26.1.
     # REMOVE both once libp2p-dns ships a release using hickory 0.26 (verified
     # 2026-06-21: cargo update -p hickory-proto locks 0 packages; still 0.25.2).
+    # Tracking: https://github.com/Gitlawb/node/issues/76
     "RUSTSEC-2026-0118", # hickory NSEC3 closest-encloser unbounded loop
     "RUSTSEC-2026-0119", # hickory O(n^2) name-compression CPU exhaustion
 

--- a/.github/workflows/audit-schedule.yml
+++ b/.github/workflows/audit-schedule.yml
@@ -67,8 +67,11 @@ jobs:
           if grep -q 'RUSTSEC-2026-011' .cargo/audit.toml; then
             ignores_present=true
           fi
-          if [ "$ignores_present" = true ] && [ -n "${version}" ] && [[ "${version}" != 0.25.* ]]; then
-            echo "::error::hickory-proto is ${version} but the RUSTSEC-2026-0118/0119 ignores are still in .cargo/audit.toml. The upstream fix appears to be available; remove the ignores."
+          # Drift = the lockfile no longer matches what the ignores assume:
+          # hickory moved off 0.25.x (fix shipped) OR was removed entirely
+          # (dead ignore entries left behind). Both must fail.
+          if [ "$ignores_present" = true ] && { [ -z "${version}" ] || [[ "${version}" != 0.25.* ]]; }; then
+            echo "::error::hickory-proto is ${version:-absent from Cargo.lock} but the RUSTSEC-2026-0118/0119 ignores are still in .cargo/audit.toml. The upstream fix appears to be available or the dependency is gone; remove the ignores."
             exit 1
           fi
           echo "No drift: ignore list is consistent with the pinned hickory-proto version."

--- a/.github/workflows/audit-schedule.yml
+++ b/.github/workflows/audit-schedule.yml
@@ -1,0 +1,74 @@
+name: Scheduled Audit
+
+# Self-expiring suppression check (companion to the PR-blocking audit gate in
+# pr-checks.yml). Runs weekly. It re-runs cargo audit WITHOUT the .cargo/audit.toml
+# ignore list to surface the full advisory set for visibility, and it hard-fails
+# if the lockfile has moved off the pinned vulnerable versions while the ignores
+# are still present, i.e. the upstream fix landed but the ignore was not dropped.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  scheduled-audit:
+    name: scheduled audit (no ignores)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: audit-schedule
+
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit
+
+      # Full advisory report with NO suppressions. Run from a scratch dir that
+      # has no .cargo/audit.toml so the ignore list does not apply; never fail
+      # the build on this step, it is visibility only.
+      - name: Full audit report (ignores not applied)
+        run: |
+          mkdir -p "$RUNNER_TEMP/full-audit"
+          cp Cargo.lock "$RUNNER_TEMP/full-audit/Cargo.lock"
+          cd "$RUNNER_TEMP/full-audit"
+          {
+            echo '### Full cargo audit (no ignores applied)'
+            echo '```'
+            cargo audit -f Cargo.lock || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Drift guard: the hickory ignores are only valid while hickory-proto is
+      # pinned at 0.25.x. If the lockfile has moved past that, the upstream fix
+      # is in and the ignores in .cargo/audit.toml must be removed. Fail loudly.
+      - name: Fail if hickory moved past 0.25.x while ignores remain
+        run: |
+          set -euo pipefail
+          version="$(grep -A1 'name = "hickory-proto"' Cargo.lock | grep '^version' | head -1 | cut -d'"' -f2)"
+          echo "hickory-proto in Cargo.lock: ${version:-not present}"
+          ignores_present=false
+          if grep -q 'RUSTSEC-2026-011' .cargo/audit.toml; then
+            ignores_present=true
+          fi
+          if [ "$ignores_present" = true ] && [ -n "${version}" ] && [[ "${version}" != 0.25.* ]]; then
+            echo "::error::hickory-proto is ${version} but the RUSTSEC-2026-0118/0119 ignores are still in .cargo/audit.toml. The upstream fix appears to be available; remove the ignores."
+            exit 1
+          fi
+          echo "No drift: ignore list is consistent with the pinned hickory-proto version."

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,15 +9,20 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs on the same PR/branch; never cancel runs on main.
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
 jobs:
-  fmt-clippy-test:
-    name: fmt + clippy + test
+  fmt-clippy:
+    name: fmt + clippy
     runs-on: ubuntu-latest
-
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -37,5 +42,109 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+  test:
+    name: test (${{ matrix.toolchain }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, beta]
+    # Beta is informational: an upstream beta regression should warn, not block merges.
+    continue-on-error: ${{ matrix.toolchain == 'beta' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: ${{ matrix.toolchain }}
+
       - name: cargo test
         run: cargo test --workspace
+
+  build-release:
+    name: build --release
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: release
+
+      - name: cargo build --release
+        run: cargo build --release --workspace
+
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: audit
+
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit
+
+      - name: cargo audit
+        run: cargo audit
+
+  msrv:
+    name: MSRV (Rust 1.91)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Rust 1.91
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # 1.91
+        with:
+          toolchain: "1.91"
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: msrv
+
+      - name: cargo check on MSRV
+        run: cargo check --workspace --all-targets
+
+  docker-build:
+    name: Docker build smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build image
+        run: docker build -t gitlawb-node:ci-test .
+
+      - name: Smoke test --version
+        run: docker run --rm gitlawb-node:ci-test --version

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
@@ -55,6 +57,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
@@ -76,6 +80,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
@@ -97,6 +103,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
@@ -121,6 +129,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Rust 1.91
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # 1.91
@@ -142,6 +152,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Build image
         run: docker build -t gitlawb-node:ci-test .

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -119,6 +119,19 @@ jobs:
       - name: Install cargo-audit
         run: cargo install --locked cargo-audit
 
+      # Hard-fail gate. Suppressions live in .cargo/audit.toml (read automatically
+      # from the repo root), each with no available upstream fix. A green check
+      # here means "no NEW advisories", not "advisory-clean": surface the active
+      # ignore list so a reviewer sees exactly what is being accepted.
+      - name: Show active audit ignores
+        run: |
+          {
+            echo '### cargo audit: accepted advisories (.cargo/audit.toml)'
+            echo '```toml'
+            sed -n '/^\[advisories\]/,$p' .cargo/audit.toml
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: cargo audit
         run: cargo audit
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2479,7 +2479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5736,9 +5736,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 [workspace.package]
 version = "0.3.9"
 edition = "2021"
+rust-version = "1.91"
 license = "MIT OR Apache-2.0"
 authors = ["gitlawb contributors"]
 repository = "https://github.com/gitlawb/node"

--- a/crates/git-remote-gitlawb/Cargo.toml
+++ b/crates/git-remote-gitlawb/Cargo.toml
@@ -3,6 +3,7 @@ name = "git-remote-gitlawb"
 description = "Git remote helper — enables 'git clone gitlawb://did:gitlawb:...'"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [[bin]]

--- a/crates/gitlawb-attest/Cargo.toml
+++ b/crates/gitlawb-attest/Cargo.toml
@@ -3,6 +3,7 @@ name = "gitlawb-attest"
 description = "External Attestation v1: pluggable provenance attachments for gitlawb ref-update certs"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [dependencies]

--- a/crates/gitlawb-core/Cargo.toml
+++ b/crates/gitlawb-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "gitlawb-core"
 description = "Core cryptographic primitives for the gitlawb network: DIDs, CIDs, UCAN, HTTP Signatures, ref-update certificates"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [dependencies]

--- a/crates/gitlawb-node/Cargo.toml
+++ b/crates/gitlawb-node/Cargo.toml
@@ -3,6 +3,7 @@ name = "gitlawb-node"
 description = "The gitlawb node daemon — git hosting over HTTP with DID auth"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [[bin]]

--- a/crates/gl/Cargo.toml
+++ b/crates/gl/Cargo.toml
@@ -3,6 +3,7 @@ name = "gl"
 description = "The gitlawb CLI — identity management, node control, MCP server"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [[bin]]


### PR DESCRIPTION
Splits the single stable-only `fmt + clippy + test` job in `pr-checks.yml` into focused jobs and adds the coverage the pipeline was missing.

What runs on every PR now:

- **fmt + clippy** (stable): `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- **test**: matrix on stable and beta, `cargo test --workspace`. Beta is `continue-on-error` so an upstream beta regression warns instead of blocking merges; stable stays required.
- **build --release**: `cargo build --release --workspace`, so PRs get a release-profile signal (previously only the release workflow built release artifacts, and only on tags).
- **cargo audit**: installs `cargo-audit` with `--locked` and runs it against the committed `Cargo.lock`.
- **MSRV (Rust 1.91)**: pins the 1.91 toolchain and runs `cargo check --workspace --all-targets`. Backed by a real `rust-version = "1.91"` in `[workspace.package]`, inherited by all five crates, so the README/Dockerfile's stated minimum is now enforced instead of aspirational.
- **Docker build smoke test**: `docker build` plus a `--version` run, mirroring the release workflow's entrypoint, so a Dockerfile regression can't reach `main` and break `docker compose up`.

Also added a concurrency group that cancels superseded PR runs (never cancels `main`) and per-job timeouts. New actions follow the existing SHA-pinned convention.

Heads up on branch protection: the required status check changes from `fmt + clippy + test` to the new job names (`fmt + clippy`, `test (stable)`, `build --release`, `cargo audit`, `MSRV (Rust 1.91)`, `Docker build smoke test`). The required-checks list will need updating or PRs will wait on a check that no longer reports. `test (beta)` is intentionally non-blocking.


---

## Accepted advisories (cargo audit)

The `cargo audit` gate is green, but two reachable advisories ship suppressed because no upstream fix exists yet. Noting them so a green check is not read as advisory-clean:

- `RUSTSEC-2026-0118` / `RUSTSEC-2026-0119` (`hickory-proto 0.25.2`, via `libp2p-dns 0.44`): reachable DoS through the node's system DNS resolver (`crates/gitlawb-node/src/p2p/mod.rs:238`). No fix until `libp2p-dns` ships hickory 0.26. Tracked in #76.
- `RUSTSEC-2023-0071` (`rsa 0.9.10`): present in the lockfile via sqlx's unconditional `sqlx-mysql`, but not linked into the binary (sqlx is postgres-only), so there is no RSA oracle to attack; no upstream fix regardless.

`rustls-webpki` was bumped to 0.103.13 to clear its three advisories rather than ignore them. Suppressions live in `.cargo/audit.toml` with inline rationale; the audit job echoes the active ignores to its summary, and the weekly scheduled job re-checks without the ignores and fails on hickory drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Set an explicit minimum supported Rust version (1.91) across the workspace and crates.
  * Improved CI reliability and coverage with PR run concurrency control, a dedicated test matrix, release builds, MSRV checks, Docker build + version smoke testing, and automated security audits.
  * Added a scheduled weekly audit that detects advisory drift to help keep the security posture current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
