### PR TITLE
chore(deps): bump tar to 0.4.46 and rand to 0.9.3 to clear advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -2107,7 +2107,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2262,7 +2262,7 @@ checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
  "digest 0.10.7",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "rustversion",
 ]
@@ -2928,7 +2928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3599,7 +3599,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -3621,7 +3621,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.3",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -4536,7 +4536,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -5283,7 +5283,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -5350,7 +5350,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -5417,9 +5417,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5739,7 +5739,7 @@ dependencies = [
  "primitive-types",
  "proptest",
  "rand 0.8.6",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -5802,7 +5802,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6677,9 +6677,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -6696,7 +6696,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7059,7 +7059,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",


### PR DESCRIPTION
Two lockfile-only security bumps, no manifest or source changes.

- `tar` 0.4.45 -> 0.4.46 clears the PAX header desynchronization issue (GHSA-3pv8-6f4r-ffg2, medium). We use tar in `crates/gitlawb-node/src/git/tigris.rs` for archive read/write, which is the affected read path; the fix is behavior-preserving.
- `rand` 0.9.2 -> 0.9.3 clears the `rand::rng()` custom-logger unsoundness (GHSA-cq8v-f236-94qc, low). Our own code only uses `OsRng`/`RngCore`, never `rand::rng()`, so this is hygiene for transitive users rather than a path we were exposed on. `rand` 0.8.6 stays, it is outside the vulnerable range.

These bumps carry no Cargo.toml version-requirement changes. The `cargo update` did move four packages onto older `windows-sys` selections already present in the tree, a normal resolver side-effect with no Windows target in our build:

- `colored`: `windows-sys` 0.61.2 -> 0.48.0
- `errno`: `windows-sys` 0.61.2 -> 0.52.0
- `rustix`: `windows-sys` 0.61.2 -> 0.52.0
- `tempfile`: `windows-sys` 0.61.2 -> 0.52.0

Left alone, with reason:
- `lru` 0.12.5 (GHSA-rhfx-m35p-ff5j, low) is pinned by aws-sdk-s3 (`lru ^0.12.2`) and cannot move to the 0.16.3 fix until aws-sdk-s3 bumps it.
- The two hickory-proto advisories remain accepted risk per `.cargo/audit.toml`, tracked in #76 (waiting on libp2p-dns to ship hickory 0.26).

Verification: `cargo build -p gitlawb-node`, `cargo test -p gitlawb-node` (220 passed), and `cargo audit` all pass; the tar and rand advisories no longer appear.
