### PR TITLE
fix(node): fail closed when a recipient DID can't be resolved (#47)

### DIFF
--- a/crates/gitlawb-node/src/encrypted_pin.rs
+++ b/crates/gitlawb-node/src/encrypted_pin.rs
@@ -75,7 +75,10 @@ enum SealPlan {
     /// partial set. Carries the unresolvable DIDs for logging.
     SkipUnresolvable(Vec<String>),
     /// Seal to `keys` and record coverage under `tag`.
-    Seal { keys: Vec<VerifyingKey>, tag: String },
+    Seal {
+        keys: Vec<VerifyingKey>,
+        tag: String,
+    },
 }
 
 /// Decide what to do with one blob given its desired recipient set and the tag
@@ -304,7 +307,11 @@ mod tests {
         match plan_seal(&SEED, &dids, None) {
             SealPlan::Seal { keys, tag } => {
                 assert_eq!(keys.len(), 2, "must seal to the full recipient set");
-                assert_eq!(tag, recipients_tag(&SEED, &dids), "records the full-set tag");
+                assert_eq!(
+                    tag,
+                    recipients_tag(&SEED, &dids),
+                    "records the full-set tag"
+                );
             }
             other => panic!("expected Seal, got {other:?}"),
         }

--- a/crates/gitlawb-node/src/encrypted_pin.rs
+++ b/crates/gitlawb-node/src/encrypted_pin.rs
@@ -63,6 +63,42 @@ fn resolve_all_recipients(dids: &BTreeSet<String>) -> Result<Vec<VerifyingKey>, 
     }
 }
 
+/// What to do with a single withheld blob, decided without any DB or IO so the
+/// fail-closed invariant (#47) is unit-testable in isolation.
+#[derive(Debug)]
+enum SealPlan {
+    /// An existing envelope already covers exactly this recipient set; nothing to do.
+    SkipUnchanged,
+    /// No recipient DID resolved to a key, so there is nothing to seal to.
+    SkipNoRecipients,
+    /// At least one recipient DID is unresolvable. Fail closed: never seal to a
+    /// partial set. Carries the unresolvable DIDs for logging.
+    SkipUnresolvable(Vec<String>),
+    /// Seal to `keys` and record coverage under `tag`.
+    Seal { keys: Vec<VerifyingKey>, tag: String },
+}
+
+/// Decide what to do with one blob given its desired recipient set and the tag
+/// already stored for it (if any). Pure: no DB, no IO.
+///
+/// This is the #47 fail-closed gate in isolation: it returns `Seal` only when
+/// EVERY recipient DID resolves, so no caller can seal to a partial set. A
+/// changed recipient set (different tag) re-seals so a newly added reader can
+/// recover the blob; reader removal is not retroactive (the old envelope is
+/// already public). The comparison is on the opaque node-keyed tag, never the
+/// DID list.
+fn plan_seal(node_seed: &[u8; 32], dids: &BTreeSet<String>, stored_tag: Option<&str>) -> SealPlan {
+    let tag = recipients_tag(node_seed, dids);
+    if stored_tag == Some(tag.as_str()) {
+        return SealPlan::SkipUnchanged;
+    }
+    match resolve_all_recipients(dids) {
+        Ok(keys) if keys.is_empty() => SealPlan::SkipNoRecipients,
+        Ok(keys) => SealPlan::Seal { keys, tag },
+        Err(unresolved) => SealPlan::SkipUnresolvable(unresolved),
+    }
+}
+
 /// Encrypt and pin every withheld blob. `recipients` maps blob oid -> DID set;
 /// `node_seed` keys the opaque recipients tag. Returns `(oid, cid)` for each blob
 /// actually sealed and recorded this call (the per-push delta), used by Option B3
@@ -78,33 +114,25 @@ pub async fn encrypt_and_pin(
     let mut sealed = Vec::new();
     let mut skipped_unresolvable = 0usize;
     for (oid, dids) in recipients {
-        // Skip only if an existing envelope already covers exactly these
-        // recipients. If the recipient set changed (e.g. a reader was added to
-        // the rule), re-seal so the new reader can recover the blob. Reader
-        // removal is not retroactive: the old envelope is already public. The
-        // comparison is on the opaque node-keyed tag, never the DID list.
-        let tag = recipients_tag(node_seed, dids);
-        match db.encrypted_blob_recipients_tag(repo_id, oid).await {
-            Ok(Some(stored_tag)) if stored_tag == tag => continue,
-            Ok(_) => {}
+        // A DB read failure is not a cache miss: re-sealing here would do an
+        // avoidable IPFS write during a partial outage. Skip and retry next push.
+        let stored_tag = match db.encrypted_blob_recipients_tag(repo_id, oid).await {
+            Ok(t) => t,
             Err(e) => {
-                // A DB read failure is not a cache miss: re-sealing here would do
-                // an avoidable IPFS write during a partial outage. Skip and retry
-                // on the next push.
                 tracing::warn!(oid = %oid, err = %e, "recipients_tag lookup failed; skipping reseal");
                 continue;
             }
-        }
-        // Fail closed: seal only when every recipient DID resolves. Sealing to a
-        // partial set while recording the full set as covered would permanently
-        // lock out the dropped readers (#47).
-        let keys = match resolve_all_recipients(dids) {
-            Ok(keys) if keys.is_empty() => {
+        };
+        // Fail closed: plan_seal returns Seal only when every recipient DID
+        // resolves, so we never seal to a partial set and record the full set as
+        // covered (which would permanently lock out the dropped readers, #47).
+        let (keys, tag) = match plan_seal(node_seed, dids, stored_tag.as_deref()) {
+            SealPlan::SkipUnchanged => continue,
+            SealPlan::SkipNoRecipients => {
                 tracing::warn!(oid = %oid, "no resolvable recipient keys; skipping encrypted pin");
                 continue;
             }
-            Ok(keys) => keys,
-            Err(unresolved) => {
+            SealPlan::SkipUnresolvable(unresolved) => {
                 skipped_unresolvable += 1;
                 // DIDs are user-controlled (rule reader_dids); log a bounded
                 // sample, not an unbounded dump. Wording stays neutral about the
@@ -119,6 +147,7 @@ pub async fn encrypt_and_pin(
                 );
                 continue;
             }
+            SealPlan::Seal { keys, tag } => (keys, tag),
         };
         let data = match crate::git::store::read_object(repo_path, oid) {
             Ok(Some((_t, bytes))) => bytes,
@@ -261,5 +290,66 @@ mod tests {
             a, b,
             "tag must depend on the node seed, not be a plain hash"
         );
+    }
+
+    // plan_seal is the seal/skip decision `encrypt_and_pin` acts on. Testing it
+    // directly pins the #47 fail-closed invariant at the function that owns it,
+    // which a unit test of `resolve_all_recipients` alone cannot do (it can't
+    // catch the caller falling through to a partial seal).
+    const SEED: [u8; 32] = [9u8; 32];
+
+    #[test]
+    fn plan_seal_seals_when_all_recipients_resolve() {
+        let dids = set(&[did_key(1), did_key(2)]);
+        match plan_seal(&SEED, &dids, None) {
+            SealPlan::Seal { keys, tag } => {
+                assert_eq!(keys.len(), 2, "must seal to the full recipient set");
+                assert_eq!(tag, recipients_tag(&SEED, &dids), "records the full-set tag");
+            }
+            other => panic!("expected Seal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_seal_fails_closed_on_any_unresolvable_recipient() {
+        // The #47 invariant at the decision boundary: one unresolvable DID among
+        // resolvable ones must NOT yield a Seal (which would seal a partial set).
+        let gitlawb = Did::gitlawb("zPending").to_string();
+        let dids = set(&[did_key(1), did_key(2), gitlawb.clone()]);
+        match plan_seal(&SEED, &dids, None) {
+            SealPlan::SkipUnresolvable(unresolved) => assert_eq!(unresolved, vec![gitlawb]),
+            other => panic!("must fail closed, never seal a partial set; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plan_seal_skips_empty_recipient_set() {
+        let dids = BTreeSet::new();
+        assert!(matches!(
+            plan_seal(&SEED, &dids, None),
+            SealPlan::SkipNoRecipients
+        ));
+    }
+
+    #[test]
+    fn plan_seal_skips_when_tag_unchanged() {
+        let dids = set(&[did_key(1)]);
+        let stored = recipients_tag(&SEED, &dids);
+        assert!(matches!(
+            plan_seal(&SEED, &dids, Some(&stored)),
+            SealPlan::SkipUnchanged
+        ));
+    }
+
+    #[test]
+    fn plan_seal_reseals_when_recipient_set_changed() {
+        // A stored tag for a DIFFERENT set is a miss: a newly added reader must
+        // trigger a re-seal, not be skipped as unchanged.
+        let dids = set(&[did_key(1), did_key(2)]);
+        let stale = recipients_tag(&SEED, &set(&[did_key(1)]));
+        match plan_seal(&SEED, &dids, Some(&stale)) {
+            SealPlan::Seal { keys, .. } => assert_eq!(keys.len(), 2),
+            other => panic!("changed recipient set must re-seal; got {other:?}"),
+        }
     }
 }

--- a/crates/gitlawb-node/src/encrypted_pin.rs
+++ b/crates/gitlawb-node/src/encrypted_pin.rs
@@ -19,6 +19,31 @@ fn did_to_key(did: &str) -> Option<VerifyingKey> {
     Did::from_str(did).ok()?.to_verifying_key().ok()
 }
 
+/// Resolve every recipient DID to its verifying key, all-or-nothing.
+///
+/// Returns `Ok(keys)` only when every DID resolves. If any DID fails, returns
+/// `Err(unresolved)` listing the unresolvable DID strings so the caller can fail
+/// closed rather than seal to a partial recipient set (#47): sealing to a subset
+/// while recording the full set as covered permanently locks out the dropped
+/// readers. Resolution is local-only, so `did:web`/`did:gitlawb` recipients (and
+/// any malformed `did:key`) land in the unresolved set until off-`did:key`
+/// resolution exists.
+fn resolve_all_recipients(dids: &BTreeSet<String>) -> Result<Vec<VerifyingKey>, Vec<String>> {
+    let mut keys = Vec::with_capacity(dids.len());
+    let mut unresolved = Vec::new();
+    for did in dids {
+        match did_to_key(did) {
+            Some(k) => keys.push(k),
+            None => unresolved.push(did.clone()),
+        }
+    }
+    if unresolved.is_empty() {
+        Ok(keys)
+    } else {
+        Err(unresolved)
+    }
+}
+
 /// Encrypt and pin every withheld blob. `recipients` maps blob oid -> DID set.
 /// Returns `(oid, cid, recipients)` for each blob actually sealed and recorded
 /// this call (the per-push delta), used by Option B3 to anchor a manifest.
@@ -30,6 +55,7 @@ pub async fn encrypt_and_pin(
     recipients: &HashMap<String, BTreeSet<String>>,
 ) -> Vec<(String, String, Vec<String>)> {
     let mut sealed = Vec::new();
+    let mut skipped_unresolvable = 0usize;
     for (oid, dids) in recipients {
         // Skip only if an existing envelope already covers exactly these
         // recipients. If the recipient set changed (e.g. a reader was added to
@@ -41,14 +67,41 @@ pub async fn encrypt_and_pin(
                 continue;
             }
         }
-        let keys: Vec<VerifyingKey> = dids.iter().filter_map(|d| did_to_key(d)).collect();
-        if keys.is_empty() {
-            tracing::warn!(oid = %oid, "no resolvable recipient keys; skipping encrypted pin");
-            continue;
-        }
+        // Fail closed: seal only when every recipient DID resolves. Sealing to a
+        // partial set while recording the full set as covered would permanently
+        // lock out the dropped readers (#47).
+        let keys = match resolve_all_recipients(dids) {
+            Ok(keys) if keys.is_empty() => {
+                tracing::warn!(oid = %oid, "no resolvable recipient keys; skipping encrypted pin");
+                continue;
+            }
+            Ok(keys) => keys,
+            Err(unresolved) => {
+                skipped_unresolvable += 1;
+                // DIDs are user-controlled (rule reader_dids); log a bounded
+                // sample, not an unbounded dump. Wording stays neutral about the
+                // cause: a malformed did:key is not DHT-pending and never will
+                // resolve, unlike a did:gitlawb awaiting anchoring.
+                let sample: Vec<&String> = unresolved.iter().take(3).collect();
+                tracing::warn!(
+                    oid = %oid,
+                    unresolved_count = unresolved.len(),
+                    unresolved_sample = ?sample,
+                    "unresolvable recipient DID(s); skipping encrypted pin to avoid sealing to a partial set"
+                );
+                continue;
+            }
+        };
         let data = match crate::git::store::read_object(repo_path, oid) {
             Ok(Some((_t, bytes))) => bytes,
-            _ => continue,
+            Ok(None) => {
+                tracing::warn!(oid = %oid, "git object not found; skipping encrypted pin");
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(oid = %oid, err = %e, "read_object failed; skipping encrypted pin");
+                continue;
+            }
         };
         let envelope = match seal_blob(&data, &keys) {
             Ok(e) => e,
@@ -59,7 +112,14 @@ pub async fn encrypt_and_pin(
         };
         let cid = match crate::ipfs_pin::pin_git_object(ipfs_api, oid, &envelope).await {
             Ok(c) if !c.is_empty() => c,
-            _ => continue,
+            Ok(_) => {
+                tracing::warn!(oid = %oid, "pin_git_object returned no cid; skipping");
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(oid = %oid, err = %e, "pin_git_object failed; skipping");
+                continue;
+            }
         };
         let dids_vec: Vec<String> = dids.iter().cloned().collect();
         if let Err(e) = db
@@ -71,5 +131,82 @@ pub async fn encrypt_and_pin(
         }
         sealed.push((oid.clone(), cid.clone(), dids_vec));
     }
+    // One aggregate signal so a coverage collapse is a single greppable line, not
+    // a per-oid scrape. In a fully-migrated did:gitlawb org every blob skips and
+    // recovery coverage silently drops to zero; this is the operator's cue that
+    // the gap is the deliberate fail-closed posture, not a malfunction.
+    if skipped_unresolvable > 0 {
+        tracing::warn!(
+            sealed = sealed.len(),
+            skipped = skipped_unresolvable,
+            "encrypted-pin coverage reduced: blobs skipped for unresolvable recipients"
+        );
+    }
     sealed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn did_key(seed: u8) -> String {
+        let vk = SigningKey::from_bytes(&[seed; 32]).verifying_key();
+        Did::from_verifying_key(&vk).to_string()
+    }
+
+    fn set(dids: &[String]) -> BTreeSet<String> {
+        dids.iter().cloned().collect()
+    }
+
+    #[test]
+    fn all_did_key_recipients_resolve() {
+        let dids = set(&[did_key(1), did_key(2)]);
+        let keys = resolve_all_recipients(&dids).expect("all did:key resolve");
+        assert_eq!(keys.len(), 2);
+    }
+
+    #[test]
+    fn mixed_set_with_did_gitlawb_fails_closed() {
+        // Core #47 regression: a resolvable subset must never yield a sealable
+        // key set. Two did:key plus one did:gitlawb -> Err naming only the
+        // unresolvable DID.
+        let gitlawb = Did::gitlawb("zSomeDhtKey").to_string();
+        let dids = set(&[did_key(1), did_key(2), gitlawb.clone()]);
+        let unresolved = resolve_all_recipients(&dids).expect_err("must fail closed");
+        assert_eq!(unresolved, vec![gitlawb]);
+    }
+
+    #[test]
+    fn did_web_recipient_fails_closed() {
+        let web = Did::web("example.com").to_string();
+        let dids = set(&[did_key(1), web.clone()]);
+        let unresolved = resolve_all_recipients(&dids).expect_err("did:web cannot resolve locally");
+        assert_eq!(unresolved, vec![web]);
+    }
+
+    #[test]
+    fn malformed_did_key_fails_closed() {
+        // The third state: not a method-resolution gap but a permanently broken
+        // did:key (invalid multibase). Must also fail closed.
+        let broken = "did:key:z!!!invalid".to_string();
+        let dids = set(&[did_key(1), broken.clone()]);
+        let unresolved = resolve_all_recipients(&dids).expect_err("malformed did:key fails");
+        assert_eq!(unresolved, vec![broken]);
+    }
+
+    #[test]
+    fn empty_set_resolves_to_empty_keys() {
+        let dids = BTreeSet::new();
+        let keys = resolve_all_recipients(&dids).expect("empty set is not an error");
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn single_unresolvable_did_returns_that_did() {
+        let gitlawb = Did::gitlawb("zOnlyOne").to_string();
+        let dids: BTreeSet<String> = [gitlawb.clone()].into_iter().collect();
+        let unresolved = resolve_all_recipients(&dids).expect_err("must fail closed");
+        assert_eq!(unresolved, vec![gitlawb]);
+    }
 }


### PR DESCRIPTION
## Summary

`encrypted_pin::encrypt_and_pin` sealed a withheld blob to whatever subset of its recipient DIDs resolved locally and recorded the full intended set as covered, permanently locking out any reader whose DID could not be resolved at seal time. This makes sealing fail closed: resolve all recipients or skip the blob.

## Motivation & context

Closes #47

`did_to_key` only resolves `did:key`; `did:web`/`did:gitlawb` (the canonical identity actors migrate to once DHT anchoring is live) and any malformed `did:key` return `None`. The old `filter_map` dropped those silently and sealed to the rest as long as one key resolved, then recorded the full DID set. Because the dedup compares the recorded set against the desired set, it matched on the next push and never re-sealed, so the dropped reader stayed locked out forever with no signal.

## Kind of change

- [x] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

gitlawb-node (`crates/gitlawb-node/src/encrypted_pin.rs`):

- Add `resolve_all_recipients`: resolves every recipient DID all-or-nothing, returning `Err(unresolved)` listing the DIDs that failed. `encrypt_and_pin` now skips the blob on any failure instead of sealing to a partial set. Nothing partial is recorded, so the dedup stays honest and the blob re-seals on a later push once resolution is available (no automatic backfill).
- Bounded per-blob warn (the unresolved DIDs are user-controlled rule data; log a count plus a small sample, not an unbounded dump) with wording that stays neutral about the cause (a malformed `did:key` is not DHT-pending).
- One aggregate coverage warn per call, so a fully-migrated `did:gitlawb` org dropping to zero encrypted-pin coverage is a single greppable line rather than a per-oid scrape.
- Give the previously silent `read_object` and `pin_git_object` failure arms warn logs.

Fail-closed is deliberate: a blob with an unresolvable reader gets no encrypted recovery envelope until resolution exists, but it is never leaked in plaintext (it was already pinned as withheld upstream). This trades recovery coverage during a transition for a clean audit invariant: a recorded `encrypted_blobs` row always means every authorized reader can recover the blob.

## How a reviewer can verify

```sh
cargo test -p gitlawb-node encrypted_pin
cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
```

The core regression is `mixed_set_with_did_gitlawb_fails_closed`: a resolvable `did:key` subset plus one `did:gitlawb` must return `Err` naming only the unresolvable DID, never a sealable key set. `malformed_did_key_fails_closed` covers the corrupt-`did:key` case.

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally
- [x] New behavior is covered by tests (required for fixes)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`feat(...)`, `fix(...)`, `docs(...)`)
- [x] Docs / `.env.example` updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Protocol & signing impact

- [ ] Touches DID / `did:key`, Ed25519 / RFC 9421 signatures, UCAN, ref certs, or P2P wire formats
- [ ] Discussed in an issue before implementation
- [x] Backward-compatible with existing nodes and previously signed history

This reads DID strings to resolve recipient keys but changes no signature, wire-format, or identity logic; existing envelopes and recorded recipient sets are untouched.

## Notes for reviewers

The peer-sync path (`sync.rs` records an empty recipient set for replicated envelopes via an overwriting upsert) interacts with the dedup but self-heals on the next push; it is pre-existing and out of scope here. A typed resolution-failure reason (distinguishing "method not resolvable yet" from "malformed `did:key`") is a possible follow-up; fail-closed behavior is identical for both today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Strengthened recipient handling to ensure all recipients are resolvable before proceeding, preventing partial processing when any recipient is invalid or unresolvable.
  * Improved behavior and messaging around skipped items, distinguishing between empty recipient sets, unresolvable recipients, and already-up-to-date recipients.
  * Refined pinning outcomes to better differentiate “no result” vs actual failures.

* **Tests**
  * Expanded coverage for recipient validation edge cases and decision paths to confirm fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->