### PR TITLE
fix(node): reject malformed path globs in visibility validation (#74)

### DIFF
--- a/crates/gitlawb-node/src/api/visibility.rs
+++ b/crates/gitlawb-node/src/api/visibility.rs
@@ -57,9 +57,23 @@ fn validate_path_glob(path_glob: &str) -> Result<()> {
             "path_glob must not end with '/'".into(),
         ));
     }
-    if path_glob.contains('*') && !path_glob.ends_with("/**") {
+    // Reject empty path segments. `glob_prefix` collapses "//**" to "/" (whole
+    // repo), so without this an operator could bypass the "/**" guard above and
+    // grant repo-wide read with "//**", or set a dead rule like "//secret/**"
+    // whose prefix never matches a real single-slash path and silently leaves
+    // the subtree readable.
+    if path_glob.contains("//") {
         return Err(AppError::BadRequest(
-            "the only supported wildcard is a trailing '/**'".into(),
+            "path_glob must not contain empty path segments".into(),
+        ));
+    }
+    // Strip the one permitted trailing "/**" before checking for stray
+    // wildcards, otherwise a "*" elsewhere in the prefix (e.g. "/a*b/**" or
+    // "/a/**/**") slips through because the string still ends with "/**".
+    let prefix = path_glob.strip_suffix("/**").unwrap_or(path_glob);
+    if prefix.contains('*') {
+        return Err(AppError::BadRequest(
+            "the only supported wildcard is a single trailing '/**'".into(),
         ));
     }
     Ok(())
@@ -240,9 +254,22 @@ mod tests {
 
     #[test]
     fn rejects_malformed_globs() {
-        // empty, no leading slash, whole-repo via "/**", trailing slash, and
-        // non-trailing wildcards are all rejected.
-        for g in ["", "secret/**", "/**", "/secret/", "/a*b", "/*/x"] {
+        // empty, no leading slash, whole-repo via "/**", trailing slash,
+        // non-trailing wildcards, double wildcards, and empty path segments
+        // (which would collapse to whole-repo or a dead rule) are all rejected.
+        for g in [
+            "",
+            "secret/**",
+            "/**",
+            "/**/**",
+            "/secret/",
+            "/a*b",
+            "/*/x",
+            "/a*b/**",
+            "/a/**/**",
+            "//**",
+            "//secret/**",
+        ] {
             assert!(validate_path_glob(g).is_err(), "{g} should be rejected");
         }
     }


### PR DESCRIPTION
## Summary

`validate_path_glob` accepted malformed visibility globs that silently misconfigure access. It now rejects a wildcard anywhere but the single trailing `/**`, and rejects empty path segments.

## Motivation & context

Closes #74

The wildcard guard checked `path_glob.ends_with("/**")` without first stripping it, so any glob that still ended in `/**` slipped through even with a `*` earlier in the prefix (e.g. `/a*b/**`, `/a/**/**`). `glob_prefix`/`glob_matches` treat that prefix as a literal, so the rule matched no real path and granted nobody, the exact silent misconfiguration this validator exists to prevent.

Reviewing the fix surfaced a second hole in the same function: `glob_prefix` greedily trims all trailing `**` and `/`, so `//**` collapsed to `/` (whole repo) and bypassed the explicit `/**` guard, and `//secret/**` became a dead rule whose prefix never matches a real single-slash path. Both are fail-closed and owner-only (only the repo owner can set rules, and a bad rule grants nobody), so this is hardening, not a live exploit, but the `//**` case is a one-character bypass of the whole-repo guard and worth closing alongside.

## Kind of change

- [x] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

Crate: `gitlawb-node`

- Strip the one permitted trailing `/**` before checking for stray `*`, so a non-trailing wildcard is rejected instead of slipping through.
- Reject path globs containing `//` (empty path segments), keeping the validator and `glob_prefix` agreed on the canonical form and closing the `//**` whole-repo bypass.
- Added `/a*b/**`, `/a/**/**`, `/**/**`, `//**`, `//secret/**` to the `rejects_malformed_globs` test.

## How a reviewer can verify

```sh
cargo test -p gitlawb-node glob
```

Both `accepts_supported_globs` (`/`, `/secret`, `/secret/**`, `/a/b/c`, `/a/b/**` still pass) and `rejects_malformed_globs` (the five added cases now rejected) cover the change.

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally
- [x] New behavior is covered by tests (required for fixes)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`feat(...)`, `fix(...)`, `docs(...)`)
- [x] Docs / `.env.example` updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Notes for reviewers

`remove_visibility` still does not run `validate_path_glob`, but deleting a never-matching rule is a no-op, so that asymmetry is harmless and left out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Path pattern validation now strictly rejects malformed patterns containing consecutive slashes, preventing invalid inputs from bypassing existing validation rules and security checks. This improves error handling, protects against problematic patterns, and ensures more robust validation across the system. The change maintains full backward compatibility with all valid glob patterns currently in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->