### PR TITLE
fix(security): reject non-public peer URLs + prune poisoned peers

### DIFF
--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -96,10 +96,7 @@ pub fn is_public_http_url(raw: &str) -> bool {
             std::net::IpAddr::V4(v4) => {
                 let o = v4.octets();
                 // RFC1918 private, link-local, or CGNAT (100.64.0.0/10).
-                if v4.is_private()
-                    || v4.is_link_local()
-                    || (o[0] == 100 && (o[1] & 0xc0) == 64)
-                {
+                if v4.is_private() || v4.is_link_local() || (o[0] == 100 && (o[1] & 0xc0) == 64) {
                     return false;
                 }
             }

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -52,10 +52,15 @@ pub fn is_public_http_url(raw: &str) -> bool {
     if !matches!(url.scheme(), "http" | "https") {
         return false;
     }
-    let host = match url.host_str() {
+    let mut host = match url.host_str() {
         Some(h) => h.to_ascii_lowercase(),
         None => return false,
     };
+    // Drop a single trailing dot (FQDN root): `localhost.` resolves the same as
+    // `localhost`, so normalize before the suffix/equality checks below.
+    if let Some(stripped) = host.strip_suffix('.') {
+        host = stripped.to_string();
+    }
     if host.is_empty()
         || host == "localhost"
         || host.ends_with(".local")
@@ -67,12 +72,34 @@ pub fn is_public_http_url(raw: &str) -> bool {
     // before parsing as an IP.
     let ip_candidate = host.trim_start_matches('[').trim_end_matches(']');
     if let Ok(ip) = ip_candidate.parse::<std::net::IpAddr>() {
+        // Reject loopback/unspecified on the literal as given — catches `::1`
+        // and `::` before the IPv4-folding below (`::1`.to_ipv4() would
+        // otherwise map to a non-loopback `0.0.0.1`).
+        if ip.is_loopback() || ip.is_unspecified() {
+            return false;
+        }
+        // Fold IPv4-mapped/compatible IPv6 (`::ffff:127.0.0.1`, `::127.0.0.1`)
+        // down to IPv4 so the v4 range checks catch loopback/private addresses
+        // smuggled in via an IPv6 literal, then re-check loopback/unspecified.
+        let ip = match ip {
+            std::net::IpAddr::V6(v6) => v6
+                .to_ipv4_mapped()
+                .or_else(|| v6.to_ipv4())
+                .map(std::net::IpAddr::V4)
+                .unwrap_or(ip),
+            v4 => v4,
+        };
         if ip.is_loopback() || ip.is_unspecified() {
             return false;
         }
         match ip {
             std::net::IpAddr::V4(v4) => {
-                if v4.is_private() || v4.is_link_local() {
+                let o = v4.octets();
+                // RFC1918 private, link-local, or CGNAT (100.64.0.0/10).
+                if v4.is_private()
+                    || v4.is_link_local()
+                    || (o[0] == 100 && (o[1] & 0xc0) == 64)
+                {
                     return false;
                 }
             }
@@ -363,7 +390,13 @@ pub async fn ping_peer(
 
     // Async ping
     let url = format!("{}/health", peer.http_url.trim_end_matches('/'));
-    let ok = reqwest::get(&url)
+    // Use the shared no-redirect client: bare `reqwest::get` follows redirects,
+    // so a peer could answer with `302 -> http://127.0.0.1/` and turn the ping
+    // into an SSRF probe.
+    let ok = state
+        .http_client
+        .get(&url)
+        .send()
         .await
         .map(|r| r.status().is_success())
         .unwrap_or(false);
@@ -405,8 +438,25 @@ mod tests {
             "ftp://node.gitlawb.com",
             "not-a-url",
             "",
+            // Trailing-dot FQDN of an internal host.
+            "http://localhost./",
+            // CGNAT (100.64.0.0/10).
+            "http://100.64.0.1:7545",
+            "http://100.127.255.255/",
+            // IPv4-mapped / IPv4-compatible IPv6 smuggling private/loopback v4.
+            "http://[::ffff:127.0.0.1]:7545",
+            "http://[::ffff:10.0.0.1]/",
+            "http://[::ffff:192.168.1.1]:7545",
+            "http://[::127.0.0.1]/",
         ] {
             assert!(!is_public_http_url(bad), "{bad:?} must be rejected");
         }
+    }
+
+    #[test]
+    fn accepts_public_outside_cgnat_range() {
+        // 100.0.0.0/10 boundary: .63 and .128 are public, only 100.64-127 is CGNAT.
+        assert!(is_public_http_url("http://100.63.255.255:7545"));
+        assert!(is_public_http_url("http://100.128.0.1/"));
     }
 }

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -40,6 +40,54 @@ pub struct PeerResponse {
     pub reachable: bool,
 }
 
+/// Whether a peer `http_url` is a public http(s) endpoint safe to register.
+/// Rejects non-http(s) schemes, loopback/unspecified/private/link-local IPs,
+/// and `localhost` / `.local` / `.internal` hostnames. Used at announce time
+/// and by the boot-time prune of already-poisoned rows.
+pub fn is_public_http_url(raw: &str) -> bool {
+    let url = match reqwest::Url::parse(raw) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+    if !matches!(url.scheme(), "http" | "https") {
+        return false;
+    }
+    let host = match url.host_str() {
+        Some(h) => h.to_ascii_lowercase(),
+        None => return false,
+    };
+    if host.is_empty()
+        || host == "localhost"
+        || host.ends_with(".local")
+        || host.ends_with(".internal")
+    {
+        return false;
+    }
+    // host_str() keeps brackets on IPv6 literals (e.g. "[::1]"); strip them
+    // before parsing as an IP.
+    let ip_candidate = host.trim_start_matches('[').trim_end_matches(']');
+    if let Ok(ip) = ip_candidate.parse::<std::net::IpAddr>() {
+        if ip.is_loopback() || ip.is_unspecified() {
+            return false;
+        }
+        match ip {
+            std::net::IpAddr::V4(v4) => {
+                if v4.is_private() || v4.is_link_local() {
+                    return false;
+                }
+            }
+            std::net::IpAddr::V6(v6) => {
+                let s = v6.segments();
+                // fc00::/7 (unique-local) or fe80::/10 (link-local)
+                if (s[0] & 0xfe00) == 0xfc00 || (s[0] & 0xffc0) == 0xfe80 {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
 /// GET /api/v1/peers
 pub async fn list_peers(State(state): State<AppState>) -> Result<Json<serde_json::Value>> {
     let peers = state.db.list_peers().await?;
@@ -83,10 +131,14 @@ pub async fn announce(
         );
     }
 
-    // Validate the URL is HTTP/HTTPS
-    if !req.http_url.starts_with("http://") && !req.http_url.starts_with("https://") {
+    // Validate the URL is a public http(s) endpoint. The announce route is
+    // reachable unauthenticated (until all peers sign), so without this an
+    // attacker can register loopback/private "peers" (localhost:5432, etc.)
+    // and turn our outbound sync-notify fan-out into an SSRF probe — and bury
+    // the real peers under junk so node-origin repos stop replicating.
+    if !is_public_http_url(&req.http_url) {
         return Err(AppError::BadRequest(
-            "http_url must start with http:// or https://".into(),
+            "http_url must be a public http(s) URL (no loopback, private, or .internal/.local hosts)".into(),
         ));
     }
 
@@ -323,4 +375,38 @@ pub async fn ping_peer(
         "http_url": peer.http_url,
         "reachable": ok,
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_public_http_url;
+
+    #[test]
+    fn accepts_public_https_and_http() {
+        assert!(is_public_http_url("https://node.gitlawb.com"));
+        assert!(is_public_http_url("https://manila.gitlawb.com/"));
+        assert!(is_public_http_url("http://203.0.113.10:7545"));
+    }
+
+    #[test]
+    fn rejects_loopback_private_and_internal() {
+        for bad in [
+            "http://localhost:7545",
+            "http://127.0.0.1:5432/",
+            "http://localhost:22/",
+            "http://0.0.0.0:7545",
+            "http://10.0.0.5:7545",
+            "http://192.168.1.10/",
+            "http://172.16.0.1:7545",
+            "http://169.254.1.1/",
+            "http://[::1]:7545",
+            "http://gitlawb-node.internal:7545",
+            "http://my-node.local/",
+            "ftp://node.gitlawb.com",
+            "not-a-url",
+            "",
+        ] {
+            assert!(!is_public_http_url(bad), "{bad:?} must be rejected");
+        }
+    }
 }

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -1601,6 +1601,26 @@ impl Db {
             .await?;
         Ok(result.rows_affected())
     }
+
+    /// Remove peer rows whose `http_url` is not a public http(s) endpoint
+    /// (loopback/private/internal hosts injected via the open announce route).
+    /// Runs at boot to clean tables poisoned before announce-time validation
+    /// existed. Filtering is done in Rust to share one definition of "public"
+    /// with the announce handler.
+    pub async fn prune_non_public_peers(&self) -> Result<u64> {
+        let peers = self.list_peers().await?;
+        let mut removed = 0u64;
+        for p in peers {
+            if !crate::api::peers::is_public_http_url(&p.http_url) {
+                sqlx::query("DELETE FROM peers WHERE did = $1")
+                    .bind(&p.did)
+                    .execute(&self.pool)
+                    .await?;
+                removed += 1;
+            }
+        }
+        Ok(removed)
+    }
 }
 
 // ── Pinned CIDs ───────────────────────────────────────────────────────────────

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -1548,6 +1548,14 @@ impl Db {
 
 impl Db {
     pub async fn upsert_peer(&self, did: &str, http_url: &str) -> Result<()> {
+        // Defense-in-depth at the DB boundary: both writers funnel through here
+        // — the announce handler and the bootstrap announce-back in main.rs.
+        // The latter has no announce-time check, so validating here is what
+        // stops a malicious bootstrap response from re-poisoning the table
+        // right after prune_non_public_peers cleaned it.
+        if !crate::api::peers::is_public_http_url(http_url) {
+            anyhow::bail!("refusing to register non-public peer http_url: {http_url}");
+        }
         let now = Utc::now().to_rfc3339();
         sqlx::query(
             "INSERT INTO peers (did, http_url, last_seen, last_ping_ok, announced_at)
@@ -1606,20 +1614,23 @@ impl Db {
     /// (loopback/private/internal hosts injected via the open announce route).
     /// Runs at boot to clean tables poisoned before announce-time validation
     /// existed. Filtering is done in Rust to share one definition of "public"
-    /// with the announce handler.
+    /// with the announce handler, then deleted in a single statement so one
+    /// transient error can't abandon the remaining poisoned rows mid-loop.
     pub async fn prune_non_public_peers(&self) -> Result<u64> {
         let peers = self.list_peers().await?;
-        let mut removed = 0u64;
-        for p in peers {
-            if !crate::api::peers::is_public_http_url(&p.http_url) {
-                sqlx::query("DELETE FROM peers WHERE did = $1")
-                    .bind(&p.did)
-                    .execute(&self.pool)
-                    .await?;
-                removed += 1;
-            }
+        let bad_dids: Vec<String> = peers
+            .into_iter()
+            .filter(|p| !crate::api::peers::is_public_http_url(&p.http_url))
+            .map(|p| p.did)
+            .collect();
+        if bad_dids.is_empty() {
+            return Ok(0);
         }
-        Ok(removed)
+        let result = sqlx::query("DELETE FROM peers WHERE did = ANY($1)")
+            .bind(&bad_dids)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
     }
 }
 

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -16,7 +16,6 @@ mod pinata;
 mod rate_limit;
 mod server;
 mod state;
-mod storage;
 mod sync;
 mod visibility;
 mod webhooks;
@@ -142,9 +141,14 @@ async fn main() -> Result<()> {
         None
     };
 
+    // Do not follow redirects: this client fans out to peer-supplied URLs
+    // (sync trigger, profile/repo fetches). A peer answering `302 Location:
+    // http://127.0.0.1/` would otherwise bypass the announce-time public-URL
+    // check and turn the redirect into an SSRF.
     let http_client = Arc::new(
         reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::none())
             .build()?,
     );
 
@@ -162,13 +166,25 @@ async fn main() -> Result<()> {
         info!("  fly machine: {mid}");
     }
 
-    // Initialize the storage-agnostic blob backend (S3-compatible / filesystem /
-    // IPFS), then wrap it in the repo-archive layer. `None` = local-only mode.
-    let blob_store = storage::build(&config).await;
-    let archive = blob_store.map(storage::archive::RepoArchive::new);
+    // Initialize Tigris S3 client if bucket is configured
+    let tigris = if !config.tigris_bucket.is_empty() {
+        match git::tigris::TigrisClient::new(&config.tigris_bucket).await {
+            Ok(client) => {
+                info!(bucket = %config.tigris_bucket, "tigris storage enabled");
+                Some(client)
+            }
+            Err(e) => {
+                tracing::warn!(err = %e, "failed to initialize Tigris client — using local-only storage");
+                None
+            }
+        }
+    } else {
+        info!("tigris storage disabled (no bucket configured)");
+        None
+    };
 
     let repo_store =
-        git::repo_store::RepoStore::new(config.repos_dir.clone(), archive, db.pool().clone());
+        git::repo_store::RepoStore::new(config.repos_dir.clone(), tigris, db.pool().clone());
 
     let rate_limiter = rate_limit::RateLimiter::new(10, std::time::Duration::from_secs(3600));
 

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -16,6 +16,7 @@ mod pinata;
 mod rate_limit;
 mod server;
 mod state;
+mod storage;
 mod sync;
 mod visibility;
 mod webhooks;
@@ -97,6 +98,15 @@ async fn main() -> Result<()> {
         }
     }
 
+    // Prune peer rows with non-public hosts (loopback/private/internal) that
+    // were injected via the unauthenticated announce route — they poison the
+    // sync-notify fan-out (SSRF + crowding out real peers).
+    match db.prune_non_public_peers().await {
+        Ok(0) => {}
+        Ok(n) => info!(removed = n, "pruned non-public (poisoned) peer rows"),
+        Err(e) => warn!(err = %e, "prune_non_public_peers failed (non-fatal)"),
+    }
+
     // Ensure repos directory exists
     std::fs::create_dir_all(&config.repos_dir).context("failed to create repos directory")?;
 
@@ -152,25 +162,13 @@ async fn main() -> Result<()> {
         info!("  fly machine: {mid}");
     }
 
-    // Initialize Tigris S3 client if bucket is configured
-    let tigris = if !config.tigris_bucket.is_empty() {
-        match git::tigris::TigrisClient::new(&config.tigris_bucket).await {
-            Ok(client) => {
-                info!(bucket = %config.tigris_bucket, "tigris storage enabled");
-                Some(client)
-            }
-            Err(e) => {
-                tracing::warn!(err = %e, "failed to initialize Tigris client — using local-only storage");
-                None
-            }
-        }
-    } else {
-        info!("tigris storage disabled (no bucket configured)");
-        None
-    };
+    // Initialize the storage-agnostic blob backend (S3-compatible / filesystem /
+    // IPFS), then wrap it in the repo-archive layer. `None` = local-only mode.
+    let blob_store = storage::build(&config).await;
+    let archive = blob_store.map(storage::archive::RepoArchive::new);
 
     let repo_store =
-        git::repo_store::RepoStore::new(config.repos_dir.clone(), tigris, db.pool().clone());
+        git::repo_store::RepoStore::new(config.repos_dir.clone(), archive, db.pool().clone());
 
     let rate_limiter = rate_limit::RateLimiter::new(10, std::time::Duration::from_secs(3600));
 

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -73,11 +73,14 @@ async fn run(
     // No redirects: peer URLs are attacker-influenceable, so a 3xx to a
     // loopback/private address must not be followed (SSRF guard, matching the
     // shared http_client and announce-time validation).
+    // Panic rather than fall back to reqwest::Client::new(): the default
+    // builder follows redirects, which would silently reintroduce the SSRF
+    // vector Policy::none() is here to close.
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .redirect(reqwest::redirect::Policy::none())
         .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+        .expect("failed to build no-redirect sync HTTP client");
     info!("sync worker started (auto_sync=true)");
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
     loop {

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -70,8 +70,12 @@ async fn run(
     let machine_id = std::env::var("FLY_MACHINE_ID").ok();
     // Bound each peer HTTP call (withheld-paths lookup + replica registration)
     // so a stalled peer cannot hang the worker.
+    // No redirects: peer URLs are attacker-influenceable, so a 3xx to a
+    // loopback/private address must not be followed (SSRF guard, matching the
+    // shared http_client and announce-time validation).
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .unwrap_or_else(|_| reqwest::Client::new());
     info!("sync worker started (auto_sync=true)");


### PR DESCRIPTION
The unauthenticated POST /api/v1/peers/announce only validated the http(s) scheme, so anyone could register loopback/private 'peers' (localhost:5432, localhost:22, internal admin URLs). On every push the node fans out signed sync-notify POSTs to all peers — turning this into an SSRF probe and burying the real peers under junk so node-origin repos stopped replicating. Observed on node.gitlawb.com: 126/194 peer rows were injected junk (fake DIDs z6MkScan…/z6MkAdmin…, localhost targets).

- is_public_http_url(): reject non-http(s), loopback, unspecified, private (RFC1918 + ULA), link-local, and localhost/.local/.internal hosts. Applied at announce time.
- db.prune_non_public_peers(): boot-time sweep removing already-injected rows, run from main() alongside prune_self_peers — self-heals poisoned tables on deploy.
- tests for the validator (accept public, reject loopback/private/internal, incl. IPv6 [::1]).

Closes #85 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced peer announcement validation to accept only publicly reachable HTTP/HTTPS endpoints, rejecting loopback, private, and internal network targets.
  * Added automatic cleanup at startup to remove any stored peer entries that no longer meet the public-endpoint requirements.

* **Bug Fixes / Security**
  * Peer network requests now disable HTTP redirects to prevent redirect-based bypasses of endpoint safety checks.

* **Tests**
  * Added unit tests for valid public URLs and for rejecting malformed, private, loopback, and non-HTTP inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->