### PR TITLE
fix(core): zeroize the derived X25519 secret (#65)

### DIFF
--- a/crates/gitlawb-core/src/encrypt.rs
+++ b/crates/gitlawb-core/src/encrypt.rs
@@ -6,6 +6,7 @@
 use crate::identity::Keypair;
 use anyhow::{Context, Result};
 use ed25519_dalek::VerifyingKey;
+use zeroize::Zeroizing;
 
 /// X25519 public key (Montgomery u) for an Ed25519 verifying key.
 fn x25519_public(vk: &VerifyingKey) -> Result<[u8; 32]> {
@@ -18,14 +19,18 @@ fn x25519_public(vk: &VerifyingKey) -> Result<[u8; 32]> {
 }
 
 /// X25519 secret scalar for an Ed25519 seed (SHA-512 of seed, lower 32, clamped).
-fn x25519_secret_from_seed(seed: &[u8; 32]) -> [u8; 32] {
+/// Returns the scalar wrapped in `Zeroizing`, and scrubs the intermediate
+/// SHA-512 digest, so no copy of this secret material lingers in freed memory.
+fn x25519_secret_from_seed(seed: &[u8; 32]) -> Zeroizing<[u8; 32]> {
     use sha2::{Digest, Sha512};
-    let h = Sha512::digest(seed);
-    let mut s = [0u8; 32];
+    use zeroize::Zeroize;
+    let mut h = Sha512::digest(seed);
+    let mut s = Zeroizing::new([0u8; 32]);
     s.copy_from_slice(&h[..32]);
     s[0] &= 248;
     s[31] &= 127;
     s[31] |= 64;
+    h.as_mut_slice().zeroize();
     s
 }
 
@@ -123,7 +128,7 @@ pub fn open_blob(envelope: &[u8], keypair: &Keypair) -> Result<Vec<u8>> {
             .context("decode header")?;
     let body = &envelope[p + hlen..];
 
-    let my_x = XSecret::from(x25519_secret_from_seed(&keypair.to_seed()));
+    let my_x = XSecret::from(*x25519_secret_from_seed(&keypair.to_seed()));
 
     // Identities are blinded: no entry says which recipient it belongs to, so
     // try each one. The ChaChaBox AEAD tag authenticates, so exactly the
@@ -188,7 +193,7 @@ mod tests {
         let seed = kp.to_seed();
         let xpub_from_public = x25519_public(&kp.verifying_key()).unwrap();
         let xsec = x25519_secret_from_seed(&seed);
-        let xpub_from_secret = crypto_box::SecretKey::from(xsec).public_key().to_bytes();
+        let xpub_from_secret = crypto_box::SecretKey::from(*xsec).public_key().to_bytes();
         assert_eq!(xpub_from_public, xpub_from_secret);
     }
 


### PR DESCRIPTION
Re-lands the #65 fix that was reviewed and merged in #66 but never reached main.

#66 was stacked on #64 and targeted `fix/zeroize-seed-bytes` as its base. #64 merged to main about a minute before #66 merged, so #66's commit landed on the already-retired stacked base and never propagated to main. The accessor signature on main still returns a bare `[u8; 32]`, so issue #65 is still open. This PR puts the same reviewed change on main directly.

## What it does

`x25519_secret_from_seed` derived the X25519 private scalar and returned it as a bare `[u8; 32]`. Because that type is `Copy` with no `Drop` (and `sha2`'s digest output has no zeroize), the scalar, the SHA-512 digest, and the returned temporary were released without being scrubbed, leaving secret-derived material in freed memory. Same `Copy`-no-`Drop` class fixed for the raw seed in #41, one hop downstream on the derived secret.

The fix returns `Zeroizing<[u8; 32]>`, builds the scalar directly into a zeroizing buffer so no bare secret local persists, and explicitly wipes the SHA-512 digest before it drops. The two callers (`open_blob` and the crypto test) deref into `crypto_box::SecretKey`, which already scrubs its own copy.

## Scope

Memory hygiene only. No change to the encryption scheme, key derivation, or wire format. The derived scalar and all decryption output are byte-identical, covered by the existing `seal_open_round_trip_for_recipients` and `ed25519_to_x25519_keypair_agrees` tests. Not remotely exploitable; defense-in-depth against core dumps, swap, and memory-disclosure bugs.

## Verification

- `cargo build -p gitlawb-core`, clippy clean
- All `encrypt` unit tests pass, including the two round-trip tests that would fail on any scalar divergence
- MSRV 1.91 confirmed for `Zeroizing` and `GenericArray::as_mut_slice().zeroize()`

Closes #65.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined internal cryptographic key handling in the encryption module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->