### PR TITLE
feat(node): pin the per-push object delta instead of re-enumerating the whole repo

### DIFF
--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -33,9 +33,11 @@ const ZERO_SHA: &str = "0000000000000000000000000000000000000000";
 /// Returns `(announce, withheld)`: `announce` is whether the repo may be
 /// announced/replicated to the anonymous public at all (also gates gossip and
 /// Arweave anchoring downstream), and `withheld` is the anonymous withheld blob
-/// set when announceable (`None` when not announceable, or when the withheld
-/// walk failed — fail closed). Returning both keeps the gate's announce
-/// decision a single source rather than recomputing it at each call site.
+/// set when announceable (`None` when not announceable). A failed/panicked
+/// withheld walk fails closed on both axes: `announce` is forced false and
+/// `withheld` is `None`, so an unvetted push neither replicates blobs nor
+/// announces. Returning both keeps the gate's announce decision a single
+/// source rather than recomputing it at each call site.
 async fn replication_withheld_set(
     rules: Option<Vec<crate::db::VisibilityRule>>,
     owner_did: &str,
@@ -74,7 +76,14 @@ async fn replication_withheld_set(
         }
         None => None,
     };
-    (announce, withheld)
+    // Fail closed on a failed/panicked withheld walk: with `announce` already
+    // true here, a `None` withheld can only mean the walk errored (rules are
+    // necessarily `Some`, else we returned above). Suppress the announce too so
+    // a push we couldn't vet does not gossip, notify peers, or anchor to Arweave.
+    match withheld {
+        Some(withheld) => (announce, Some(withheld)),
+        None => (false, None),
+    }
 }
 
 // ── Request / Response types ───────────────────────────────────────────────

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -17,6 +17,66 @@ use crate::state::AppState;
 use crate::visibility::{visibility_check, Decision};
 use crate::webhooks;
 
+/// The git all-zeros object id — the create/delete sentinel in a ref update.
+const ZERO_SHA: &str = "0000000000000000000000000000000000000000";
+
+/// The set of blob OIDs withheld from **anonymous** replication for a repo, or
+/// `None` when the repo must not replicate at all (private / mode A /
+/// undetermined — fail closed). This is the anonymous replication gate:
+/// `caller` is hard-coded to `None` and there is intentionally no caller
+/// parameter, which distinguishes it from the per-caller read-serve projection
+/// in `git_upload_pack` (which passes the real caller). Both the push pin path
+/// and the reconciliation sweep call this helper so the two cannot drift on
+/// what is withheld. `rules` is the already-fetched visibility-rule snapshot
+/// (callers fetch once and may reuse it, e.g. for encrypt-then-pin).
+///
+/// Returns `(announce, withheld)`: `announce` is whether the repo may be
+/// announced/replicated to the anonymous public at all (also gates gossip and
+/// Arweave anchoring downstream), and `withheld` is the anonymous withheld blob
+/// set when announceable (`None` when not announceable, or when the withheld
+/// walk failed — fail closed). Returning both keeps the gate's announce
+/// decision a single source rather than recomputing it at each call site.
+async fn replication_withheld_set(
+    rules: Option<Vec<crate::db::VisibilityRule>>,
+    owner_did: &str,
+    is_public: bool,
+    disk_path: std::path::PathBuf,
+) -> (bool, Option<std::collections::HashSet<String>>) {
+    let announce = match &rules {
+        Some(rules) => visibility_check(rules, is_public, owner_did, None, "/") == Decision::Allow,
+        None => false,
+    };
+    if !announce {
+        return (false, None);
+    }
+    let withheld = match rules {
+        Some(rules) if rules.is_empty() => Some(std::collections::HashSet::new()),
+        // withheld_blob_oids walks every ref with blocking `git ls-tree`; keep
+        // that off the async worker thread.
+        Some(rules) => {
+            let owner_did = owner_did.to_string();
+            tokio::task::spawn_blocking(move || {
+                crate::git::visibility_pack::withheld_blob_oids(
+                    &disk_path, &rules, is_public, &owner_did, None,
+                )
+            })
+            .await
+            .map_err(|e| {
+                tracing::warn!(err = %e, "withheld_blob_oids task panicked; skipping replication")
+            })
+            .ok()
+            .and_then(|r| {
+                r.map_err(|e| {
+                    tracing::warn!(err = %e, "withheld_blob_oids failed; skipping replication")
+                })
+                .ok()
+            })
+        }
+        None => None,
+    };
+    (announce, withheld)
+}
+
 // ── Request / Response types ───────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -653,49 +713,54 @@ pub async fn git_receive_pack(
     // network-facing announcements. Fail closed: a private or undetermined repo
     // never leaks.
     let rules_opt = state.db.list_visibility_rules(&record.id).await.ok();
-    let announce = match &rules_opt {
-        Some(rules) => {
-            visibility_check(rules, record.is_public, &record.owner_did, None, "/")
-                == Decision::Allow
-        }
-        None => false,
-    };
-    let withheld: Option<std::collections::HashSet<String>> = if !announce {
-        None
-    } else {
-        match &rules_opt {
-            Some(rules) if rules.is_empty() => Some(std::collections::HashSet::new()),
-            // withheld_blob_oids walks every ref with blocking `git ls-tree`;
-            // keep that off the async worker thread.
-            Some(rules) => {
-                let path = disk_path.clone();
-                let rules = rules.clone();
-                let owner_did = record.owner_did.clone();
-                let is_public = record.is_public;
-                tokio::task::spawn_blocking(move || {
-                    crate::git::visibility_pack::withheld_blob_oids(
-                        &path, &rules, is_public, &owner_did, None,
-                    )
-                })
-                .await
-                .map_err(|e| {
-                    tracing::warn!(err = %e, "withheld_blob_oids task panicked; skipping replication for this push")
-                })
-                .ok()
-                .and_then(|r| {
-                    r.map_err(|e| {
-                        tracing::warn!(err = %e, "withheld_blob_oids failed; skipping replication for this push")
-                    })
-                    .ok()
-                })
+    let (announce, withheld) = replication_withheld_set(
+        rules_opt.clone(),
+        &record.owner_did,
+        record.is_public,
+        disk_path.clone(),
+    )
+    .await;
+
+    // Compute the per-push pin candidate set once, off the async worker (git
+    // subprocess). On the happy path this is the push delta (objects this push
+    // introduced); on any non-commit tip or git error it fails closed to a full
+    // repo scan. Only needed when something will actually replicate.
+    let candidates: Vec<String> = if withheld.is_some() {
+        let path = disk_path.clone();
+        let new_tips: Vec<String> = ref_updates
+            .iter()
+            .map(|u| u.new_sha.clone())
+            .filter(|s| s != ZERO_SHA)
+            .collect();
+        let old_tips: Vec<String> = ref_updates
+            .iter()
+            .map(|u| u.old_sha.clone())
+            .filter(|s| s != ZERO_SHA)
+            .collect();
+        tokio::task::spawn_blocking(move || {
+            let new_refs: Vec<&str> = new_tips.iter().map(String::as_str).collect();
+            let old_refs: Vec<&str> = old_tips.iter().map(String::as_str).collect();
+            match crate::git::push_delta::resolve_push_delta(&path, &new_refs, &old_refs) {
+                crate::git::push_delta::PinCandidates::Delta(objs) => {
+                    tracing::info!(delta = objs.len(), repo = %path.display(), "pin candidate set from push delta");
+                    objs
+                }
+                crate::git::push_delta::PinCandidates::FullScanRequired => {
+                    tracing::warn!(repo = %path.display(), "pin delta unavailable (non-commit tip, git error, or force-full-scan) — full-scan fallback");
+                    crate::git::push_delta::list_all_objects(&path).unwrap_or_default()
+                }
             }
-            None => None,
-        }
+        })
+        .await
+        .unwrap_or_default()
+    } else {
+        Vec::new()
     };
 
     // Pin new git objects to the local IPFS node (no-op if ipfs_api is empty).
     // Skipped entirely when the public cannot read the repo (withheld == None).
     if let Some(withheld_ipfs) = withheld.clone() {
+        let candidates_ipfs = candidates.clone();
         let ipfs_api = state.config.ipfs_api.clone();
         let repo_path_clone = disk_path.clone();
         let db_clone = state.db.clone();
@@ -712,6 +777,7 @@ pub async fn git_receive_pack(
             let pinned = crate::ipfs_pin::pin_new_objects(
                 &ipfs_api,
                 &repo_path_clone,
+                candidates_ipfs,
                 &db_clone,
                 &withheld_ipfs,
             )
@@ -814,6 +880,7 @@ pub async fn git_receive_pack(
         let self_public_url = state.config.public_url.clone();
         let node_keypair = Arc::clone(&state.node_keypair);
         let withheld_pinata = withheld;
+        let candidates_pinata = candidates;
         tokio::spawn(async move {
             let pinned = match &withheld_pinata {
                 Some(withheld) => {
@@ -822,6 +889,7 @@ pub async fn git_receive_pack(
                         &pinata_upload_url,
                         &pinata_jwt,
                         &repo_path_clone,
+                        candidates_pinata,
                         &db_clone,
                         withheld,
                     )

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -724,9 +724,9 @@ pub async fn git_receive_pack(
     // Compute the per-push pin candidate set once, off the async worker (git
     // subprocess). On the happy path this is the push delta (objects this push
     // introduced); on any non-commit tip or git error it fails closed to a full
-    // repo scan. Only needed when something will actually replicate.
+    // repo scan. Only needed when something will actually replicate. All
+    // degraded paths log inside the helper rather than failing silently.
     let candidates: Vec<String> = if withheld.is_some() {
-        let path = disk_path.clone();
         let new_tips: Vec<String> = ref_updates
             .iter()
             .map(|u| u.new_sha.clone())
@@ -737,22 +737,8 @@ pub async fn git_receive_pack(
             .map(|u| u.old_sha.clone())
             .filter(|s| s != ZERO_SHA)
             .collect();
-        tokio::task::spawn_blocking(move || {
-            let new_refs: Vec<&str> = new_tips.iter().map(String::as_str).collect();
-            let old_refs: Vec<&str> = old_tips.iter().map(String::as_str).collect();
-            match crate::git::push_delta::resolve_push_delta(&path, &new_refs, &old_refs) {
-                crate::git::push_delta::PinCandidates::Delta(objs) => {
-                    tracing::info!(delta = objs.len(), repo = %path.display(), "pin candidate set from push delta");
-                    objs
-                }
-                crate::git::push_delta::PinCandidates::FullScanRequired => {
-                    tracing::warn!(repo = %path.display(), "pin delta unavailable (non-commit tip, git error, or force-full-scan) — full-scan fallback");
-                    crate::git::push_delta::list_all_objects(&path).unwrap_or_default()
-                }
-            }
-        })
-        .await
-        .unwrap_or_default()
+        crate::git::push_delta::resolve_candidates_for_push(disk_path.clone(), new_tips, old_tips)
+            .await
     } else {
         Vec::new()
     };

--- a/crates/gitlawb-node/src/git/mod.rs
+++ b/crates/gitlawb-node/src/git/mod.rs
@@ -1,4 +1,5 @@
 pub mod issues;
+pub mod push_delta;
 pub mod repo_store;
 pub mod smart_http;
 pub mod store;

--- a/crates/gitlawb-node/src/git/push_delta.rs
+++ b/crates/gitlawb-node/src/git/push_delta.rs
@@ -1,0 +1,463 @@
+//! Push-delta object enumeration for the IPFS/Pinata pin path.
+//!
+//! The pin path needs the set of git objects to consider for pinning after a
+//! push. Historically both pin functions enumerated the *whole* repo
+//! (`git cat-file --batch-all-objects`) on every push, so cost scaled with
+//! repo size rather than push size (finding N16). This module computes the
+//! per-push *delta* instead — the objects a push introduced — and keeps the
+//! whole-repo lister for the reconciliation sweep and the fail-closed fallback.
+//!
+//! ## Correctness framing (do not confuse with the #84 withholding direction)
+//!
+//! The pin enumeration is part of the *exposure* set, not the withheld filter.
+//! Narrowing it per push only *shrinks* what is pinned, so it cannot create an
+//! under-withholding leak — the withheld filter (`visibility_pack`) still
+//! subtracts from whatever, smaller, set we feed it. The only risk here is
+//! *under-pinning* (a durability gap), which the reconciliation sweep backstops.
+//!
+//! Because the pin candidate set needs only the OID *set* (never the per-path
+//! information the withheld classifier needs), `git rev-list --objects
+//! --no-object-names` is safe here. The "rev-list reports one path per object"
+//! trap from #84 applies only to `visibility_pack`'s per-path `ls-tree` walk.
+
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+
+/// Env var that forces the push path to always full-scan, bypassing the delta
+/// optimization (KTD7 kill-switch). Reuses the already-tested fallback branch
+/// rather than introducing a second enumeration path. Does not gate the sweep.
+const FORCE_FULL_SCAN_ENV: &str = "GITLAWB_PIN_FORCE_FULLSCAN";
+
+/// The objects a push introduced, or a signal that the delta could not be
+/// computed safely and the caller should fall back to a full scan.
+///
+/// Three-valued by design: `Delta(vec![])` (a no-op push — pin nothing) is a
+/// *different* fact from `FullScanRequired` (could not compute — fall back),
+/// and they drive different actions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PinCandidates {
+    /// Objects reachable from the new tips but not the old tips.
+    Delta(Vec<String>),
+    /// The delta is not safe to use; the caller must enumerate the whole repo
+    /// with [`list_all_objects`] instead. Returned on a non-commit tip, any git
+    /// error, or the force-full-scan kill-switch.
+    FullScanRequired,
+}
+
+/// Resolve the set of objects introduced by a push from its ref updates.
+///
+/// `new_tips` / `old_tips` are the non-zero new/old SHAs of the push's ref
+/// updates (the caller strips the all-zeros create/delete sentinel). Keeping
+/// the helper on plain SHA slices (not the `api` `RefUpdate` type) keeps it
+/// unit-testable without the HTTP layer.
+///
+/// Fail-closed: any condition where the introduced set cannot be safely
+/// determined returns [`PinCandidates::FullScanRequired`] rather than a partial
+/// set, so the caller full-scans instead of silently under-pinning.
+pub fn resolve_push_delta(repo_path: &Path, new_tips: &[&str], old_tips: &[&str]) -> PinCandidates {
+    // KTD7 kill-switch: force the (already-tested) full-scan fallback. The env
+    // read is split out from the pure logic so the resolver stays unit-testable
+    // without touching process-global state.
+    resolve_push_delta_inner(repo_path, new_tips, old_tips, force_full_scan())
+}
+
+/// Whether the force-full-scan kill-switch env var is set.
+fn force_full_scan() -> bool {
+    std::env::var_os(FORCE_FULL_SCAN_ENV).is_some()
+}
+
+fn resolve_push_delta_inner(
+    repo_path: &Path,
+    new_tips: &[&str],
+    old_tips: &[&str],
+    force_full_scan: bool,
+) -> PinCandidates {
+    if force_full_scan {
+        tracing::debug!("{FORCE_FULL_SCAN_ENV} set — forcing full scan");
+        return PinCandidates::FullScanRequired;
+    }
+
+    // A push that only deleted refs introduces no objects.
+    if new_tips.is_empty() {
+        return PinCandidates::Delta(Vec::new());
+    }
+
+    // Ref-type guard (the fail-closed mechanism). `git rev-list` does NOT error
+    // on a non-commit tip — a blob/tree/tag-of-non-commit all exit 0 and walk
+    // the object — so the rev-list exit code cannot catch this. Check each new
+    // tip's *fully-peeled* type with `cat-file -t '<sha>^{}'` (recursive peel:
+    // tag-of-commit -> commit, tag-of-tree -> tree, tag-of-tag-of-commit ->
+    // commit). Bare `cat-file -t` returns `tag` for an annotated tag, and
+    // `for-each-ref %(*objecttype)` peels only one level — neither is correct.
+    for tip in new_tips {
+        match peeled_object_type(repo_path, tip) {
+            Some(t) if t == "commit" => {}
+            other => {
+                tracing::debug!(
+                    tip = %tip,
+                    peeled_type = ?other,
+                    "push tip is not a commit (or type lookup failed) — forcing full scan"
+                );
+                return PinCandidates::FullScanRequired;
+            }
+        }
+    }
+
+    match rev_list_delta(repo_path, new_tips, old_tips) {
+        Ok(oids) => PinCandidates::Delta(oids),
+        Err(e) => {
+            tracing::debug!(err = %e, "push-delta rev-list failed — forcing full scan");
+            PinCandidates::FullScanRequired
+        }
+    }
+}
+
+/// Return the fully-peeled object type of `sha` (e.g. `commit`, `tree`,
+/// `blob`), or `None` if the object is missing/unpeelable or git errored.
+fn peeled_object_type(repo_path: &Path, sha: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["cat-file", "-t", &format!("{sha}^{{}}")])
+        .current_dir(repo_path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Run `git rev-list --objects --no-object-names <new> --not <old>` and return
+/// the bare OID set. Decides on `status.success()` *before* parsing stdout, so
+/// a walk that prints a valid prefix then errors mid-walk is discarded.
+fn rev_list_delta(repo_path: &Path, new_tips: &[&str], old_tips: &[&str]) -> Result<Vec<String>> {
+    let mut args: Vec<&str> = vec!["rev-list", "--objects", "--no-object-names"];
+    args.extend_from_slice(new_tips);
+    if !old_tips.is_empty() {
+        args.push("--not");
+        args.extend_from_slice(old_tips);
+    }
+
+    let output = Command::new("git")
+        .args(&args)
+        .current_dir(repo_path)
+        .output()
+        .context("failed to run git rev-list for push delta")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git rev-list failed: {stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect())
+}
+
+/// List every object in the repository via
+/// `git cat-file --batch-all-objects --batch-check='%(objectname)'`.
+///
+/// This is the whole-repo enumeration the push path falls back to and the
+/// reconciliation sweep relies on. It returns *all* objects (including
+/// unreachable/dangling ones), which is what the sweep needs to catch
+/// stragglers — do not swap it for a reachability walk.
+pub fn list_all_objects(repo_path: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args([
+            "cat-file",
+            "--batch-all-objects",
+            "--batch-check=%(objectname)",
+        ])
+        .current_dir(repo_path)
+        .output()
+        .context("failed to run git cat-file")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git cat-file failed: {stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use tempfile::TempDir;
+
+    /// Minimal git helper for building test repos.
+    struct Repo {
+        _td: TempDir,
+        path: std::path::PathBuf,
+    }
+
+    impl Repo {
+        fn new() -> Self {
+            let td = TempDir::new().unwrap();
+            let path = td.path().to_path_buf();
+            let r = Repo { _td: td, path };
+            r.git(&["init", "-q", "-b", "main"]);
+            r.git(&["config", "user.email", "t@t"]);
+            r.git(&["config", "user.name", "t"]);
+            r
+        }
+
+        fn git(&self, args: &[&str]) -> String {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(&self.path)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        }
+
+        fn commit_file(&self, name: &str, body: &str) -> String {
+            std::fs::write(self.path.join(name), body).unwrap();
+            self.git(&["add", name]);
+            self.git(&["commit", "-qm", &format!("add {name}")]);
+            self.git(&["rev-parse", "HEAD"])
+        }
+
+        fn rev(&self, r: &str) -> String {
+            self.git(&["rev-parse", r])
+        }
+    }
+
+    const ZERO: &str = "0000000000000000000000000000000000000000";
+
+    fn delta(c: PinCandidates) -> Vec<String> {
+        match c {
+            PinCandidates::Delta(v) => v,
+            PinCandidates::FullScanRequired => panic!("expected Delta, got FullScanRequired"),
+        }
+    }
+
+    #[test]
+    fn single_new_commit_delta_excludes_preexisting_objects() {
+        let repo = Repo::new();
+        let c1 = repo.commit_file("a.txt", "one\n");
+        let c2 = repo.commit_file("b.txt", "two\n");
+        let got: HashSet<String> = delta(resolve_push_delta(&repo.path, &[&c2], &[&c1]))
+            .into_iter()
+            .collect();
+        // The new blob b.txt and commit c2 are in the delta; the old blob a.txt
+        // and commit c1 are not.
+        let new_blob = repo.rev("HEAD:b.txt");
+        let old_blob = repo.rev(&format!("{c1}:a.txt"));
+        assert!(got.contains(&c2), "new commit in delta");
+        assert!(got.contains(&new_blob), "new blob in delta");
+        assert!(!got.contains(&c1), "old commit excluded");
+        assert!(!got.contains(&old_blob), "old blob excluded");
+    }
+
+    #[test]
+    fn created_ref_is_superset_of_new_objects() {
+        // A created ref (old tip all-zeros, filtered out by caller) with no old
+        // tips walks everything reachable from the new tip — a superset of the
+        // genuinely new objects, never fewer.
+        let repo = Repo::new();
+        let c1 = repo.commit_file("a.txt", "one\n");
+        let got: HashSet<String> = delta(resolve_push_delta(&repo.path, &[&c1], &[]))
+            .into_iter()
+            .collect();
+        assert!(got.contains(&c1));
+        assert!(got.contains(&repo.rev("HEAD:a.txt")));
+        assert!(got.contains(&repo.rev("HEAD^{tree}")));
+    }
+
+    #[test]
+    fn force_push_delta_is_objects_unique_to_new_tip() {
+        let repo = Repo::new();
+        let base = repo.commit_file("a.txt", "one\n");
+        let old_tip = repo.commit_file("b.txt", "two\n");
+        // Rewrite history: reset to base, commit a different file.
+        repo.git(&["reset", "-q", "--hard", &base]);
+        let new_tip = repo.commit_file("c.txt", "three\n");
+        let got: HashSet<String> = delta(resolve_push_delta(&repo.path, &[&new_tip], &[&old_tip]))
+            .into_iter()
+            .collect();
+        assert!(got.contains(&new_tip), "new tip in delta");
+        assert!(got.contains(&repo.rev(&format!("{new_tip}:c.txt"))));
+        // No error; force-push computes new-minus-old cleanly.
+    }
+
+    #[test]
+    fn deleted_ref_only_yields_empty_delta_without_git() {
+        let repo = Repo::new();
+        repo.commit_file("a.txt", "one\n");
+        // All updates were deletions => new_tips empty after the caller strips zeros.
+        assert_eq!(
+            resolve_push_delta(&repo.path, &[], &[ZERO]),
+            PinCandidates::Delta(Vec::new())
+        );
+    }
+
+    #[test]
+    fn blob_tip_forces_full_scan() {
+        let repo = Repo::new();
+        repo.commit_file("a.txt", "one\n");
+        let blob = repo.rev("HEAD:a.txt");
+        assert_eq!(
+            resolve_push_delta(&repo.path, &[&blob], &[]),
+            PinCandidates::FullScanRequired,
+            "a blob tip must force full scan (rev-list would exit 0 and walk it)"
+        );
+    }
+
+    #[test]
+    fn tree_tip_forces_full_scan() {
+        let repo = Repo::new();
+        repo.commit_file("a.txt", "one\n");
+        let tree = repo.rev("HEAD^{tree}");
+        assert_eq!(
+            resolve_push_delta(&repo.path, &[&tree], &[]),
+            PinCandidates::FullScanRequired
+        );
+    }
+
+    #[test]
+    fn annotated_tag_of_tree_forces_full_scan() {
+        let repo = Repo::new();
+        repo.commit_file("a.txt", "one\n");
+        let tree = repo.rev("HEAD^{tree}");
+        repo.git(&["tag", "-a", "treetag", "-m", "x", &tree]);
+        let tag = repo.rev("treetag");
+        assert_eq!(
+            resolve_push_delta(&repo.path, &[&tag], &[]),
+            PinCandidates::FullScanRequired,
+            "annotated tag peeling to a tree must force full scan"
+        );
+    }
+
+    #[test]
+    fn tag_of_tag_of_noncommit_forces_full_scan() {
+        let repo = Repo::new();
+        repo.commit_file("a.txt", "one\n");
+        let blob = repo.rev("HEAD:a.txt");
+        repo.git(&["tag", "-a", "t1", "-m", "x", &blob]);
+        let t1 = repo.rev("t1");
+        repo.git(&["tag", "-a", "t2", "-m", "x", &t1]);
+        let t2 = repo.rev("t2");
+        assert_eq!(
+            resolve_push_delta(&repo.path, &[&t2], &[]),
+            PinCandidates::FullScanRequired
+        );
+    }
+
+    #[test]
+    fn annotated_tag_of_commit_proceeds_as_delta() {
+        // DISCRIMINATING positive-path regression: an annotated tag whose peeled
+        // target is a commit must return Delta, not FullScanRequired. A
+        // FullScanRequired here means the guard used bare `cat-file -t` (returns
+        // `tag`) instead of the `^{}` peel.
+        let repo = Repo::new();
+        let c1 = repo.commit_file("a.txt", "one\n");
+        repo.git(&["tag", "-a", "rel", "-m", "release", &c1]);
+        let tag = repo.rev("rel");
+        let got: HashSet<String> = delta(resolve_push_delta(&repo.path, &[&tag], &[]))
+            .into_iter()
+            .collect();
+        assert!(got.contains(&c1), "peeled commit's objects are in the delta");
+    }
+
+    #[test]
+    fn missing_oid_tip_forces_full_scan() {
+        let repo = Repo::new();
+        repo.commit_file("a.txt", "one\n");
+        let bogus = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        assert_eq!(
+            resolve_push_delta(&repo.path, &[bogus], &[]),
+            PinCandidates::FullScanRequired,
+            "a missing/corrupt tip OID must force full scan"
+        );
+    }
+
+    #[test]
+    fn present_noncommit_old_tip_is_safe() {
+        // A present-but-non-commit old_sha (a --not arg) must not under-pin:
+        // either rev-list errors (FullScanRequired) or it over-lists (Delta).
+        // Either way the new tip's objects are covered; never fewer.
+        let repo = Repo::new();
+        let c1 = repo.commit_file("a.txt", "one\n");
+        let c2 = repo.commit_file("b.txt", "two\n");
+        let old_tree = repo.rev(&format!("{c1}^{{tree}}"));
+        let result = resolve_push_delta(&repo.path, &[&c2], &[&old_tree]);
+        match result {
+            PinCandidates::FullScanRequired => {} // safe: caller full-scans
+            PinCandidates::Delta(objs) => {
+                // Safe direction: must still contain the new commit (over-list ok).
+                assert!(objs.contains(&c2), "new tip objects must be covered");
+            }
+        }
+    }
+
+    #[test]
+    fn multi_ref_push_unions_ranges() {
+        let repo = Repo::new();
+        let base = repo.commit_file("a.txt", "one\n");
+        // branch1 advances
+        let b1 = repo.commit_file("b.txt", "two\n");
+        // branch2 from base advances independently
+        repo.git(&["checkout", "-q", "-b", "branch2", &base]);
+        let b2 = repo.commit_file("c.txt", "three\n");
+        let got: HashSet<String> =
+            delta(resolve_push_delta(&repo.path, &[&b1, &b2], &[&base, &base]))
+                .into_iter()
+                .collect();
+        assert!(got.contains(&b1), "branch1 new commit");
+        assert!(got.contains(&b2), "branch2 new commit");
+    }
+
+    #[test]
+    fn empty_repo_no_tips_yields_empty_delta() {
+        let repo = Repo::new();
+        assert_eq!(
+            resolve_push_delta(&repo.path, &[], &[]),
+            PinCandidates::Delta(Vec::new())
+        );
+    }
+
+    #[test]
+    fn force_full_scan_flag_overrides() {
+        // Test the kill-switch via the pure inner fn so we never touch
+        // process-global env (which would race with parallel tests, and is
+        // unsafe in Rust 2024). The public resolve_push_delta wires the env
+        // read into this same flag.
+        let repo = Repo::new();
+        let c1 = repo.commit_file("a.txt", "one\n");
+        assert_eq!(
+            resolve_push_delta_inner(&repo.path, &[&c1], &[], true),
+            PinCandidates::FullScanRequired
+        );
+        // And with the flag off, the same push yields a Delta.
+        assert!(matches!(
+            resolve_push_delta_inner(&repo.path, &[&c1], &[], false),
+            PinCandidates::Delta(_)
+        ));
+    }
+
+    #[test]
+    fn list_all_objects_returns_full_repo() {
+        let repo = Repo::new();
+        repo.commit_file("a.txt", "one\n");
+        repo.commit_file("b.txt", "two\n");
+        let all = list_all_objects(&repo.path).unwrap();
+        // 2 commits + 2 trees + 2 blobs = 6 objects.
+        assert_eq!(all.len(), 6, "got: {all:?}");
+    }
+}

--- a/crates/gitlawb-node/src/git/push_delta.rs
+++ b/crates/gitlawb-node/src/git/push_delta.rs
@@ -20,7 +20,7 @@
 //! --no-object-names` is safe here. The "rev-list reports one path per object"
 //! trap from #84 applies only to `visibility_pack`'s per-path `ls-tree` walk.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
@@ -68,6 +68,8 @@ fn force_full_scan() -> bool {
     std::env::var_os(FORCE_FULL_SCAN_ENV).is_some()
 }
 
+// Intentionally private but reachable from the test module (via `use super::*`)
+// so the kill-switch can be exercised without mutating process-global env.
 fn resolve_push_delta_inner(
     repo_path: &Path,
     new_tips: &[&str],
@@ -187,6 +189,51 @@ pub fn list_all_objects(repo_path: &Path) -> Result<Vec<String>> {
         .map(|l| l.trim().to_string())
         .filter(|l| !l.is_empty())
         .collect())
+}
+
+/// Resolve the pin candidate OID set for a push, off the async worker.
+///
+/// Runs [`resolve_push_delta`] in `spawn_blocking` (git subprocess) and applies
+/// the full-scan fallback for [`PinCandidates::FullScanRequired`]. Owns the
+/// dispatch so the push call site stays thin and this wiring is unit-testable
+/// without the HTTP layer.
+///
+/// Every degraded path is **logged**, not silent: a full-scan fallback, a
+/// failed full scan, and a panicked blocking task each emit a warning. On a
+/// failed full scan or a task panic the candidate set is empty (pin nothing
+/// this push); that is a durability gap the reconciliation sweep backstops, and
+/// it can never leak because the withheld filter still runs on whatever set is
+/// returned.
+pub async fn resolve_candidates_for_push(
+    repo_path: PathBuf,
+    new_tips: Vec<String>,
+    old_tips: Vec<String>,
+) -> Vec<String> {
+    tokio::task::spawn_blocking(move || {
+        let new_refs: Vec<&str> = new_tips.iter().map(String::as_str).collect();
+        let old_refs: Vec<&str> = old_tips.iter().map(String::as_str).collect();
+        match resolve_push_delta(&repo_path, &new_refs, &old_refs) {
+            PinCandidates::Delta(objs) => {
+                tracing::info!(delta = objs.len(), repo = %repo_path.display(), "pin candidate set from push delta");
+                objs
+            }
+            PinCandidates::FullScanRequired => {
+                tracing::warn!(repo = %repo_path.display(), "pin delta unavailable (non-commit tip, git error, or force-full-scan) — full-scan fallback");
+                match list_all_objects(&repo_path) {
+                    Ok(objs) => objs,
+                    Err(e) => {
+                        tracing::warn!(repo = %repo_path.display(), err = %e, "full-scan fallback failed; pinning nothing this push (reconciliation sweep backstops)");
+                        Vec::new()
+                    }
+                }
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|e| {
+        tracing::warn!(err = %e, "pin candidate computation task panicked; pinning nothing this push (reconciliation sweep backstops)");
+        Vec::new()
+    })
 }
 
 #[cfg(test)]
@@ -372,7 +419,66 @@ mod tests {
         let got: HashSet<String> = delta(resolve_push_delta(&repo.path, &[&tag], &[]))
             .into_iter()
             .collect();
-        assert!(got.contains(&c1), "peeled commit's objects are in the delta");
+        assert!(
+            got.contains(&c1),
+            "peeled commit's objects are in the delta"
+        );
+    }
+
+    #[test]
+    fn tag_of_tag_of_commit_proceeds_as_delta() {
+        // Deep-peel positive path: tag -> tag -> commit must recurse to `commit`
+        // via `^{}` and return Delta. Complements tag_of_tag_of_noncommit (which
+        // forces full scan) — guards against a regression in peel depth that
+        // would silently downgrade a legitimate nested-tag push to full scan.
+        let repo = Repo::new();
+        let c1 = repo.commit_file("a.txt", "one\n");
+        repo.git(&["tag", "-a", "t1", "-m", "x", &c1]);
+        let t1 = repo.rev("t1");
+        repo.git(&["tag", "-a", "t2", "-m", "x", &t1]);
+        let t2 = repo.rev("t2");
+        let got: HashSet<String> = delta(resolve_push_delta(&repo.path, &[&t2], &[]))
+            .into_iter()
+            .collect();
+        assert!(
+            got.contains(&c1),
+            "peeled commit's objects are in the delta"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_candidates_for_push_returns_delta() {
+        // The extracted wiring returns the per-push delta on the happy path.
+        let repo = Repo::new();
+        let c1 = repo.commit_file("a.txt", "one\n");
+        let c2 = repo.commit_file("b.txt", "two\n");
+        let got: HashSet<String> =
+            resolve_candidates_for_push(repo.path.clone(), vec![c2.clone()], vec![c1.clone()])
+                .await
+                .into_iter()
+                .collect();
+        let new_blob = repo.rev("HEAD:b.txt");
+        assert!(
+            got.contains(&c2) && got.contains(&new_blob),
+            "new objects pinned"
+        );
+        assert!(!got.contains(&c1), "old commit excluded from delta");
+    }
+
+    #[tokio::test]
+    async fn resolve_candidates_for_push_falls_back_to_full_scan_on_noncommit_tip() {
+        // A non-commit tip forces FullScanRequired, and the wiring resolves that
+        // to the whole-repo list (a superset), never an empty set.
+        let repo = Repo::new();
+        repo.commit_file("a.txt", "one\n");
+        let blob = repo.rev("HEAD:a.txt");
+        let all: HashSet<String> = list_all_objects(&repo.path).unwrap().into_iter().collect();
+        let got: HashSet<String> =
+            resolve_candidates_for_push(repo.path.clone(), vec![blob], vec![])
+                .await
+                .into_iter()
+                .collect();
+        assert_eq!(got, all, "non-commit tip falls back to full repo scan");
     }
 
     #[test]

--- a/crates/gitlawb-node/src/ipfs_pin.rs
+++ b/crates/gitlawb-node/src/ipfs_pin.rs
@@ -85,13 +85,20 @@ pub async fn cat(ipfs_api: &str, cid: &str) -> Result<Vec<u8>> {
     Ok(resp.bytes().await?.to_vec())
 }
 
-/// List all git objects in the given bare repo and pin any that are not yet
-/// recorded in `pinned_cids`.
+/// Pin any of the given candidate git objects that are not yet recorded in
+/// `pinned_cids`.
+///
+/// `candidates` is the OID set to consider — the per-push delta on the push
+/// path, or the whole-repo list on the reconciliation sweep / full-scan
+/// fallback (see `git::push_delta`). `repo_path` is still needed to read each
+/// object's bytes. The twin in `pinata.rs` mirrors this shape — change both in
+/// lockstep.
 ///
 /// Returns a list of `(sha256_hex, cid)` pairs for objects pinned this call.
 pub async fn pin_new_objects(
     ipfs_api: &str,
     repo_path: &std::path::Path,
+    candidates: Vec<String>,
     db: &crate::db::Db,
     withheld: &HashSet<String>,
 ) -> Vec<(String, String)> {
@@ -99,16 +106,7 @@ pub async fn pin_new_objects(
         return vec![];
     }
 
-    // Enumerate all objects in the repo
-    let object_list = match list_all_objects(repo_path) {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!(repo = %repo_path.display(), err = %e, "failed to list git objects for IPFS pinning");
-            return vec![];
-        }
-    };
-
-    let object_list = crate::git::visibility_pack::replicable_objects(object_list, withheld);
+    let object_list = crate::git::visibility_pack::replicable_objects(candidates, withheld);
 
     let mut pinned = Vec::new();
 
@@ -149,32 +147,4 @@ pub async fn pin_new_objects(
     }
 
     pinned
-}
-
-/// Run `git cat-file --batch-all-objects --batch-check='%(objectname)'`
-/// to get all object SHA-256 hashes in the repository.
-fn list_all_objects(repo_path: &std::path::Path) -> Result<Vec<String>> {
-    let output = std::process::Command::new("git")
-        .args([
-            "cat-file",
-            "--batch-all-objects",
-            "--batch-check=%(objectname)",
-        ])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| anyhow::anyhow!("failed to run git cat-file: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(anyhow::anyhow!("git cat-file failed: {stderr}"));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let hashes = stdout
-        .lines()
-        .map(|l| l.trim().to_string())
-        .filter(|l| !l.is_empty())
-        .collect();
-
-    Ok(hashes)
 }

--- a/crates/gitlawb-node/src/pinata.rs
+++ b/crates/gitlawb-node/src/pinata.rs
@@ -67,15 +67,21 @@ pub async fn pin_object(
     Ok(cid)
 }
 
-/// Pin all git objects in a repo that haven't yet been sent to Pinata.
+/// Pin any of the given candidate git objects that haven't yet been sent to
+/// Pinata.
 ///
-/// Objects already recorded with a `pinata_cid` in the DB are skipped.
+/// `candidates` is the OID set to consider — the per-push delta on the push
+/// path, or the whole-repo list on the reconciliation sweep / full-scan
+/// fallback (see `git::push_delta`). `repo_path` is still needed to read each
+/// object's bytes. The twin in `ipfs_pin.rs` mirrors this shape — change both
+/// in lockstep. Objects already recorded with a `pinata_cid` are skipped.
 /// Returns `(sha_hex, cid)` pairs for each newly pinned object.
 pub async fn pin_new_objects(
     client: &reqwest::Client,
     upload_url: &str,
     jwt: &str,
     repo_path: &std::path::Path,
+    candidates: Vec<String>,
     db: &crate::db::Db,
     withheld: &HashSet<String>,
 ) -> Vec<(String, String)> {
@@ -83,18 +89,7 @@ pub async fn pin_new_objects(
         return vec![];
     }
 
-    let object_list = match list_all_objects(repo_path) {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::warn!(
-                repo = %repo_path.display(),
-                err = %e,
-                "failed to list git objects for Pinata upload"
-            );
-            return vec![];
-        }
-    };
-    let object_list = crate::git::visibility_pack::replicable_objects(object_list, withheld);
+    let object_list = crate::git::visibility_pack::replicable_objects(candidates, withheld);
 
     let mut pinned = Vec::new();
 
@@ -132,29 +127,6 @@ pub async fn pin_new_objects(
     }
 
     pinned
-}
-
-fn list_all_objects(repo_path: &std::path::Path) -> Result<Vec<String>> {
-    let out = std::process::Command::new("git")
-        .args([
-            "cat-file",
-            "--batch-all-objects",
-            "--batch-check=%(objectname)",
-        ])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| anyhow::anyhow!("failed to run git cat-file: {e}"))?;
-
-    if !out.status.success() {
-        let stderr = String::from_utf8_lossy(&out.stderr);
-        return Err(anyhow::anyhow!("git cat-file failed: {stderr}"));
-    }
-
-    Ok(String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .map(|l| l.trim().to_string())
-        .filter(|l| !l.is_empty())
-        .collect())
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Pin only the objects a push actually introduces, instead of re-enumerating the entire repository on every push. Pin cost now scales with push size rather than total repo size.

## Motivation & context

After each push the IPFS and Pinata pin paths ran `git cat-file --batch-all-objects` over the whole repo and then a per-object DB lookup, so a one-commit push to a large repo walked and checked every object in history. The post-receive handler already has the push's ref updates (old/new tips) in scope, so the introduced objects are computable directly.

No tracked issue for this one; it came out of a performance pass on the replication path.

## Kind of change

- [ ] Bug fix
- [x] Feature
- [ ] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

Crate touched: `gitlawb-node`.

- New `git::push_delta` module. `resolve_push_delta` computes the per-push delta with `git rev-list --objects --no-object-names <new tips> --not <old tips>`. It fails closed to a full scan (returns `FullScanRequired`) on a non-commit tip, any git error, or the `GITLAWB_PIN_FORCE_FULLSCAN` kill-switch. The non-commit guard peels fully with `git cat-file -t '<sha>^{}'` (a bare `cat-file -t` returns `tag` for an annotated tag, and `rev-list` does not error on a non-commit tip, so neither can be the guard).
- `pin_new_objects` in both `ipfs_pin` and `pinata` now take the candidate OID set from the caller instead of scanning the repo themselves. The two identical `list_all_objects` copies collapse into one in `push_delta`. The withheld filter and per-object DB dedup downstream are unchanged.
- Extracted the anonymous replication withheld gate (`caller = None`) into a shared `replication_withheld_set` helper returning `(announce, withheld)`, so the push path and a future reconciliation sweep cannot drift. The per-caller read-serve withheld computation in `git_upload_pack` is deliberately left separate (it filters per requester, not for anonymous replication).
- `resolve_candidates_for_push` owns the dispatch and logs every degraded path (fallback taken, fallback failed, task panicked) rather than silently pinning nothing.

## How a reviewer can verify

```sh
cargo test -p gitlawb-node push_delta       # delta + all degenerate states (blob/tree/tag/tag-of-tag tips, force-push, multi-ref, missing OID, fallback)
cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
# Optional: set GITLAWB_PIN_FORCE_FULLSCAN=1 to force the old whole-repo behavior.
```

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally
- [x] New behavior is covered by tests (required for fixes)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`feat(...)`, `fix(...)`, `docs(...)`)
- [x] Docs / `.env.example` updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Notes for reviewers

- Security framing: narrowing the pin enumeration only shrinks the per-push exposure set, so it cannot cause an under-withholding leak. The withheld filter still runs on whatever candidate set arrives (delta, full-scan fallback, or empty). The only risk it introduces is bounded under-pinning (a durability gap), not a leak.
- That durability gap is backstopped by a reconciliation sweep that is intentionally **not** in this PR. The sweep is a full-history caller of the withheld walk, so it depends on the history-deep `blob_paths` fix from #84 landing on `main` first. Holding it as a follow-up keeps this change to the pin-enumeration side only.
- Known edge: a bulk `--mirror` push spawns one `cat-file` per ref. Fine for ordinary pushes; batchable with a single `cat-file --batch` session if bulk pushes become common.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added delta-based pinning for push operations, pinning only newly introduced objects instead of scanning the full repository each time.

* **Refactor**
  * Centralized replication “fail-closed” gating for anonymous replication and updated push replication enforcement to use it.
  * Updated the IPFS and Pinata pinning flows to accept a per-push candidate object set derived from the push.

* **Tests**
  * Added a comprehensive test suite for push delta candidate resolution, including fail-closed and kill-switch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->