### PR TITLE
feat(node): enforce per-route authorization across the REST and GraphQL surface

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -54,6 +54,23 @@ jobs:
         toolchain: [stable, beta]
     # Beta is informational: an upstream beta regression should warn, not block merges.
     continue-on-error: ${{ matrix.toolchain == 'beta' }}
+    # Postgres for the DB-backed integration tests (#[sqlx::test] provisions an
+    # isolated database per test off this connection). The health-check gate keeps
+    # `cargo test` from racing a not-yet-ready server.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: gitlawb_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -71,6 +88,8 @@ jobs:
           key: ${{ matrix.toolchain }}
 
       - name: cargo test
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/gitlawb_test
         run: cargo test --workspace
 
   build-release:

--- a/crates/gitlawb-node/Cargo.toml
+++ b/crates/gitlawb-node/Cargo.toml
@@ -28,7 +28,7 @@ async-graphql-axum = "7"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace", "request-id", "limit"] }
-sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid"] }
+sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid", "macros", "migrate"] }
 clap = { version = "4", features = ["derive", "env"] }
 bytes = "1"
 cid = { workspace = true }

--- a/crates/gitlawb-node/src/api/bounties.rs
+++ b/crates/gitlawb-node/src/api/bounties.rs
@@ -215,7 +215,7 @@ pub async fn submit_bounty(
         .as_deref()
         .is_some_and(|c| crate::api::did_matches(&auth.0, c));
     if !is_claimant {
-        return Err(AppError::BadRequest("only the claimant can submit".into()));
+        return Err(AppError::Forbidden("only the claimant can submit".into()));
     }
 
     let now = Utc::now().to_rfc3339();
@@ -251,7 +251,7 @@ pub async fn approve_bounty(
         )));
     }
     if !crate::api::did_matches(&auth.0, &bounty.creator_did) {
-        return Err(AppError::BadRequest(
+        return Err(AppError::Forbidden(
             "only the bounty creator can approve".into(),
         ));
     }
@@ -298,7 +298,7 @@ pub async fn cancel_bounty(
         )));
     }
     if !crate::api::did_matches(&auth.0, &bounty.creator_did) {
-        return Err(AppError::BadRequest(
+        return Err(AppError::Forbidden(
             "only the bounty creator can cancel".into(),
         ));
     }

--- a/crates/gitlawb-node/src/api/bounties.rs
+++ b/crates/gitlawb-node/src/api/bounties.rs
@@ -79,12 +79,9 @@ pub async fn create_bounty(
         return Err(AppError::BadRequest("amount must be positive".into()));
     }
 
-    // Verify repo exists
-    let _ = state
-        .db
-        .get_repo(&owner, &repo)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{repo}")))?;
+    // Read-gate: anyone who can read the repo may fund a bounty on it (this closes
+    // the private-repo bounty leak); ownership is not required.
+    crate::api::authorize_repo_read(&state, &owner, &repo, Some(auth.0.as_str()), "/").await?;
 
     let now = Utc::now().to_rfc3339();
     let bounty = BountyRecord {
@@ -213,7 +210,11 @@ pub async fn submit_bounty(
             bounty.status
         )));
     }
-    if bounty.claimant_did.as_deref() != Some(&auth.0) {
+    let is_claimant = bounty
+        .claimant_did
+        .as_deref()
+        .is_some_and(|c| crate::api::did_matches(&auth.0, c));
+    if !is_claimant {
         return Err(AppError::BadRequest("only the claimant can submit".into()));
     }
 
@@ -249,7 +250,7 @@ pub async fn approve_bounty(
             bounty.status
         )));
     }
-    if bounty.creator_did != auth.0 {
+    if !crate::api::did_matches(&auth.0, &bounty.creator_did) {
         return Err(AppError::BadRequest(
             "only the bounty creator can approve".into(),
         ));
@@ -296,7 +297,7 @@ pub async fn cancel_bounty(
             bounty.status
         )));
     }
-    if bounty.creator_did != auth.0 {
+    if !crate::api::did_matches(&auth.0, &bounty.creator_did) {
         return Err(AppError::BadRequest(
             "only the bounty creator can cancel".into(),
         ));
@@ -330,6 +331,19 @@ pub async fn dispute_bounty(
             "can only dispute claimed/submitted bounties, status is {}",
             bounty.status
         )));
+    }
+
+    // Only the bounty creator or the current claimant may dispute (N19 — this
+    // endpoint had no identity check at all).
+    let is_creator = crate::api::did_matches(&auth.0, &bounty.creator_did);
+    let is_claimant = bounty
+        .claimant_did
+        .as_deref()
+        .is_some_and(|c| crate::api::did_matches(&auth.0, c));
+    if !is_creator && !is_claimant {
+        return Err(AppError::Forbidden(
+            "only the bounty creator or claimant can dispute this bounty".into(),
+        ));
     }
 
     // Check if deadline exceeded

--- a/crates/gitlawb-node/src/api/issues.rs
+++ b/crates/gitlawb-node/src/api/issues.rs
@@ -39,11 +39,11 @@ pub async fn create_issue(
     Path((owner, repo)): Path<(String, String)>,
     Json(req): Json<CreateIssueRequest>,
 ) -> Result<(StatusCode, Json<IssueRecord>)> {
-    let record = state
-        .db
-        .get_repo(&owner, &repo)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{repo}")))?;
+    // Authorize the caller as a reader before accepting an issue: a non-reader
+    // must not be able to file an issue against a private repo they cannot read.
+    // Mirrors create_issue_comment / create_review / create_bounty.
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &repo, Some(auth.0.as_str()), "/").await?;
 
     let issue_id = Uuid::new_v4().to_string();
     let now = Utc::now().to_rfc3339();

--- a/crates/gitlawb-node/src/api/issues.rs
+++ b/crates/gitlawb-node/src/api/issues.rs
@@ -161,11 +161,9 @@ pub async fn create_issue_comment(
         ));
     }
 
-    let record = state
-        .db
-        .get_repo(&owner, &repo)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{repo}")))?;
+    // Read-gate: a commenter must be able to read the repo, but need not own it.
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &repo, Some(auth.0.as_str()), "/").await?;
 
     let disk_path = state
         .repo_store
@@ -207,7 +205,7 @@ pub async fn list_issue_comments(
 /// POST /api/v1/repos/{owner}/{repo}/issues/{id}/close
 pub async fn close_issue(
     State(state): State<AppState>,
-    Extension(_auth): Extension<AuthenticatedDid>,
+    Extension(auth): Extension<AuthenticatedDid>,
     Path((owner, repo, issue_id)): Path<(String, String, String)>,
 ) -> Result<Json<serde_json::Value>> {
     let record = state
@@ -222,6 +220,33 @@ pub async fn close_issue(
         .await
         .map_err(|e| AppError::Git(e.to_string()))?;
     let disk_path = guard.path().to_path_buf();
+
+    // Owner OR issue author may close. The author lives in the issue's git-JSON
+    // blob (not a DB column); a None author (legacy issues) falls back to
+    // owner-only. Read it under the write guard, before mutating.
+    let author_did: Option<String> = match git_issues::get_issue(&disk_path, &issue_id) {
+        Ok(Some(raw)) => serde_json::from_str::<IssueRecord>(&raw)
+            .ok()
+            .and_then(|i| i.author),
+        Ok(None) => {
+            guard.release(false).await;
+            return Err(AppError::NotFound(format!("issue {issue_id} not found")));
+        }
+        Err(e) => {
+            guard.release(false).await;
+            return Err(AppError::Git(e.to_string()));
+        }
+    };
+    let is_owner = crate::api::require_repo_owner(&record, &auth.0).is_ok();
+    let is_author = author_did
+        .as_deref()
+        .is_some_and(|a| crate::api::did_matches(&auth.0, a));
+    if !is_owner && !is_author {
+        guard.release(false).await;
+        return Err(AppError::Forbidden(
+            "only the repo owner or the issue author can close this issue".into(),
+        ));
+    }
 
     let close_result = git_issues::close_issue(&disk_path, &issue_id);
 

--- a/crates/gitlawb-node/src/api/labels.rs
+++ b/crates/gitlawb-node/src/api/labels.rs
@@ -17,7 +17,7 @@ pub struct LabelRequest {
 /// POST /api/v1/repos/:owner/:repo/labels
 pub async fn add_label(
     State(state): State<AppState>,
-    Extension(_auth): Extension<AuthenticatedDid>,
+    Extension(auth): Extension<AuthenticatedDid>,
     Path((owner, name)): Path<(String, String)>,
     Json(req): Json<LabelRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>)> {
@@ -39,6 +39,7 @@ pub async fn add_label(
         .get_repo(&owner, &name)
         .await?
         .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    crate::api::require_repo_owner(&record, &auth.0)?;
 
     let added = state.db.add_label(&record.id, &label).await?;
     let status = if added {
@@ -55,7 +56,7 @@ pub async fn add_label(
 /// DELETE /api/v1/repos/:owner/:repo/labels/:label
 pub async fn remove_label(
     State(state): State<AppState>,
-    Extension(_auth): Extension<AuthenticatedDid>,
+    Extension(auth): Extension<AuthenticatedDid>,
     Path((owner, name, label)): Path<(String, String, String)>,
 ) -> Result<Json<serde_json::Value>> {
     let record = state
@@ -63,6 +64,7 @@ pub async fn remove_label(
         .get_repo(&owner, &name)
         .await?
         .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    crate::api::require_repo_owner(&record, &auth.0)?;
 
     state.db.remove_label(&record.id, &label).await?;
     Ok(Json(serde_json::json!({ "label": label, "removed": true })))

--- a/crates/gitlawb-node/src/api/mod.rs
+++ b/crates/gitlawb-node/src/api/mod.rs
@@ -54,3 +54,139 @@ pub(crate) async fn authorize_repo_read(
     }
     Ok((record, rules))
 }
+
+/// Match a presented DID against a stored DID that may be the full `did:key:<id>`
+/// form or the bare `<id>` short form (mirror rows store the bare key). Collapse
+/// representation only within `did:key`; never let a bare id match across methods —
+/// `did:web` / `did:gitlawb` share the base58 space with `did:key`, so a
+/// trailing-segment compare would treat `did:key:X` and `did:gitlawb:X` as equal.
+pub(crate) fn did_matches(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    fn key_id(d: &str) -> &str {
+        d.strip_prefix("did:key:").unwrap_or(d)
+    }
+    let (ka, kb) = (key_id(a), key_id(b));
+    // After stripping `did:key:`, a value still containing ':' is a non-key full
+    // DID — do not let it match a bare `did:key` id.
+    !ka.contains(':') && !kb.contains(':') && ka == kb
+}
+
+/// 403 unless `caller` is the repo owner. Uses [`did_matches`] so the owner check
+/// and the author check (close policy) share one normalization.
+pub(crate) fn require_repo_owner(record: &RepoRecord, caller: &str) -> Result<()> {
+    if did_matches(caller, &record.owner_did) {
+        Ok(())
+    } else {
+        Err(AppError::Forbidden(
+            "only the repo owner can perform this action".into(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod did_tests {
+    use super::did_matches;
+
+    #[test]
+    fn full_matches_bare_same_key() {
+        assert!(did_matches("did:key:zABC", "zABC"));
+        assert!(did_matches("zABC", "did:key:zABC"));
+    }
+
+    #[test]
+    fn rejects_cross_method_collision() {
+        assert!(!did_matches("did:key:zABC", "did:gitlawb:zABC"));
+        assert!(!did_matches("did:key:zABC", "did:web:zABC"));
+    }
+
+    #[test]
+    fn exact_match_and_distinct_keys() {
+        assert!(did_matches("did:key:zABC", "did:key:zABC"));
+        assert!(!did_matches("did:key:zABC", "did:key:zXYZ"));
+        assert!(!did_matches("zABC", "zXYZ"));
+    }
+}
+
+/// Drift guard (plan 002 §Gate-type table, Step 5). Every in-scope mutation
+/// handler must contain its expected gate marker in its own body; removing a
+/// gate fails this test. Source-level (no DB), so it runs everywhere. When a new
+/// route is added to an in-scope group, add its row here with a deliberate gate
+/// type — that forced decision is the point.
+#[cfg(test)]
+mod authz_guard {
+    fn fn_body<'a>(src: &'a str, func: &'a str) -> &'a str {
+        let needle = format!("fn {func}(");
+        let start = src
+            .find(&needle)
+            .unwrap_or_else(|| panic!("handler `{func}` not found (renamed or removed?)"));
+        let rest = &src[start..];
+        // End at the next top-level handler so a marker in a later fn can't leak in.
+        let end = rest[1..]
+            .find("\npub async fn ")
+            .map(|i| i + 1)
+            .unwrap_or(rest.len());
+        &rest[..end]
+    }
+
+    #[test]
+    fn every_in_scope_mutation_has_its_gate() {
+        let pulls = include_str!("pulls.rs");
+        let webhooks = include_str!("webhooks.rs");
+        let labels = include_str!("labels.rs");
+        let issues = include_str!("issues.rs");
+        let bounties = include_str!("bounties.rs");
+        let replicas = include_str!("replicas.rs");
+        let tasks = include_str!("tasks.rs");
+        let stars = include_str!("stars.rs");
+        let protect = include_str!("protect.rs");
+        let visibility = include_str!("visibility.rs");
+
+        // (source, handler, expected gate marker)
+        let rows: &[(&str, &str, &str)] = &[
+            // Bucket A — owner-gate
+            (pulls, "merge_pr", "require_repo_owner"),
+            (webhooks, "create_webhook", "require_repo_owner"),
+            (webhooks, "delete_webhook", "require_repo_owner"),
+            (labels, "add_label", "require_repo_owner"),
+            (labels, "remove_label", "require_repo_owner"),
+            // Bucket A' — owner OR author
+            (pulls, "close_pr", "did_matches"),
+            (issues, "close_issue", "did_matches"),
+            // Bucket B — read-gate
+            (pulls, "create_review", "authorize_repo_read"),
+            (pulls, "create_comment", "authorize_repo_read"),
+            (issues, "create_issue_comment", "authorize_repo_read"),
+            (bounties, "create_bounty", "authorize_repo_read"),
+            // Bucket C — signer-self (acting DID bound to auth.0)
+            (tasks, "create_task", "auth.0"),
+            (tasks, "claim_task", "auth.0"),
+            (tasks, "complete_task", "auth.0"),
+            (tasks, "fail_task", "auth.0"),
+            // Bucket D — non-owner-by-design, positive per-route marker
+            (bounties, "submit_bounty", "did_matches"),
+            (bounties, "approve_bounty", "did_matches"),
+            (bounties, "cancel_bounty", "did_matches"),
+            (bounties, "dispute_bounty", "did_matches"),
+            (replicas, "register_replica", "did_matches"),
+            (replicas, "unregister_replica", "auth.0"),
+            (stars, "star_repo", "auth.0"),
+            (stars, "unstar_repo", "auth.0"),
+            // PRE-GATED — already owner-gated, in-scope group; guarded against regression
+            (protect, "protect_branch", "owner_did"),
+            (protect, "unprotect_branch", "owner_did"),
+            (visibility, "set_visibility", "require_owner"),
+            (visibility, "remove_visibility", "require_owner"),
+            (visibility, "list_visibility", "require_owner"),
+        ];
+
+        for (src, func, marker) in rows {
+            let body = fn_body(src, func);
+            assert!(
+                body.contains(marker),
+                "handler `{func}` is missing its gate marker `{marker}` — gate removed or route reclassified"
+            );
+        }
+    }
+}

--- a/crates/gitlawb-node/src/api/mod.rs
+++ b/crates/gitlawb-node/src/api/mod.rs
@@ -114,20 +114,41 @@ mod did_tests {
 /// gate fails this test. Source-level (no DB), so it runs everywhere. When a new
 /// route is added to an in-scope group, add its row here with a deliberate gate
 /// type — that forced decision is the point.
+///
+/// Markers are gate-SHAPED — a call (`require_repo_owner(`, `did_matches(`) or a
+/// binding/comparison expression (`caller != &record.owner_did`,
+/// `let owner_did = auth.0`) — never a bare identifier that could also appear in
+/// a log line. Full-line comments are stripped before matching, so a marker that
+/// survives only as a comment above a deleted gate does NOT satisfy a row.
 #[cfg(test)]
 mod authz_guard {
-    fn fn_body<'a>(src: &'a str, func: &'a str) -> &'a str {
+    /// The body of `func` with full-line comments removed. Bounds the slice at the
+    /// next top-level fn item so a marker in a later handler can't leak in,
+    /// tolerating `pub async`, `pub(crate) async`, `async`, `pub`, and bare `fn`
+    /// declarations (the old single-`pub async fn` delimiter over-ran on any other
+    /// form).
+    fn fn_body(src: &str, func: &str) -> String {
         let needle = format!("fn {func}(");
         let start = src
             .find(&needle)
             .unwrap_or_else(|| panic!("handler `{func}` not found (renamed or removed?)"));
         let rest = &src[start..];
-        // End at the next top-level handler so a marker in a later fn can't leak in.
-        let end = rest[1..]
-            .find("\npub async fn ")
-            .map(|i| i + 1)
-            .unwrap_or(rest.len());
-        &rest[..end]
+        let end = [
+            "\npub async fn ",
+            "\npub(crate) async fn ",
+            "\nasync fn ",
+            "\npub fn ",
+            "\nfn ",
+        ]
+        .iter()
+        .filter_map(|p| rest[1..].find(p).map(|i| i + 1))
+        .min()
+        .unwrap_or(rest.len());
+        rest[..end]
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     #[test]
@@ -142,43 +163,54 @@ mod authz_guard {
         let stars = include_str!("stars.rs");
         let protect = include_str!("protect.rs");
         let visibility = include_str!("visibility.rs");
+        let profiles = include_str!("profiles.rs");
+        let repos = include_str!("repos.rs");
 
         // (source, handler, expected gate marker)
         let rows: &[(&str, &str, &str)] = &[
-            // Bucket A — owner-gate
-            (pulls, "merge_pr", "require_repo_owner"),
-            (webhooks, "create_webhook", "require_repo_owner"),
-            (webhooks, "delete_webhook", "require_repo_owner"),
-            (labels, "add_label", "require_repo_owner"),
-            (labels, "remove_label", "require_repo_owner"),
-            // Bucket A' — owner OR author
-            (pulls, "close_pr", "did_matches"),
-            (issues, "close_issue", "did_matches"),
-            // Bucket B — read-gate
-            (pulls, "create_review", "authorize_repo_read"),
-            (pulls, "create_comment", "authorize_repo_read"),
-            (issues, "create_issue_comment", "authorize_repo_read"),
-            (bounties, "create_bounty", "authorize_repo_read"),
-            // Bucket C — signer-self (acting DID bound to auth.0)
-            (tasks, "create_task", "auth.0"),
-            (tasks, "claim_task", "auth.0"),
-            (tasks, "complete_task", "auth.0"),
-            (tasks, "fail_task", "auth.0"),
+            // Bucket A — owner-gate (require_repo_owner -> 403)
+            (pulls, "merge_pr", "require_repo_owner("),
+            (webhooks, "create_webhook", "require_repo_owner("),
+            (webhooks, "delete_webhook", "require_repo_owner("),
+            (labels, "add_label", "require_repo_owner("),
+            (labels, "remove_label", "require_repo_owner("),
+            // Bucket A' — owner OR author (did_matches against the author)
+            (pulls, "close_pr", "did_matches("),
+            (issues, "close_issue", "did_matches("),
+            // Bucket B — read-gate (authorize_repo_read)
+            (pulls, "create_review", "authorize_repo_read("),
+            (pulls, "create_comment", "authorize_repo_read("),
+            (pulls, "create_pr", "authorize_repo_read("),
+            (issues, "create_issue_comment", "authorize_repo_read("),
+            (issues, "create_issue", "authorize_repo_read("),
+            (bounties, "create_bounty", "authorize_repo_read("),
+            (repos, "fork_repo", "authorize_repo_read("),
+            // Bucket C — signer-self: the acting DID is matched/bound to auth.0
+            (tasks, "create_task", "did_matches("),
+            (tasks, "claim_task", "did_matches("),
+            (tasks, "complete_task", "did_matches("),
+            (tasks, "fail_task", "did_matches("),
+            (repos, "create_repo", "let owner_did = auth.0"),
+            (profiles, "set_profile", "let did = auth.0"),
+            (stars, "star_repo", "caller = &auth.0"),
+            (stars, "unstar_repo", "caller = &auth.0"),
             // Bucket D — non-owner-by-design, positive per-route marker
-            (bounties, "submit_bounty", "did_matches"),
-            (bounties, "approve_bounty", "did_matches"),
-            (bounties, "cancel_bounty", "did_matches"),
-            (bounties, "dispute_bounty", "did_matches"),
-            (replicas, "register_replica", "did_matches"),
-            (replicas, "unregister_replica", "auth.0"),
-            (stars, "star_repo", "auth.0"),
-            (stars, "unstar_repo", "auth.0"),
-            // PRE-GATED — already owner-gated, in-scope group; guarded against regression
-            (protect, "protect_branch", "owner_did"),
-            (protect, "unprotect_branch", "owner_did"),
-            (visibility, "set_visibility", "require_owner"),
-            (visibility, "remove_visibility", "require_owner"),
-            (visibility, "list_visibility", "require_owner"),
+            (bounties, "claim_bounty", "claim_bounty(&id, &auth.0"),
+            (bounties, "submit_bounty", "did_matches("),
+            (bounties, "approve_bounty", "did_matches("),
+            (bounties, "cancel_bounty", "did_matches("),
+            (bounties, "dispute_bounty", "did_matches("),
+            (replicas, "register_replica", "did_matches("),
+            (replicas, "unregister_replica", "replica_did = &auth.0"),
+            // PRE-GATED — already owner-gated, in-scope group; guard the gate itself
+            (protect, "protect_branch", "caller != &record.owner_did"),
+            (protect, "unprotect_branch", "caller != &record.owner_did"),
+            (visibility, "set_visibility", "require_owner("),
+            (visibility, "remove_visibility", "require_owner("),
+            (visibility, "list_visibility", "require_owner("),
+            // NOT GATED, tracked separately: register (register.rs) trusts the body
+            // `did` instead of binding to the signer (audit D3-1, P3). Excluded
+            // until fixed — adding a row would assert a gate that does not exist.
         ];
 
         for (src, func, marker) in rows {
@@ -188,5 +220,17 @@ mod authz_guard {
                 "handler `{func}` is missing its gate marker `{marker}` — gate removed or route reclassified"
             );
         }
+    }
+
+    /// Proves the comment-stripping that GUARD-1 added: a marker that appears only
+    /// in a full-line comment (the real `replicas.rs` false-pass shape) must NOT
+    /// satisfy a row.
+    #[test]
+    fn comment_only_marker_does_not_satisfy_a_row() {
+        let src = "pub async fn demo() {\n    // did_matches( handles the owner form\n    do_thing();\n}\n";
+        assert!(
+            !fn_body(src, "demo").contains("did_matches("),
+            "a marker present only in a comment must not count as an enforced gate"
+        );
     }
 }

--- a/crates/gitlawb-node/src/api/mod.rs
+++ b/crates/gitlawb-node/src/api/mod.rs
@@ -205,12 +205,19 @@ mod authz_guard {
             (replicas, "register_replica", "did_matches("),
             (replicas, "unregister_replica", "replica_did = &auth.0"),
             // PRE-GATED — already owner-gated, in-scope group; guard the gate itself
-            (protect, "protect_branch", "caller != &record.owner_did"),
-            (protect, "unprotect_branch", "caller != &record.owner_did"),
+            (protect, "protect_branch", "did_matches("),
+            (protect, "unprotect_branch", "did_matches("),
             (visibility, "set_visibility", "require_owner("),
             (visibility, "remove_visibility", "require_owner("),
             (visibility, "list_visibility", "require_owner("),
         ];
+
+        // The visibility rows prove require_owner is CALLED; this proves the helper
+        // itself does DID-safe matching, not a raw/trailing-segment compare.
+        assert!(
+            fn_body(visibility, "require_owner").contains("did_matches("),
+            "visibility::require_owner must use did_matches for DID-safe owner matching"
+        );
 
         for (src, func, marker) in rows {
             let body = fn_body(src, func);

--- a/crates/gitlawb-node/src/api/mod.rs
+++ b/crates/gitlawb-node/src/api/mod.rs
@@ -165,6 +165,7 @@ mod authz_guard {
         let visibility = include_str!("visibility.rs");
         let profiles = include_str!("profiles.rs");
         let repos = include_str!("repos.rs");
+        let register = include_str!("register.rs");
 
         // (source, handler, expected gate marker)
         let rows: &[(&str, &str, &str)] = &[
@@ -192,6 +193,7 @@ mod authz_guard {
             (tasks, "fail_task", "did_matches("),
             (repos, "create_repo", "let owner_did = auth.0"),
             (profiles, "set_profile", "let did = auth.0"),
+            (register, "register", "did_matches("),
             (stars, "star_repo", "caller = &auth.0"),
             (stars, "unstar_repo", "caller = &auth.0"),
             // Bucket D — non-owner-by-design, positive per-route marker
@@ -208,9 +210,6 @@ mod authz_guard {
             (visibility, "set_visibility", "require_owner("),
             (visibility, "remove_visibility", "require_owner("),
             (visibility, "list_visibility", "require_owner("),
-            // NOT GATED, tracked separately: register (register.rs) trusts the body
-            // `did` instead of binding to the signer (audit D3-1, P3). Excluded
-            // until fixed — adding a row would assert a gate that does not exist.
         ];
 
         for (src, func, marker) in rows {

--- a/crates/gitlawb-node/src/api/protect.rs
+++ b/crates/gitlawb-node/src/api/protect.rs
@@ -31,7 +31,7 @@ pub async fn protect_branch(
         .next_back()
         .unwrap_or(&record.owner_did);
     if caller != &record.owner_did && caller != owner_short {
-        return Err(AppError::BadRequest(
+        return Err(AppError::Forbidden(
             "only the repo owner can protect branches".into(),
         ));
     }
@@ -69,7 +69,7 @@ pub async fn unprotect_branch(
         .next_back()
         .unwrap_or(&record.owner_did);
     if caller != &record.owner_did && caller != owner_short {
-        return Err(AppError::BadRequest(
+        return Err(AppError::Forbidden(
             "only the repo owner can unprotect branches".into(),
         ));
     }

--- a/crates/gitlawb-node/src/api/protect.rs
+++ b/crates/gitlawb-node/src/api/protect.rs
@@ -23,14 +23,9 @@ pub async fn protect_branch(
         .await?
         .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{repo}")))?;
 
-    // Only the repo owner can protect branches
+    // Only the repo owner can protect branches (DID-safe match, shared idiom).
     let caller = &auth.0;
-    let owner_short = record
-        .owner_did
-        .split(':')
-        .next_back()
-        .unwrap_or(&record.owner_did);
-    if caller != &record.owner_did && caller != owner_short {
+    if !crate::api::did_matches(caller, &record.owner_did) {
         return Err(AppError::Forbidden(
             "only the repo owner can protect branches".into(),
         ));
@@ -63,12 +58,7 @@ pub async fn unprotect_branch(
         .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{repo}")))?;
 
     let caller = &auth.0;
-    let owner_short = record
-        .owner_did
-        .split(':')
-        .next_back()
-        .unwrap_or(&record.owner_did);
-    if caller != &record.owner_did && caller != owner_short {
+    if !crate::api::did_matches(caller, &record.owner_did) {
         return Err(AppError::Forbidden(
             "only the repo owner can unprotect branches".into(),
         ));

--- a/crates/gitlawb-node/src/api/pulls.rs
+++ b/crates/gitlawb-node/src/api/pulls.rs
@@ -194,6 +194,11 @@ pub async fn merge_pr(
         .await?
         .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
 
+    // Owner-only merge (N7). Merging writes the served tree, so this is the same
+    // trust boundary as owner-only push; it subsumes branch protection (a
+    // non-owner cannot merge to any branch, protected or not).
+    crate::api::require_repo_owner(&record, &auth.0)?;
+
     let pr = state
         .db
         .get_pr(&record.id, number)
@@ -252,6 +257,7 @@ pub async fn merge_pr(
 /// POST /api/v1/repos/:owner/:repo/pulls/:number/close
 pub async fn close_pr(
     State(state): State<AppState>,
+    Extension(auth): Extension<AuthenticatedDid>,
     Path((owner, name, number)): Path<(String, String, i64)>,
 ) -> Result<Json<serde_json::Value>> {
     let record = state
@@ -265,6 +271,15 @@ pub async fn close_pr(
         .get_pr(&record.id, number)
         .await?
         .ok_or_else(|| AppError::NotFound(format!("PR #{number} not found")))?;
+
+    // Owner OR author may close (forge norm).
+    let is_owner = crate::api::require_repo_owner(&record, &auth.0).is_ok();
+    let is_author = crate::api::did_matches(&auth.0, &pr.author_did);
+    if !is_owner && !is_author {
+        return Err(AppError::Forbidden(
+            "only the repo owner or the PR author can close this PR".into(),
+        ));
+    }
 
     state.db.close_pr(&pr.id).await?;
 
@@ -290,11 +305,9 @@ pub async fn create_review(
     Path((owner, name, number)): Path<(String, String, i64)>,
     Json(req): Json<CreateReviewRequest>,
 ) -> Result<(StatusCode, Json<PrReview>)> {
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    // Read-gate: a reviewer must be able to read the repo, but need not own it.
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, Some(auth.0.as_str()), "/").await?;
 
     let pr = state
         .db
@@ -369,11 +382,9 @@ pub async fn create_comment(
         ));
     }
 
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    // Read-gate: a commenter must be able to read the repo, but need not own it.
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, Some(auth.0.as_str()), "/").await?;
 
     let pr = state
         .db

--- a/crates/gitlawb-node/src/api/pulls.rs
+++ b/crates/gitlawb-node/src/api/pulls.rs
@@ -40,11 +40,11 @@ pub async fn create_pr(
     Path((owner, name)): Path<(String, String)>,
     Json(req): Json<CreatePrRequest>,
 ) -> Result<(StatusCode, Json<PullRequest>)> {
-    let record = state
-        .db
-        .get_repo(&owner, &name)
-        .await?
-        .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    // Authorize the caller as a reader before accepting a PR: a non-reader must
+    // not be able to open a PR (and fire its webhooks) against a private repo
+    // they cannot read. Mirrors create_review / create_comment / create_bounty.
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &name, Some(auth.0.as_str()), "/").await?;
 
     let author_did = auth.0;
     let target_branch = req

--- a/crates/gitlawb-node/src/api/register.rs
+++ b/crates/gitlawb-node/src/api/register.rs
@@ -35,6 +35,7 @@ pub struct RegisterResponse {
 /// Accepts only requests with a valid HTTP Signature (enforced by middleware).
 pub async fn register(
     State(state): State<AppState>,
+    axum::Extension(auth): axum::Extension<crate::auth::AuthenticatedDid>,
     Json(req): Json<RegisterRequest>,
 ) -> Result<(StatusCode, Json<RegisterResponse>)> {
     // Parse and validate the DID
@@ -42,6 +43,14 @@ pub async fn register(
         .did
         .parse()
         .map_err(|e: gitlawb_core::Error| AppError::BadRequest(e.to_string()))?;
+
+    // Bind registration to the authenticated signer: an agent may only register
+    // itself, not create or refresh a trust row for a DID it does not control.
+    if !crate::api::did_matches(&auth.0, agent_did.as_str()) {
+        return Err(AppError::Forbidden(
+            "did must be the authenticated signer".into(),
+        ));
+    }
 
     // Store the agent in the local index
     state

--- a/crates/gitlawb-node/src/api/replicas.rs
+++ b/crates/gitlawb-node/src/api/replicas.rs
@@ -47,8 +47,9 @@ pub async fn register_replica(
 
     let replica_did = &auth.0;
 
-    // Don't let an owner register themselves as a replica of their own repo.
-    if replica_did == &record.owner_did {
+    // Don't let an owner register themselves as a replica of their own repo
+    // (did_matches handles the full vs bare did:key owner form).
+    if crate::api::did_matches(replica_did, &record.owner_did) {
         return Err(AppError::BadRequest(
             "the repo owner is not a replica of their own repo".into(),
         ));

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -306,9 +306,15 @@ pub async fn get_tree(
 ) -> Result<Json<serde_json::Value>> {
     let caller = auth.as_ref().map(|e| e.0 .0.as_str());
     // Gate on the REQUESTED subtree, not the repo root (N3) — otherwise a caller
-    // denied a withheld subtree can still enumerate its names/SHAs. Mirrors get_blob.
+    // denied a withheld subtree can still enumerate its names/SHAs. Reject
+    // traversal and empty interior segments as get_blob does, so the gate path and
+    // the path git resolves cannot diverge; an empty path here is the root listing.
     let normalized = tree_path.trim_matches('/');
-    if normalized.split('/').any(|seg| seg == "." || seg == "..") {
+    if !normalized.is_empty()
+        && normalized
+            .split('/')
+            .any(|seg| seg.is_empty() || seg == "." || seg == "..")
+    {
         return Err(AppError::BadRequest("invalid tree path".into()));
     }
     let gate_path = if normalized.is_empty() {

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -305,8 +305,19 @@ pub async fn get_tree(
     auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<serde_json::Value>> {
     let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    // Gate on the REQUESTED subtree, not the repo root (N3) — otherwise a caller
+    // denied a withheld subtree can still enumerate its names/SHAs. Mirrors get_blob.
+    let normalized = tree_path.trim_matches('/');
+    if normalized.split('/').any(|seg| seg == "." || seg == "..") {
+        return Err(AppError::BadRequest("invalid tree path".into()));
+    }
+    let gate_path = if normalized.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{normalized}")
+    };
     let (record, _rules) =
-        crate::api::authorize_repo_read(&state, &owner, &name, caller, "/").await?;
+        crate::api::authorize_repo_read(&state, &owner, &name, caller, &gate_path).await?;
 
     let disk_path = state
         .repo_store

--- a/crates/gitlawb-node/src/api/tasks.rs
+++ b/crates/gitlawb-node/src/api/tasks.rs
@@ -64,13 +64,11 @@ pub struct ClaimTaskBody {
 #[derive(Deserialize)]
 pub struct CompleteTaskBody {
     pub result: Option<String>,
-    pub by_did: Option<String>,
 }
 
 #[derive(Deserialize)]
 pub struct FailTaskBody {
     pub reason: Option<String>,
-    pub by_did: Option<String>,
 }
 
 fn task_to_json(t: &AgentTask) -> Value {
@@ -199,12 +197,31 @@ pub async fn complete_task(
     Path(id): Path<String>,
     Json(body): Json<CompleteTaskBody>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    // Bind the actor to the authenticated signer (N13); ignore any body by_did
-    // that doesn't match.
-    if let Some(by) = &body.by_did {
-        if !crate::api::did_matches(&auth.0, by) {
-            return Err(forbidden("by_did must be the authenticated signer"));
-        }
+    // Authorize the actor, not just bind their identity: the N13 signer-binding
+    // proved the caller was whoever they claimed, but never that they were the
+    // task's assignee. Load the task and require the caller to be its assignee;
+    // finish_task then transitions only a claimed task.
+    let existing = state
+        .db
+        .get_task(&id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "task not found" })),
+            )
+        })?;
+    if !crate::api::did_matches(
+        &auth.0,
+        existing.assignee_did.as_deref().unwrap_or_default(),
+    ) {
+        return Err(forbidden("only the task assignee can complete it"));
     }
     let by_did = auth.0;
     let task = state
@@ -213,7 +230,7 @@ pub async fn complete_task(
         .await
         .map_err(|e| {
             (
-                StatusCode::UNPROCESSABLE_ENTITY,
+                StatusCode::CONFLICT,
                 Json(json!({ "error": e.to_string() })),
             )
         })?;
@@ -234,11 +251,30 @@ pub async fn fail_task(
     Path(id): Path<String>,
     Json(body): Json<FailTaskBody>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    // Bind the actor to the authenticated signer (N13).
-    if let Some(by) = &body.by_did {
-        if !crate::api::did_matches(&auth.0, by) {
-            return Err(forbidden("by_did must be the authenticated signer"));
-        }
+    // Authorize the actor, not just bind their identity (see complete_task): only
+    // the task's assignee may fail it, and finish_task transitions only a claimed
+    // task.
+    let existing = state
+        .db
+        .get_task(&id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(json!({ "error": "task not found" })),
+            )
+        })?;
+    if !crate::api::did_matches(
+        &auth.0,
+        existing.assignee_did.as_deref().unwrap_or_default(),
+    ) {
+        return Err(forbidden("only the task assignee can fail it"));
     }
     let by_did = auth.0;
     let reason = body.reason.unwrap_or_default();
@@ -248,7 +284,7 @@ pub async fn fail_task(
         .await
         .map_err(|e| {
             (
-                StatusCode::UNPROCESSABLE_ENTITY,
+                StatusCode::CONFLICT,
                 Json(json!({ "error": e.to_string() })),
             )
         })?;

--- a/crates/gitlawb-node/src/api/tasks.rs
+++ b/crates/gitlawb-node/src/api/tasks.rs
@@ -9,7 +9,7 @@
 //!   POST   /api/v1/tasks/{id}/fail          — fail task
 
 use axum::{
-    extract::{Path, Query, State},
+    extract::{Extension, Path, Query, State},
     http::StatusCode,
     Json,
 };
@@ -18,8 +18,17 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use crate::auth::AuthenticatedDid;
 use crate::db::AgentTask;
 use crate::state::{AppState, TaskEventBroadcast};
+
+/// 403 in this module's error shape (`(StatusCode, Json<Value>)`, not `AppError`).
+fn forbidden(msg: &str) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::FORBIDDEN,
+        Json(json!({ "error": "forbidden", "message": msg })),
+    )
+}
 
 // ── Request / response types ──────────────────────────────────────────────────
 
@@ -87,15 +96,20 @@ fn task_to_json(t: &AgentTask) -> Value {
 /// POST /api/v1/tasks
 pub async fn create_task(
     State(state): State<AppState>,
+    Extension(auth): Extension<AuthenticatedDid>,
     Json(body): Json<CreateTaskBody>,
 ) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Value>)> {
+    // Bind the delegator to the authenticated signer (N13).
+    if !crate::api::did_matches(&auth.0, &body.delegator_did) {
+        return Err(forbidden("delegator_did must be the authenticated signer"));
+    }
     let now = Utc::now().to_rfc3339();
     let task = AgentTask {
         id: Uuid::new_v4().to_string(),
         repo_id: body.repo_id,
         kind: body.kind,
         status: "pending".to_string(),
-        delegator_did: body.delegator_did,
+        delegator_did: auth.0,
         assignee_did: body.assignee_did,
         capability: body.capability,
         ucan_token: body.ucan_token,
@@ -154,24 +168,25 @@ pub async fn get_task(
 /// POST /api/v1/tasks/{id}/claim
 pub async fn claim_task(
     State(state): State<AppState>,
+    Extension(auth): Extension<AuthenticatedDid>,
     Path(id): Path<String>,
     Json(body): Json<ClaimTaskBody>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let task = state
-        .db
-        .claim_task(&id, &body.assignee_did)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::CONFLICT,
-                Json(json!({ "error": e.to_string() })),
-            )
-        })?;
+    // Bind the assignee to the authenticated signer (N13).
+    if !crate::api::did_matches(&auth.0, &body.assignee_did) {
+        return Err(forbidden("assignee_did must be the authenticated signer"));
+    }
+    let task = state.db.claim_task(&id, &auth.0).await.map_err(|e| {
+        (
+            StatusCode::CONFLICT,
+            Json(json!({ "error": e.to_string() })),
+        )
+    })?;
     let _ = state.task_event_tx.send(TaskEventBroadcast {
         task_id: id,
         old_status: "pending".to_string(),
         new_status: "claimed".to_string(),
-        by_did: body.assignee_did,
+        by_did: auth.0,
         at: Utc::now().to_rfc3339(),
     });
     Ok(Json(task_to_json(&task)))
@@ -180,10 +195,18 @@ pub async fn claim_task(
 /// POST /api/v1/tasks/{id}/complete
 pub async fn complete_task(
     State(state): State<AppState>,
+    Extension(auth): Extension<AuthenticatedDid>,
     Path(id): Path<String>,
     Json(body): Json<CompleteTaskBody>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let by_did = body.by_did.unwrap_or_default();
+    // Bind the actor to the authenticated signer (N13); ignore any body by_did
+    // that doesn't match.
+    if let Some(by) = &body.by_did {
+        if !crate::api::did_matches(&auth.0, by) {
+            return Err(forbidden("by_did must be the authenticated signer"));
+        }
+    }
+    let by_did = auth.0;
     let task = state
         .db
         .finish_task(&id, "completed", body.result.as_deref())
@@ -207,10 +230,17 @@ pub async fn complete_task(
 /// POST /api/v1/tasks/{id}/fail
 pub async fn fail_task(
     State(state): State<AppState>,
+    Extension(auth): Extension<AuthenticatedDid>,
     Path(id): Path<String>,
     Json(body): Json<FailTaskBody>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let by_did = body.by_did.unwrap_or_default();
+    // Bind the actor to the authenticated signer (N13).
+    if let Some(by) = &body.by_did {
+        if !crate::api::did_matches(&auth.0, by) {
+            return Err(forbidden("by_did must be the authenticated signer"));
+        }
+    }
+    let by_did = auth.0;
     let reason = body.reason.unwrap_or_default();
     let task = state
         .db

--- a/crates/gitlawb-node/src/api/visibility.rs
+++ b/crates/gitlawb-node/src/api/visibility.rs
@@ -32,7 +32,7 @@ fn require_owner(record: &crate::db::RepoRecord, caller: &str) -> Result<()> {
         .next_back()
         .unwrap_or(&record.owner_did);
     if caller != record.owner_did && caller != owner_short {
-        return Err(AppError::BadRequest(
+        return Err(AppError::Forbidden(
             "only the repo owner can manage visibility".into(),
         ));
     }

--- a/crates/gitlawb-node/src/api/visibility.rs
+++ b/crates/gitlawb-node/src/api/visibility.rs
@@ -26,17 +26,16 @@ pub struct RemoveVisibilityRequest {
 }
 
 fn require_owner(record: &crate::db::RepoRecord, caller: &str) -> Result<()> {
-    let owner_short = record
-        .owner_did
-        .split(':')
-        .next_back()
-        .unwrap_or(&record.owner_did);
-    if caller != record.owner_did && caller != owner_short {
-        return Err(AppError::Forbidden(
+    // DID-safe owner match (collapses did:key full vs bare on both sides, never
+    // across methods), shared with require_repo_owner — not a trailing-segment
+    // compare that only normalized the owner side.
+    if crate::api::did_matches(caller, &record.owner_did) {
+        Ok(())
+    } else {
+        Err(AppError::Forbidden(
             "only the repo owner can manage visibility".into(),
-        ));
+        ))
     }
-    Ok(())
 }
 
 /// Reject malformed globs before they reach the store, where they would

--- a/crates/gitlawb-node/src/api/webhooks.rs
+++ b/crates/gitlawb-node/src/api/webhooks.rs
@@ -38,6 +38,7 @@ pub async fn create_webhook(
         .get_repo(&owner, &name)
         .await?
         .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    crate::api::require_repo_owner(&record, &auth.0)?;
 
     // Validate URL is http/https
     if !req.url.starts_with("http://") && !req.url.starts_with("https://") {
@@ -95,6 +96,7 @@ pub async fn list_webhooks(
 /// DELETE /api/v1/repos/:owner/:repo/hooks/:id
 pub async fn delete_webhook(
     State(state): State<AppState>,
+    Extension(auth): Extension<AuthenticatedDid>,
     Path((owner, name, id)): Path<(String, String, String)>,
 ) -> Result<Json<serde_json::Value>> {
     let record = state
@@ -102,6 +104,7 @@ pub async fn delete_webhook(
         .get_repo(&owner, &name)
         .await?
         .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    crate::api::require_repo_owner(&record, &auth.0)?;
 
     // Verify the webhook belongs to this repo
     let hook = state

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -1971,7 +1971,7 @@ impl Db {
         let now = Utc::now().to_rfc3339();
         let row = sqlx::query(
             "UPDATE agent_tasks SET status=$2, result=$3, updated_at=$4
-             WHERE id=$1
+             WHERE id=$1 AND status='claimed'
              RETURNING id, repo_id, kind, status, delegator_did, assignee_did, capability, ucan_token, payload, result, created_at, updated_at, deadline",
         )
         .bind(id)
@@ -1981,7 +1981,7 @@ impl Db {
         .fetch_optional(&self.pool)
         .await?;
         row.map(row_to_task)
-            .ok_or_else(|| anyhow::anyhow!("task not found"))
+            .ok_or_else(|| anyhow::anyhow!("task not found or not in claimed state"))
     }
 }
 

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -254,6 +254,15 @@ impl Db {
         Self { pool }
     }
 
+    /// Test-only: apply the full schema to a fresh pool. `#[sqlx::test]`
+    /// provisions an empty per-test database, so DB-backed tests must run this
+    /// before seeding. Reuses the production `migrate()` path (the advisory lock
+    /// is harmless on an isolated test DB and migrations are idempotent).
+    #[cfg(test)]
+    pub(crate) async fn run_migrations(&self) -> Result<()> {
+        self.migrate().await
+    }
+
     pub async fn connect(database_url: &str) -> Result<Self> {
         let pool = PgPool::connect(database_url).await?;
         let db = Self { pool };

--- a/crates/gitlawb-node/src/graphql/mutation.rs
+++ b/crates/gitlawb-node/src/graphql/mutation.rs
@@ -3,10 +3,20 @@ use chrono::Utc;
 use std::sync::Arc;
 use uuid::Uuid;
 
+use crate::auth::AuthenticatedDid;
 use crate::db::{AgentTask, Db};
 use crate::state::TaskEventBroadcast;
 
 use super::types::{AgentTaskType, CreateTaskInput, FinishTaskInput};
+
+/// The verified signer DID for this request, or an auth error (N2). The DID is
+/// attached request-scoped by the `/graphql` `optional_signature` layer; its
+/// absence means the request was unsigned, so every mutation rejects.
+fn require_signer<'a>(ctx: &'a Context<'_>) -> Result<&'a str> {
+    ctx.data::<AuthenticatedDid>()
+        .map(|d| d.0.as_str())
+        .map_err(|_| async_graphql::Error::new("authentication required"))
+}
 
 pub struct MutationRoot;
 
@@ -18,6 +28,13 @@ impl MutationRoot {
         delegator_did: String,
         input: CreateTaskInput,
     ) -> Result<AgentTaskType> {
+        let caller = require_signer(ctx)?;
+        if !crate::api::did_matches(caller, &delegator_did) {
+            return Err(async_graphql::Error::new(
+                "delegator_did must be the authenticated signer",
+            ));
+        }
+        let delegator_did = caller.to_string();
         let db = ctx.data_unchecked::<Arc<Db>>();
         let now = Utc::now().to_rfc3339();
         let task = AgentTask {
@@ -47,6 +64,13 @@ impl MutationRoot {
         id: String,
         assignee_did: String,
     ) -> Result<AgentTaskType> {
+        let caller = require_signer(ctx)?;
+        if !crate::api::did_matches(caller, &assignee_did) {
+            return Err(async_graphql::Error::new(
+                "assignee_did must be the authenticated signer",
+            ));
+        }
+        let assignee_did = caller.to_string();
         let db = ctx.data_unchecked::<Arc<Db>>();
         let tx = ctx.data_unchecked::<tokio::sync::broadcast::Sender<TaskEventBroadcast>>();
         let task = db
@@ -70,6 +94,13 @@ impl MutationRoot {
         by_did: String,
         input: FinishTaskInput,
     ) -> Result<AgentTaskType> {
+        let caller = require_signer(ctx)?;
+        if !crate::api::did_matches(caller, &by_did) {
+            return Err(async_graphql::Error::new(
+                "by_did must be the authenticated signer",
+            ));
+        }
+        let by_did = caller.to_string();
         let db = ctx.data_unchecked::<Arc<Db>>();
         let tx = ctx.data_unchecked::<tokio::sync::broadcast::Sender<TaskEventBroadcast>>();
         let task = db
@@ -93,6 +124,13 @@ impl MutationRoot {
         by_did: String,
         input: FinishTaskInput,
     ) -> Result<AgentTaskType> {
+        let caller = require_signer(ctx)?;
+        if !crate::api::did_matches(caller, &by_did) {
+            return Err(async_graphql::Error::new(
+                "by_did must be the authenticated signer",
+            ));
+        }
+        let by_did = caller.to_string();
         let db = ctx.data_unchecked::<Arc<Db>>();
         let tx = ctx.data_unchecked::<tokio::sync::broadcast::Sender<TaskEventBroadcast>>();
         let reason = input.reason.unwrap_or_default();
@@ -108,5 +146,64 @@ impl MutationRoot {
             at: Utc::now().to_rfc3339(),
         });
         Ok(AgentTaskType::from(task))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::auth::AuthenticatedDid;
+    use async_graphql::{Request, Response};
+    use sqlx::PgPool;
+
+    fn errors(resp: &Response) -> String {
+        resp.errors
+            .iter()
+            .map(|e| e.message.clone())
+            .collect::<Vec<_>>()
+            .join("; ")
+    }
+
+    /// N2: GraphQL mutations require a verified signer and bind the acting DID to
+    /// it. Unsigned is rejected; a signer other than the claimed actor is
+    /// rejected; the matching signer passes the auth gate.
+    #[sqlx::test]
+    async fn mutation_requires_and_binds_signer(pool: PgPool) {
+        let state = crate::test_support::test_state(pool).await;
+        let schema = state.graphql_schema.as_ref();
+        let assignee = "did:key:zASSIGNEEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let q = format!(
+            r#"mutation {{ claimTask(id: "no-such-task", assigneeDid: "{assignee}") {{ id }} }}"#
+        );
+
+        // 1. Unsigned → rejected before any DB work.
+        let resp = schema.execute(Request::new(&q)).await;
+        assert!(
+            errors(&resp).contains("authentication required"),
+            "unsigned mutation must be rejected: {}",
+            errors(&resp)
+        );
+
+        // 2. Signed as someone other than the claimed assignee → rejected.
+        let resp = schema
+            .execute(Request::new(&q).data(AuthenticatedDid(
+                "did:key:zOTHERBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".into(),
+            )))
+            .await;
+        assert!(
+            errors(&resp).contains("authenticated signer"),
+            "DID mismatch must be rejected: {}",
+            errors(&resp)
+        );
+
+        // 3. Signed as the claimed assignee → passes the auth gate (any remaining
+        //    error is the missing task, not an auth error).
+        let resp = schema
+            .execute(Request::new(&q).data(AuthenticatedDid(assignee.into())))
+            .await;
+        let errs = errors(&resp);
+        assert!(
+            !errs.contains("authentication required") && !errs.contains("authenticated signer"),
+            "matching signer must pass the auth gate: {errs}"
+        );
     }
 }

--- a/crates/gitlawb-node/src/graphql/mutation.rs
+++ b/crates/gitlawb-node/src/graphql/mutation.rs
@@ -103,6 +103,18 @@ impl MutationRoot {
         let by_did = caller.to_string();
         let db = ctx.data_unchecked::<Arc<Db>>();
         let tx = ctx.data_unchecked::<tokio::sync::broadcast::Sender<TaskEventBroadcast>>();
+        // Authorize the actor: binding by_did to the signer is necessary but not
+        // sufficient — only the task's assignee may finish it.
+        let existing = db
+            .get_task(&id)
+            .await
+            .map_err(|e| async_graphql::Error::new(e.to_string()))?
+            .ok_or_else(|| async_graphql::Error::new("task not found"))?;
+        if !crate::api::did_matches(caller, existing.assignee_did.as_deref().unwrap_or_default()) {
+            return Err(async_graphql::Error::new(
+                "only the task assignee can complete it",
+            ));
+        }
         let task = db
             .finish_task(&id, "completed", input.result.as_deref())
             .await
@@ -133,6 +145,17 @@ impl MutationRoot {
         let by_did = caller.to_string();
         let db = ctx.data_unchecked::<Arc<Db>>();
         let tx = ctx.data_unchecked::<tokio::sync::broadcast::Sender<TaskEventBroadcast>>();
+        // Authorize the actor: only the task's assignee may fail it.
+        let existing = db
+            .get_task(&id)
+            .await
+            .map_err(|e| async_graphql::Error::new(e.to_string()))?
+            .ok_or_else(|| async_graphql::Error::new("task not found"))?;
+        if !crate::api::did_matches(caller, existing.assignee_did.as_deref().unwrap_or_default()) {
+            return Err(async_graphql::Error::new(
+                "only the task assignee can fail it",
+            ));
+        }
         let reason = input.reason.unwrap_or_default();
         let task = db
             .finish_task(&id, "failed", Some(&reason))
@@ -204,6 +227,67 @@ mod tests {
         assert!(
             !errs.contains("authentication required") && !errs.contains("authenticated signer"),
             "matching signer must pass the auth gate: {errs}"
+        );
+    }
+
+    /// Adversarial-review GATE-1 (GraphQL): completing a task requires being its
+    /// assignee, not merely signing as the by_did you pass. A signer who is not
+    /// the assignee is rejected even though the by_did binding passes; the
+    /// assignee completes.
+    #[sqlx::test]
+    async fn complete_task_requires_assignee(pool: PgPool) {
+        let state = crate::test_support::test_state(pool).await;
+        let assignee = "did:key:zGQLASSIGNEEAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let stranger = "did:key:zGQLSTRANGERBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        let now = chrono::Utc::now().to_rfc3339();
+        let task = crate::db::AgentTask {
+            id: "task-g".into(),
+            repo_id: None,
+            kind: "build".into(),
+            status: "pending".into(),
+            delegator_did: "did:key:zGQLDELEGATORCCCCCCCCCCCCCCCCCCCCCCCCCC".into(),
+            assignee_did: None,
+            capability: "repo:write".into(),
+            ucan_token: None,
+            payload: None,
+            result: None,
+            created_at: now.clone(),
+            updated_at: now,
+            deadline: None,
+        };
+        state.db.create_task(&task).await.expect("seed task");
+        state
+            .db
+            .claim_task("task-g", assignee)
+            .await
+            .expect("claim");
+        let schema = state.graphql_schema.as_ref();
+
+        let q = |actor: &str| {
+            format!(
+                r#"mutation {{ completeTask(id: "task-g", byDid: "{actor}", input: {{}}) {{ id status }} }}"#
+            )
+        };
+
+        // Stranger signs as themselves and passes byDid=self (so the signer
+        // binding passes), but is not the assignee → rejected by authorization.
+        let resp = schema
+            .execute(Request::new(q(stranger)).data(AuthenticatedDid(stranger.into())))
+            .await;
+        assert!(
+            errors(&resp).contains("assignee"),
+            "a non-assignee signer must be rejected: {}",
+            errors(&resp)
+        );
+
+        // The assignee completes with no error.
+        let resp = schema
+            .execute(Request::new(q(assignee)).data(AuthenticatedDid(assignee.into())))
+            .await;
+        assert!(
+            errors(&resp).is_empty(),
+            "the assignee should complete the task: {}",
+            errors(&resp)
         );
     }
 }

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -18,6 +18,8 @@ mod rate_limit;
 mod server;
 mod state;
 mod sync;
+#[cfg(test)]
+mod test_support;
 mod visibility;
 mod webhooks;
 

--- a/crates/gitlawb-node/src/server.rs
+++ b/crates/gitlawb-node/src/server.rs
@@ -20,8 +20,19 @@ use crate::auth;
 use crate::rate_limit;
 use crate::state::AppState;
 
-async fn graphql_handler(State(state): State<AppState>, req: GraphQLRequest) -> GraphQLResponse {
-    state.graphql_schema.execute(req.into_inner()).await.into()
+async fn graphql_handler(
+    State(state): State<AppState>,
+    auth: Option<axum::Extension<crate::auth::AuthenticatedDid>>,
+    req: GraphQLRequest,
+) -> GraphQLResponse {
+    // `optional_signature` attaches the verified DID when a signature is present.
+    // Thread it into request-scoped GraphQL data; mutations enforce its presence
+    // in-resolver (N2) while queries stay open.
+    let mut inner = req.into_inner();
+    if let Some(axum::Extension(did)) = auth {
+        inner = inner.data(did);
+    }
+    state.graphql_schema.execute(inner).await.into()
 }
 
 async fn graphql_playground() -> impl IntoResponse {
@@ -49,6 +60,10 @@ pub fn build_router(state: AppState) -> Router {
     let schema = state.graphql_schema.as_ref().clone();
     let graphql_routes = Router::new()
         .route("/graphql", get(graphql_playground).post(graphql_handler))
+        // Attach the verified DID to /graphql when a signature is present. The
+        // layer covers only routes added before it, so /graphql/ws (added after,
+        // read-only subscriptions) stays open.
+        .layer(middleware::from_fn(auth::optional_signature))
         .route_service("/graphql/ws", GraphQLSubscription::new(schema));
 
     // ── Task routes (write — require HTTP Signature) ───────────────────────

--- a/crates/gitlawb-node/src/test_support.rs
+++ b/crates/gitlawb-node/src/test_support.rs
@@ -1,0 +1,184 @@
+//! Shared `#[cfg(test)]` HTTP-API integration-test harness.
+//!
+//! Provides a migrated [`AppState`] over a real `#[sqlx::test]` Postgres pool
+//! ([`test_state`]), a DB-free variant for middleware tests that never query
+//! ([`test_state_lazy`]), the assembled router ([`app`]), and a request builder
+//! that injects an already-verified [`AuthenticatedDid`] without producing real
+//! RFC-9421 signatures ([`signed_request_as`]).
+//!
+//! NOTE on auth: the production router wraps mutation routes in `add_auth_layers`
+//! (`require_signature` then `require_ucan_chain`). `require_signature` rejects a
+//! request that carries only an injected `AuthenticatedDid` (no real signature),
+//! so [`app`] is for tests of *open* routes or no-auth-rejection paths. To test a
+//! handler's own authorization (e.g. `require_owner`), mount the handler directly
+//! with the state and inject the DID — see the `tests` module below, which
+//! mirrors the pattern in `auth/mod.rs`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Method, Request};
+use axum::Router;
+use sqlx::PgPool;
+
+use gitlawb_core::identity::Keypair;
+
+use crate::auth::AuthenticatedDid;
+use crate::state::AppState;
+
+/// Build an [`AppState`] over a real, migrated Postgres pool (from `#[sqlx::test]`).
+/// Runs the schema migrations first, because the per-test database starts empty.
+pub(crate) async fn test_state(pool: PgPool) -> AppState {
+    let db = Arc::new(crate::db::Db::for_testing(pool.clone()));
+    db.run_migrations()
+        .await
+        .expect("test schema migrations should apply");
+    build_state(db, pool)
+}
+
+/// DB-free [`AppState`] for middleware/auth tests that return before any query.
+/// The pool is lazy and never connects — do NOT use for tests that hit the DB.
+// Harness API consumed by the plan-002/003 middleware and no-auth-rejection tests.
+#[allow(dead_code)]
+pub(crate) fn test_state_lazy() -> AppState {
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .connect_lazy("postgres://localhost/gitlawb_test_placeholder")
+        .expect("lazy pool creation should not fail");
+    let db = Arc::new(crate::db::Db::for_testing(pool.clone()));
+    build_state(db, pool)
+}
+
+fn build_state(db: Arc<crate::db::Db>, pool: PgPool) -> AppState {
+    use crate::{config::Config, graphql, rate_limit::RateLimiter};
+    use clap::Parser;
+
+    let keypair = Keypair::generate();
+    let node_did = keypair.did();
+    let (ref_tx, _) = tokio::sync::broadcast::channel(1);
+    let (task_tx, _) = tokio::sync::broadcast::channel(1);
+    let schema = Arc::new(graphql::build_schema(
+        db.clone(),
+        ref_tx.clone(),
+        task_tx.clone(),
+    ));
+    AppState {
+        config: Arc::new(Config::parse_from(["gitlawb-node"])),
+        db,
+        node_did,
+        node_keypair: Arc::new(keypair),
+        p2p: None,
+        http_client: Arc::new(reqwest::Client::new()),
+        ref_update_tx: ref_tx,
+        task_event_tx: task_tx,
+        graphql_schema: schema,
+        machine_id: None,
+        repo_store: crate::git::repo_store::RepoStore::for_testing(PathBuf::from("/tmp"), pool),
+        rate_limiter: RateLimiter::new(100, Duration::from_secs(60)),
+        shutdown_tx: tokio::sync::watch::channel(false).0,
+    }
+}
+
+/// The full production router over a migrated test state. See the module note:
+/// requests through this router must carry a real signature, so it suits open
+/// routes and no-auth-rejection tests, not injected-DID authorization tests.
+// Harness API consumed by plan-003's no-auth GraphQL test and open-route tests.
+#[allow(dead_code)]
+pub(crate) async fn app(pool: PgPool) -> Router {
+    crate::server::build_router(test_state(pool).await)
+}
+
+/// Build a request carrying an already-verified [`AuthenticatedDid`] extension,
+/// so a handler mounted without `require_signature` sees the caller identity.
+/// Sets `Content-Type: application/json` — the API is JSON throughout, and
+/// without it axum's `Json` extractor returns 415 before the handler runs
+/// (which would make any JSON-body authz assertion a false pass).
+pub(crate) fn signed_request_as(did: &str, method: Method, uri: &str, body: Body) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .extension(AuthenticatedDid(did.to_string()))
+        .body(body)
+        .expect("request builder")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::RepoRecord;
+    use axum::http::StatusCode;
+    use chrono::Utc;
+    use tower::ServiceExt;
+
+    fn seed_repo(owner_did: &str, name: &str) -> RepoRecord {
+        let now = Utc::now();
+        RepoRecord {
+            id: uuid::Uuid::new_v4().to_string(),
+            name: name.to_string(),
+            owner_did: owner_did.to_string(),
+            description: None,
+            is_public: true,
+            default_branch: "main".to_string(),
+            created_at: now,
+            updated_at: now,
+            disk_path: format!("/tmp/{name}"),
+            forked_from: None,
+            machine_id: None,
+        }
+    }
+
+    /// Proves the harness end to end: a migrated DB, a seeded repo, and the
+    /// owner gate on an ALREADY-gated endpoint (`PUT /visibility`, gated by
+    /// `require_owner`). Non-owner is rejected; owner succeeds. Mounts the
+    /// handler directly (not via `app`) because `require_signature` would
+    /// reject the injected-DID request — see the module note.
+    #[sqlx::test]
+    async fn visibility_set_is_owner_gated(pool: PgPool) {
+        let owner = "did:key:zHARNESSOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let stranger = "did:key:zHARNESSSTRANGERBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+        let state = test_state(pool).await;
+        state
+            .db
+            .create_repo(&seed_repo(owner, "harness-repo"))
+            .await
+            .expect("seed repo");
+
+        let router = || {
+            Router::new()
+                .route(
+                    "/api/v1/repos/{owner}/{repo}/visibility",
+                    axum::routing::put(crate::api::visibility::set_visibility),
+                )
+                .with_state(state.clone())
+        };
+        let uri = format!("/api/v1/repos/{owner}/harness-repo/visibility");
+        let body = || Body::from(r#"{"path_glob":"/","reader_dids":[]}"#);
+
+        // Non-owner → rejected by require_owner. Current code returns 400
+        // (AppError::BadRequest). Asserting the exact code proves the rejection
+        // came from the owner gate, not an incidental 404/415.
+        let resp = router()
+            .oneshot(signed_request_as(stranger, Method::PUT, &uri, body()))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "non-owner must be rejected by the owner gate"
+        );
+
+        // Owner → accepted (2xx).
+        let resp = router()
+            .oneshot(signed_request_as(owner, Method::PUT, &uri, body()))
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_success(),
+            "owner should be allowed to set visibility, got {}",
+            resp.status()
+        );
+    }
+}

--- a/crates/gitlawb-node/src/test_support.rs
+++ b/crates/gitlawb-node/src/test_support.rs
@@ -181,4 +181,73 @@ mod tests {
             resp.status()
         );
     }
+
+    /// N7: merge_pr is owner-only. A non-owner is rejected by require_repo_owner
+    /// before any git work (so no on-disk repo is needed for the rejection).
+    #[sqlx::test]
+    async fn merge_pr_rejects_non_owner(pool: PgPool) {
+        let owner = "did:key:zMERGEOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let stranger = "did:key:zMERGESTRANGERBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        let state = test_state(pool).await;
+        state
+            .db
+            .create_repo(&seed_repo(owner, "merge-repo"))
+            .await
+            .expect("seed repo");
+
+        let router = Router::new()
+            .route(
+                "/api/v1/repos/{owner}/{repo}/pulls/{number}/merge",
+                axum::routing::post(crate::api::pulls::merge_pr),
+            )
+            .with_state(state);
+        let uri = format!("/api/v1/repos/{owner}/merge-repo/pulls/1/merge");
+        let resp = router
+            .oneshot(signed_request_as(
+                stranger,
+                Method::POST,
+                &uri,
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "a non-owner must not be able to merge"
+        );
+    }
+
+    /// N13: the task handlers bind the acting DID to the signer. A caller signed
+    /// as B claiming delegator_did A is rejected before any DB write (DB-free).
+    #[sqlx::test]
+    async fn create_task_binds_delegator_to_signer(pool: PgPool) {
+        let signer = "did:key:zSIGNERBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        let claimed = "did:key:zCLAIMEDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let state = test_state(pool).await;
+
+        let router = Router::new()
+            .route(
+                "/api/v1/tasks",
+                axum::routing::post(crate::api::tasks::create_task),
+            )
+            .with_state(state);
+        let body = Body::from(format!(
+            r#"{{"kind":"build","capability":"repo:write","delegator_did":"{claimed}"}}"#
+        ));
+        let resp = router
+            .oneshot(signed_request_as(
+                signer,
+                Method::POST,
+                "/api/v1/tasks",
+                body,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "delegator_did must be bound to the signer"
+        );
+    }
 }

--- a/crates/gitlawb-node/src/test_support.rs
+++ b/crates/gitlawb-node/src/test_support.rs
@@ -250,4 +250,65 @@ mod tests {
             "delegator_did must be bound to the signer"
         );
     }
+
+    /// N3: get_tree gates on the REQUESTED subtree, not the repo root. A caller
+    /// denied a withheld subtree is rejected there (404) but passes the gate on a
+    /// non-withheld path (so the rejection is path-scoped, not repo-wide).
+    #[sqlx::test]
+    async fn get_tree_gate_is_path_scoped(pool: PgPool) {
+        use crate::db::VisibilityMode;
+        let owner = "did:key:zTREEOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let stranger = "did:key:zTREESTRANGERBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        let state = test_state(pool).await;
+        let repo = seed_repo(owner, "tree-repo");
+        state.db.create_repo(&repo).await.expect("seed repo");
+        // Withhold /secret/** from everyone but the owner.
+        state
+            .db
+            .set_visibility_rule(&repo.id, "/secret/**", VisibilityMode::B, &[], owner)
+            .await
+            .expect("set rule");
+
+        let router = || {
+            Router::new()
+                .route(
+                    "/api/v1/repos/{owner}/{repo}/tree/{*path}",
+                    axum::routing::get(crate::api::repos::get_tree),
+                )
+                .with_state(state.clone())
+        };
+
+        // Withheld subtree → denied at the gate (opaque 404), before any disk access.
+        let resp = router()
+            .oneshot(signed_request_as(
+                stranger,
+                Method::GET,
+                &format!("/api/v1/repos/{owner}/tree-repo/tree/secret"),
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "withheld subtree must be denied"
+        );
+
+        // Non-withheld path → passes the gate (whatever the disk layer then returns,
+        // it is NOT the gate's 404). Proves the gate keyed off the path, not the repo.
+        let resp = router()
+            .oneshot(signed_request_as(
+                stranger,
+                Method::GET,
+                &format!("/api/v1/repos/{owner}/tree-repo/tree/public"),
+                Body::empty(),
+            ))
+            .await
+            .unwrap();
+        assert_ne!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "a non-withheld path must pass the path-scoped gate"
+        );
+    }
 }

--- a/crates/gitlawb-node/src/test_support.rs
+++ b/crates/gitlawb-node/src/test_support.rs
@@ -107,7 +107,7 @@ pub(crate) fn signed_request_as(did: &str, method: Method, uri: &str, body: Body
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::RepoRecord;
+    use crate::db::{AgentTask, RepoRecord};
     use axum::http::StatusCode;
     use chrono::Utc;
     use tower::ServiceExt;
@@ -309,6 +309,174 @@ mod tests {
             resp.status(),
             StatusCode::NOT_FOUND,
             "a non-withheld path must pass the path-scoped gate"
+        );
+    }
+
+    fn seed_task(id: &str, delegator: &str) -> AgentTask {
+        let now = Utc::now().to_rfc3339();
+        AgentTask {
+            id: id.to_string(),
+            repo_id: None,
+            kind: "build".to_string(),
+            status: "pending".to_string(),
+            delegator_did: delegator.to_string(),
+            assignee_did: None,
+            capability: "repo:write".to_string(),
+            ucan_token: None,
+            payload: None,
+            result: None,
+            created_at: now.clone(),
+            updated_at: now,
+            deadline: None,
+        }
+    }
+
+    /// Adversarial-review GATE-1: complete_task authorizes the assignee, not just
+    /// the claimed identity. A stranger (even with an empty body, which used to
+    /// skip the signer binding entirely) is rejected; the assignee succeeds; and a
+    /// task that is no longer `claimed` cannot transition again.
+    #[sqlx::test]
+    async fn complete_task_authorizes_assignee_only(pool: PgPool) {
+        let delegator = "did:key:zTASKDELEGATORAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let assignee = "did:key:zTASKASSIGNEEBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        let stranger = "did:key:zTASKSTRANGERCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+        let state = test_state(pool).await;
+        state
+            .db
+            .create_task(&seed_task("task-1", delegator))
+            .await
+            .expect("seed task");
+        // Assignee claims it: pending -> claimed, assignee_did = assignee.
+        state
+            .db
+            .claim_task("task-1", assignee)
+            .await
+            .expect("claim");
+
+        let router = || {
+            Router::new()
+                .route(
+                    "/api/v1/tasks/{id}/complete",
+                    axum::routing::post(crate::api::tasks::complete_task),
+                )
+                .with_state(state.clone())
+        };
+        let uri = "/api/v1/tasks/task-1/complete";
+        let body = || Body::from("{}");
+
+        // Stranger (not the assignee) is rejected by the authorization gate, even
+        // with the empty body that previously bypassed the binding. Exact 403.
+        let resp = router()
+            .oneshot(signed_request_as(stranger, Method::POST, uri, body()))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "a non-assignee must not complete the task"
+        );
+
+        // The assignee completes successfully.
+        let resp = router()
+            .oneshot(signed_request_as(assignee, Method::POST, uri, body()))
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_success(),
+            "the assignee should complete the task, got {}",
+            resp.status()
+        );
+
+        // The task is now `completed`, not `claimed`; the status predicate in
+        // finish_task rejects a second transition (proves only a claimed task moves).
+        let resp = router()
+            .oneshot(signed_request_as(assignee, Method::POST, uri, body()))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::CONFLICT,
+            "a task that is no longer claimed must not transition again"
+        );
+    }
+
+    /// Adversarial-review GATE-2 (create_pr): opening a PR requires read access.
+    /// A non-reader is denied on a private repo before any PR is created; the
+    /// owner is allowed.
+    #[sqlx::test]
+    async fn create_pr_denies_non_reader_on_private_repo(pool: PgPool) {
+        let owner = "did:key:zPROWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let stranger = "did:key:zPRSTRANGERBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        let state = test_state(pool).await;
+        let mut repo = seed_repo(owner, "priv-pr-repo");
+        repo.is_public = false;
+        state.db.create_repo(&repo).await.expect("seed repo");
+
+        let router = || {
+            Router::new()
+                .route(
+                    "/api/v1/repos/{owner}/{repo}/pulls",
+                    axum::routing::post(crate::api::pulls::create_pr),
+                )
+                .with_state(state.clone())
+        };
+        let uri = format!("/api/v1/repos/{owner}/priv-pr-repo/pulls");
+        let body = || Body::from(r#"{"title":"x","source_branch":"feature"}"#);
+
+        // Non-reader on a private repo: opaque 404 (RepoNotFound), no PR created.
+        let resp = router()
+            .oneshot(signed_request_as(stranger, Method::POST, &uri, body()))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "a non-reader must not open a PR against a private repo"
+        );
+
+        // Owner is a reader, so the gate admits them (create_pr does no disk I/O).
+        let resp = router()
+            .oneshot(signed_request_as(owner, Method::POST, &uri, body()))
+            .await
+            .unwrap();
+        assert!(
+            resp.status().is_success(),
+            "the owner should be able to open a PR, got {}",
+            resp.status()
+        );
+    }
+
+    /// Adversarial-review GATE-2 (create_issue): filing an issue requires read
+    /// access. A non-reader is denied on a private repo before any git work.
+    #[sqlx::test]
+    async fn create_issue_denies_non_reader_on_private_repo(pool: PgPool) {
+        let owner = "did:key:zISOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let stranger = "did:key:zISSTRANGERBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        let state = test_state(pool).await;
+        let mut repo = seed_repo(owner, "priv-issue-repo");
+        repo.is_public = false;
+        state.db.create_repo(&repo).await.expect("seed repo");
+
+        let router = Router::new()
+            .route(
+                "/api/v1/repos/{owner}/{repo}/issues",
+                axum::routing::post(crate::api::issues::create_issue),
+            )
+            .with_state(state);
+        let uri = format!("/api/v1/repos/{owner}/priv-issue-repo/issues");
+        let resp = router
+            .oneshot(signed_request_as(
+                stranger,
+                Method::POST,
+                &uri,
+                Body::from(r#"{"title":"x","body":"y"}"#),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "a non-reader must not file an issue against a private repo"
         );
     }
 }

--- a/crates/gitlawb-node/src/test_support.rs
+++ b/crates/gitlawb-node/src/test_support.rs
@@ -157,16 +157,16 @@ mod tests {
         let uri = format!("/api/v1/repos/{owner}/harness-repo/visibility");
         let body = || Body::from(r#"{"path_glob":"/","reader_dids":[]}"#);
 
-        // Non-owner → rejected by require_owner. Current code returns 400
-        // (AppError::BadRequest). Asserting the exact code proves the rejection
-        // came from the owner gate, not an incidental 404/415.
+        // Non-owner → rejected by require_owner with 403 Forbidden. Asserting the
+        // exact code proves the rejection came from the owner gate, not an
+        // incidental 404/415.
         let resp = router()
             .oneshot(signed_request_as(stranger, Method::PUT, &uri, body()))
             .await
             .unwrap();
         assert_eq!(
             resp.status(),
-            StatusCode::BAD_REQUEST,
+            StatusCode::FORBIDDEN,
             "non-owner must be rejected by the owner gate"
         );
 
@@ -305,10 +305,11 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_ne!(
+        assert_eq!(
             resp.status(),
-            StatusCode::NOT_FOUND,
-            "a non-withheld path must pass the path-scoped gate"
+            StatusCode::OK,
+            "a non-withheld path must pass the path-scoped gate (exact 200, so a \
+             future upstream 4xx/5xx cannot masquerade as gate-pass)"
         );
     }
 
@@ -477,6 +478,36 @@ mod tests {
             resp.status(),
             StatusCode::NOT_FOUND,
             "a non-reader must not file an issue against a private repo"
+        );
+    }
+
+    /// Adversarial-review D3-1: register binds the registered DID to the signer.
+    /// A caller signed as A cannot register a different DID B (no spoofed
+    /// registration or trust row under a victim DID). Rejected before any write.
+    #[sqlx::test]
+    async fn register_binds_did_to_signer(pool: PgPool) {
+        let signer = "did:key:zREGSIGNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let other = "did:key:zREGOTHERBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        let state = test_state(pool).await;
+        let router = Router::new()
+            .route(
+                "/api/register",
+                axum::routing::post(crate::api::register::register),
+            )
+            .with_state(state);
+        let resp = router
+            .oneshot(signed_request_as(
+                signer,
+                Method::POST,
+                "/api/register",
+                Body::from(format!(r#"{{"did":"{other}"}}"#)),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "register must reject a DID other than the signer"
         );
     }
 }


### PR DESCRIPTION
Authenticated never meant authorized on the node's signed API. Identities are self-issued `did:key`, so a valid signature passed every gate regardless of who the caller was. This locks down the write surface: each mutation checks the caller against the resource it touches, and a DB-backed test harness exercises those checks against real Postgres in CI.

## What's enforced

- **Owner-only mutations.** Merge, branch protect/unprotect, webhooks, and labels require the repo owner (403 otherwise). Closing a PR or issue allows the owner or the original author.
- **Read-gated writes.** Opening a PR or issue, reviewing, commenting, creating a bounty, and forking now require read access, so a non-reader cannot write to (or fork) a private repo they cannot read. Some of these were already gated; this makes it consistent across all of them.
- **Signer-bound actions.** Task create/claim/complete/fail, bounty claim, profile, repo create, registration, and starring bind the acting DID to the authenticated signer instead of trusting a value from the request body. Completing or failing a task additionally requires being its assignee, and only a claimed task can transition.
- **GraphQL mutations** require a verified signer and the same DID binding; queries and subscriptions stay open.
- **`get_tree`** gates on the requested subtree rather than the repo root, so a caller denied a withheld path can no longer enumerate its filenames and blob SHAs.

A source-level drift guard asserts every in-scope handler still carries its gate, so a future change that drops one fails CI.

## Test harness

The node had no DB-backed tests, and CI ran without Postgres, so the entire handler-to-database path was uncovered. This adds a Postgres service to the PR pipeline and a `#[sqlx::test]` harness, with behavioral tests for the authorization paths above.

## Known limitation

`did_matches` compares `did:key` identities by their multibase string. A key presented in a non-canonical multibase encoding (for example base16 rather than base58btc) will not match the canonical form, so a key-holder on a non-conforming client could be denied their own owner gate. This is a false-negative only, never an impersonation vector (producing any encoding still requires the private key), and the conforming client always emits canonical base58btc. Left as-is rather than decoding keys in the auth path; noted here so it is on record.

## Verification

143 node tests pass against real Postgres; clippy and rustfmt are clean. The commits are ordered harness, REST gates, GraphQL, `get_tree`, then three follow-ups (task-completion authorization, drift-guard hardening, and a small consistency batch) so they can be reviewed or bisected independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened DID-based authorization across API and GraphQL: actions that create/modify/terminate resources are now properly gated for authenticated callers (including owner/author/assignee/claimant checks).
  * Standardized authorization failures to return the correct “Forbidden” responses instead of other error types.
  * Scoped subtree visibility to the requested path to prevent enumeration of withheld repository content.

* **Tests**
  * Expanded PostgreSQL-backed integration testing in CI and added an end-to-end test harness with additional authorization coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->