### PR TITLE
fix(core): zeroize the derived X25519 secret (#65)

### DIFF
--- a/crates/gitlawb-core/src/encrypt.rs
+++ b/crates/gitlawb-core/src/encrypt.rs
@@ -6,6 +6,7 @@
 use crate::identity::Keypair;
 use anyhow::{Context, Result};
 use ed25519_dalek::VerifyingKey;
+use zeroize::Zeroizing;
 
 /// X25519 public key (Montgomery u) for an Ed25519 verifying key.
 fn x25519_public(vk: &VerifyingKey) -> Result<[u8; 32]> {
@@ -18,14 +19,18 @@ fn x25519_public(vk: &VerifyingKey) -> Result<[u8; 32]> {
 }
 
 /// X25519 secret scalar for an Ed25519 seed (SHA-512 of seed, lower 32, clamped).
-fn x25519_secret_from_seed(seed: &[u8; 32]) -> [u8; 32] {
+/// Returns the scalar wrapped in `Zeroizing`, and scrubs the intermediate
+/// SHA-512 digest, so no copy of this secret material lingers in freed memory.
+fn x25519_secret_from_seed(seed: &[u8; 32]) -> Zeroizing<[u8; 32]> {
     use sha2::{Digest, Sha512};
-    let h = Sha512::digest(seed);
-    let mut s = [0u8; 32];
+    use zeroize::Zeroize;
+    let mut h = Sha512::digest(seed);
+    let mut s = Zeroizing::new([0u8; 32]);
     s.copy_from_slice(&h[..32]);
     s[0] &= 248;
     s[31] &= 127;
     s[31] |= 64;
+    h.as_mut_slice().zeroize();
     s
 }
 
@@ -123,7 +128,7 @@ pub fn open_blob(envelope: &[u8], keypair: &Keypair) -> Result<Vec<u8>> {
             .context("decode header")?;
     let body = &envelope[p + hlen..];
 
-    let my_x = XSecret::from(x25519_secret_from_seed(&keypair.to_seed()));
+    let my_x = XSecret::from(*x25519_secret_from_seed(&keypair.to_seed()));
 
     // Identities are blinded: no entry says which recipient it belongs to, so
     // try each one. The ChaChaBox AEAD tag authenticates, so exactly the
@@ -188,7 +193,7 @@ mod tests {
         let seed = kp.to_seed();
         let xpub_from_public = x25519_public(&kp.verifying_key()).unwrap();
         let xsec = x25519_secret_from_seed(&seed);
-        let xpub_from_secret = crypto_box::SecretKey::from(xsec).public_key().to_bytes();
+        let xpub_from_secret = crypto_box::SecretKey::from(*xsec).public_key().to_bytes();
         assert_eq!(xpub_from_public, xpub_from_secret);
     }
 


### PR DESCRIPTION
> Stacked on #64 (#41). Based on `fix/zeroize-seed-bytes`; the diff here is only this change. Retarget/rebase onto `main` once #64 merges. Please merge #64 first.

## Summary

`x25519_secret_from_seed` derived the X25519 private scalar from the Ed25519 seed and returned it as a bare `[u8; 32]`. Because `[u8; 32]` is `Copy` with no `Drop` (and `sha2`'s digest output likewise has no zeroize), the scalar, the SHA-512 digest, and the returned temporary were released without being scrubbed. This routes the derived secret through `Zeroizing` and explicitly wipes the digest.

## Motivation & context

Closes #65

Direct sibling of #41/#64: same `Copy`-no-`Drop` memory-hygiene class, on the *derived* X25519 secret rather than the raw seed. #41 was deliberately scoped to the seed accessor and flagged this downstream leak for its own follow-up. The derived scalar is the actual private key fed into `crypto_box::SecretKey` in `open_blob`, which runs on every withheld-blob read.

## Kind of change

- [ ] Bug fix
- [ ] Feature
- [x] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

Crate touched: `gitlawb-core`.

- `x25519_secret_from_seed` now returns `Zeroizing<[u8; 32]>` and builds the scalar directly into a zeroizing buffer, so no bare `[u8; 32]` secret local persists.
- The intermediate SHA-512 digest is explicitly wiped (`h.as_mut_slice().zeroize()`, a volatile non-elidable write) before it drops.
- The two callers (`open_blob` and a crypto test) deref the result into `crypto_box::SecretKey`, which already scrubs its own copy.

No behavior change: the derived scalar and all decryption output are byte-identical, covered by the existing `ed25519_to_x25519_keypair_agrees` and `seal_open_round_trip_for_recipients` tests.

## How a reviewer can verify

```sh
cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
```

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally
- [x] New behavior is covered by tests (behavior is byte-identical; existing crypto round-trip tests guard it)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`feat(...)`, `fix(...)`, `docs(...)`)
- [x] Docs / `.env.example` updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Protocol & signing impact

- [ ] Touches DID / `did:key`, Ed25519 / RFC 9421 signatures, UCAN, ref certs, or P2P wire formats
- [x] Discussed in an issue before implementation
- [x] Backward-compatible with existing nodes and previously signed history

In-memory hygiene only. No change to the encryption scheme, key derivation math, or wire format; output is byte-identical.
