### PR TITLE
fix(repos): log the cause when repo create fails

### DIFF
--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -158,7 +158,12 @@ pub async fn create_repo(
         .repo_store
         .init(&owner_did, &req.name)
         .await
-        .map_err(|e| AppError::Git(e.to_string()))?;
+        .map_err(|e| {
+            // `{:#}` walks the anyhow chain to the leaf cause; the other git
+            // handlers log their failures, this one didn't.
+            tracing::error!(owner = %owner_did, repo = %req.name, err = %format!("{e:#}"), "repo create failed");
+            AppError::Git(e.to_string())
+        })?;
 
     let now = Utc::now();
     let record = crate::db::RepoRecord {


### PR DESCRIPTION
## What

`create_repo` was the one git-backed handler that mapped its error without logging it. `info_refs`, `receive_pack`, and `acquire` all `tracing::error!` with `repo`/`service` context on failure; `create_repo` just did `.map_err(|e| AppError::Git(e.to_string()))?`.

So a failed `POST /api/v1/repos` returns an opaque `500 {"error":"git_error","message":"initializing bare repo"}` with no server-side trail to the real cause. `to_string()` on the `anyhow::Error` keeps only the outer `.context(...)`, and nothing logs the rest, so the underlying `init_bare` failure (the `git init` stderr, a filesystem error like `No space left on device`, and so on) is lost.

## Change

`create_repo` now logs the full chain on failure (`{:#}`, so the leaf cause is kept) with `owner`/`repo` context, matching the other git handlers. The response is unchanged, the detail goes to the logs only, not the client.

One handler, one log line. No status codes, routes, response bodies, or control flow change.

## Note

This makes a failure diagnosable, it doesn't fix whatever the underlying `init_bare` failure is (that looked environment-specific when I hit it against a live node, the `git init` itself is fine). The point is the next one shows up in the logs with its cause instead of as a bare 500.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository creation error handling so setup failures are surfaced more reliably.
  * Added clearer, formatted error logging when repository initialization fails, making it easier to diagnose troubleshooting issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->