### PR TITLE
ci(release): smoke-test packaged binaries' --version before attaching

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,27 @@ jobs:
       - name: Build
         run: cargo build --release --target ${{ matrix.target }} -p gl -p git-remote-gitlawb -p gitlawb-node
 
+      # Run each packaged binary's --version so a broken release artifact fails the
+      # build instead of shipping. Skipped for cross-compiled targets that can't run
+      # on the host runner (aarch64 linux on an x86_64 runner).
+      - name: Smoke test binaries
+        if: ${{ matrix.target != 'aarch64-unknown-linux-musl' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.release-please.outputs.version }}"
+          BIN_DIR="target/${{ matrix.target }}/release"
+          for bin in gl git-remote-gitlawb gitlawb-node; do
+            echo "== $bin --version =="
+            out="$("$BIN_DIR/$bin" --version)"
+            echo "$out"
+            # Each binary prints "<name> <version>"; assert the released version is present.
+            grep -qF "$VERSION" <<<"$out" || {
+              echo "::error::$bin --version did not report expected version $VERSION (got: $out)"
+              exit 1
+            }
+          done
+
       - name: Package
         id: pkg
         shell: bash


### PR DESCRIPTION
## What

Smoke-tests the packaged release binaries (`gl`, `git-remote-gitlawb`, `gitlawb-node`) by running each one's `--version` in the `release-binaries` job before they're attached to the release.

## Why

This is the follow-up I flagged in #30 ("wiring `--version` checks for all three binaries into `release.yml`"), now unblocked by `git-remote-gitlawb` gaining `--version` in that PR.

`docs/OSS-READINESS-AUDIT.md` notes:

> *"release binaries are not smoke-tested after packaging."*

The `release-binaries` job builds and tars up all three binaries but never executes them, so a broken artifact (bad build, missing runtime symbol) would ship to a release unnoticed. The `docker` job only smoke-tests the image's `gitlawb-node --version`, not the standalone binaries in the tarball.

## How

- After `Build`, a new `Smoke test binaries` step runs `--version` on each of the three binaries and asserts the released version string is present in the output (they print `<name> <version>`, matching the convention #30 aligned `git-remote-gitlawb` to).
- A version mismatch or non-zero exit fails the release with a clear `::error::` annotation.
- Skipped for `aarch64-unknown-linux-musl`, which is cross-compiled and can't execute on the x86_64 runner. The other three targets (`x86_64-linux-musl`, `x86_64-apple-darwin`, `aarch64-apple-darwin`) run natively on their matrix runners.

No protocol, API, or release-artifact changes — purely an added verification gate.

## Testing

- `release.yml` validated as well-formed YAML.
- Verified locally against a release build of the current `main`:
  - `gl --version` → `gl 0.3.9`
  - `git-remote-gitlawb --version` → `git-remote-gitlawb 0.3.9`
  - `gitlawb-node --version` → `gitlawb-node 0.3.9`
  - The exact loop from the workflow passes for all three, and correctly **fails** when the expected version doesn't match (confirming the gate isn't a no-op).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release pipeline with automated verification of compiled binaries to ensure version consistency across all target platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->