### PR TITLE
ci(triage): label fork PRs and stop auto-closing PRs that only lack an issue link

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -68,8 +68,8 @@ jobs:
             if (isFork && touchesWorkflows) want.add("workflow-change");
 
             const changedRust = names.some(n => n.startsWith("crates/") && n.endsWith(".rs"));
-            // A test can live in a tests/ dir, a *_test.rs file, or — the common Rust
-            // pattern — an inline #[test] / #[cfg(test)] block added inside the source file.
+            // A test can live in a tests/ dir, a *_test.rs file, or (the common Rust
+            // pattern) an inline #[test] / #[cfg(test)] block added inside the source file.
             const addsInlineTest = files.some(f =>
               f.filename.endsWith(".rs") && f.patch &&
               /^\+.*#\[(test\]|cfg\(test\))/m.test(f.patch));
@@ -108,7 +108,7 @@ jobs:
 
             const reasons = {
               "needs-issue": "Link the issue this addresses (`Closes #123`). For protocol changes, open an issue first.",
-              "needs-description": "Add a short summary of what changes and why — the template's Summary and Motivation sections.",
+              "needs-description": "Add a short summary of what changes and why: the template's Summary and Motivation sections.",
               "needs-tests": "This changes Rust source but no tests changed. Tests are required for fixes and strongly encouraged for features.",
             };
             const lines = advisory.map(l => `- ${reasons[l]}`).join("\n");

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,7 +1,11 @@
 name: PR Triage
 
+# Runs on pull_request_target, not pull_request: fork PRs get a read-only
+# GITHUB_TOKEN under pull_request regardless of the permissions below, so the
+# label/comment writes 403. This job never checks out or runs PR head code (it
+# only reads context.payload and the files API), so pull_request_target is safe.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,8 +23,10 @@ jobs:
           # Act on PRs only; never on issues.
           days-before-issue-stale: -1
           days-before-issue-close: -1
-          # Only PRs the triage step flagged as needing an author response.
-          only-pr-labels: "needs-issue,needs-description"
+          # Only PRs the triage step flagged as missing a real description.
+          # needs-issue is advisory-only (linking an issue is a SHOULD, and many
+          # legitimate small PRs have none) so it does not drive auto-close.
+          only-pr-labels: "needs-description"
           stale-pr-label: "stale"
           exempt-pr-labels: "workflow-change,security,pinned"
           remove-stale-when-updated: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,10 +31,9 @@ jobs:
           exempt-pr-labels: "workflow-change,security,pinned"
           remove-stale-when-updated: true
           stale-pr-message: >
-            This PR has been inactive for 14 days and is still missing a linked issue
-            or a description. It will be closed in 7 days if there's no update. Push a
-            change or leave a comment to keep it open — no hard feelings, you can reopen
-            anytime.
+            This PR has been inactive for 14 days and is still missing a description.
+            It will be closed in 7 days if there's no update. Push a change or leave a
+            comment to keep it open — no hard feelings, you can reopen anytime.
           close-pr-message: >
             Closing due to inactivity. Reopen whenever you're ready to update it — see
             CONTRIBUTING.md for what helps us review quickly.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,8 +33,8 @@ jobs:
           stale-pr-message: >
             This PR has been inactive for 14 days and is still missing a description.
             It will be closed in 7 days if there's no update. Push a change or leave a
-            comment to keep it open — no hard feelings, you can reopen anytime.
+            comment to keep it open. No hard feelings, you can reopen anytime.
           close-pr-message: >
-            Closing due to inactivity. Reopen whenever you're ready to update it — see
+            Closing due to inactivity. Reopen whenever you're ready to update it. See
             CONTRIBUTING.md for what helps us review quickly.
           ascending: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,9 +69,10 @@ expected to clear a basic quality bar:
 - **A real description.** Say what changes and why. "Update code" is not a description.
 
 A triage bot labels PRs that are missing these and leaves a short note. Nothing is closed
-automatically while you're engaging. A flagged PR that goes 14 days with no linked issue or
-description gets a stale warning, and is closed 7 days later if still untouched. Closed PRs can
-be reopened at any time once updated.
+automatically while you're engaging. A flagged PR still missing a description after 14 days of
+inactivity gets a stale warning, and is closed 7 days later if still untouched. A missing issue
+link alone never triggers closure; that label stays advisory. Closed PRs can be reopened at any
+time once updated.
 
 ## Development environment
 


### PR DESCRIPTION
## What

The PR triage bot has never labeled a single PR. Both of its target populations fall through:

- Trusted authors (`OWNER`/`MEMBER`/`COLLABORATOR`) hit the early-return bypass and skip triage entirely.
- Everyone else opens from a fork, where `on: pull_request` gives the job a read-only `GITHUB_TOKEN` regardless of the `permissions:` block, so `addLabels`/`createComment` fail with `403 Resource not accessible by integration`.

That second case is the visible one: it's the red `Quality-signal triage` check on every external contributor's PR (e.g. #103). Because the labels never get applied, the downstream stale→close pipeline (`stale.yml` keys off `needs-issue`/`needs-description`) has also been inert for forks. The advertised flag-then-close flow in CONTRIBUTING.md simply never ran for the contributors it was written for.

## Changes

**`pr-triage.yml`: `pull_request` → `pull_request_target`.** This runs the job in the base-repo context with the declared write token, even for forks. It's safe here specifically because the job never checks out or executes PR head code: it only reads `context.payload.pull_request`, calls the read-only files API, regex-scans patch strings in `actions/github-script`, and writes labels/comments. None of the untrusted-code-execution risk that makes `pull_request_target` dangerous applies. The heavy CI in `pr-checks.yml` stays on `pull_request` and keeps its first-time-contributor approval gate.

**`stale.yml`: drop `needs-issue` from `only-pr-labels`.** Linking an issue is a SHOULD in CONTRIBUTING (required only for protocol-level changes), and plenty of legitimate small PRs have none. Coupling it to the 14/21-day auto-close meant a substantive, well-described PR could be closed purely for missing an issue reference. `needs-issue` stays as an advisory label and guidance nudge; `needs-description` (a thin/empty body, a far stronger low-effort signal) remains the sole closer.

## Notes

- `pull_request_target` reads the workflow from the base branch, so the fix takes effect for fork PRs only once this merges to `main`. It won't retroactively green an existing failed run.
- The triage check is not a required status check, so none of this changes merge gating; it removes a spurious red X and makes the labeling/stale pipeline actually function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the PR triage workflow to run in a safe, read-only context-only mode for fork pull requests.
  * Updated stale/auto-close behavior so only pull requests with the `needs-description` label are marked stale/closed (missing issue link remains advisory).
* **Chores**
  * Refreshed workflow and contribution documentation text to accurately describe the updated “What gets merged, what gets closed” triage and inactivity rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->