### PR TITLE
feat(node): iCaptcha-aware repo propagation gate with quarantine

### DIFF
--- a/crates/gitlawb-node/src/api/mod.rs
+++ b/crates/gitlawb-node/src/api/mod.rs
@@ -47,6 +47,13 @@ pub(crate) async fn authorize_repo_read(
         .get_repo(owner, name)
         .await?
         .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+    // A quarantined mirror (admitted by the iCaptcha propagation gate but not
+    // validated) is hidden from every reader — serve/clone and fork alike — as if
+    // it did not exist, until an operator releases it. Checked before the
+    // visibility gate so its existence is never disclosed.
+    if state.db.is_repo_quarantined(&record.id).await? {
+        return Err(AppError::RepoNotFound(format!("{owner}/{name}")));
+    }
     let rules = state.db.list_visibility_rules(&record.id).await?;
     if visibility_check(&rules, record.is_public, &record.owner_did, caller, path) == Decision::Deny
     {

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -205,7 +205,7 @@ pub async fn create_repo(
     }
 
     // Request is admissible — spend the proof now, immediately before the write.
-    proof.consume(&state.db).await?;
+    let verified_proof = proof.consume(&state.db).await?;
 
     let disk_path = state
         .repo_store
@@ -229,6 +229,14 @@ pub async fn create_repo(
     };
 
     state.db.create_repo(&record).await?;
+
+    // Persist the proof so it can travel with the repo and a mirroring peer can
+    // re-verify it (enforce-mode origins only; off/shadow yield no proof here).
+    if let Some(p) = verified_proof {
+        if let Err(e) = p.record_for_repo(&state.db, &record.id).await {
+            tracing::warn!(repo = %req.name, err = %e, "failed to record iCaptcha proof for repo");
+        }
+    }
 
     tracing::info!(repo = %req.name, owner = %owner_did, "created repository");
 
@@ -489,6 +497,12 @@ pub async fn git_info_refs(
         .await?
         .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
 
+    // A quarantined mirror is served to no one (clone or push advertisement) —
+    // hidden as repo-not-found until an operator releases it.
+    if state.db.is_repo_quarantined(&record.id).await? {
+        return Err(AppError::RepoNotFound(format!("{owner}/{name}")));
+    }
+
     let service = query
         .service
         .ok_or_else(|| AppError::BadRequest("missing ?service= parameter".into()))?;
@@ -549,6 +563,11 @@ pub async fn git_upload_pack(
         .get_repo(&owner, name)
         .await?
         .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+
+    // A quarantined mirror is never served for clone/fetch.
+    if state.db.is_repo_quarantined(&record.id).await? {
+        return Err(AppError::RepoNotFound(format!("{owner}/{name}")));
+    }
 
     let rules = state.db.list_visibility_rules(&record.id).await?;
     let caller = auth.as_ref().map(|e| e.0 .0.as_str());
@@ -780,6 +799,12 @@ pub async fn git_receive_pack(
         .get_repo(&owner, name)
         .await?
         .ok_or_else(|| AppError::RepoNotFound(format!("{owner}/{name}")))?;
+
+    // A quarantined mirror is hidden from every git endpoint, push included —
+    // it must not accept writes while withheld from clone/fetch.
+    if state.db.is_repo_quarantined(&record.id).await? {
+        return Err(AppError::RepoNotFound(format!("{owner}/{name}")));
+    }
 
     // Parse ref updates from pkt-line body before handing to git
     let ref_updates = parse_ref_updates(&body);
@@ -1457,7 +1482,7 @@ pub async fn fork_repo(
     }
 
     // Request is admissible — spend the proof now, immediately before the write.
-    proof.consume(&state.db).await?;
+    let verified_proof = proof.consume(&state.db).await?;
 
     // Ensure source repo is on local disk (downloads from Tigris on cache miss)
     let source_path = state
@@ -1509,9 +1534,38 @@ pub async fn fork_repo(
 
     state.db.create_repo(&record).await?;
 
+    // Persist the proof so the fork carries it when it propagates to peers.
+    if let Some(p) = verified_proof {
+        if let Err(e) = p.record_for_repo(&state.db, &record.id).await {
+            tracing::warn!(fork = %fork_name, err = %e, "failed to record iCaptcha proof for fork");
+        }
+    }
+
     tracing::info!(fork = %fork_name, source = %source.name, forker = %forker_did, "forked repository");
 
     Ok((StatusCode::CREATED, Json(to_response(&record, &state, 0))))
+}
+
+/// GET /api/v1/repos/{owner}/{repo}/icaptcha-proof
+///
+/// Returns the iCaptcha proof token this repo was created with (`null` if none).
+/// A peer mirroring this repo fetches it and re-verifies it offline before
+/// admitting the mirror (see [`crate::icaptcha::admit_mirror`]). Not owner-gated,
+/// but gated on whole-repo `"/"` read like the other replication endpoints, so a
+/// private repo's proof is never disclosed.
+pub async fn get_icaptcha_proof(
+    State(state): State<AppState>,
+    auth: Option<Extension<AuthenticatedDid>>,
+    Path((owner, repo)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>> {
+    let caller = auth.as_ref().map(|e| e.0 .0.as_str());
+    let (record, _rules) =
+        crate::api::authorize_repo_read(&state, &owner, &repo, caller, "/").await?;
+    let proof = state.db.get_repo_proof_token(&record.id).await?;
+    Ok(Json(serde_json::json!({
+        "repo": format!("{owner}/{repo}"),
+        "proof": proof,
+    })))
 }
 
 // ── Pkt-line parsing ──────────────────────────────────────────────────────

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -796,6 +796,32 @@ const MIGRATIONS: &[Migration] = &[
             "CREATE INDEX IF NOT EXISTS idx_icaptcha_consumed_expires ON icaptcha_consumed_proofs(expires_at)",
         ],
     },
+    Migration {
+        version: 9,
+        name: "icaptcha_propagation",
+        stmts: &[
+            // The iCaptcha proof presented at repo creation, kept so it can travel
+            // with the repo when it propagates to peers. A mirroring node that
+            // enforces iCaptcha re-verifies this token offline before admitting the
+            // mirror (see `icaptcha::admit_mirror`). One row per repo (its creation
+            // proof); rows are best-effort and absent for repos created with the
+            // gate off/in shadow or before this migration.
+            r#"CREATE TABLE IF NOT EXISTS repo_icaptcha_proofs (
+                repo_id     TEXT   NOT NULL PRIMARY KEY,
+                proof_token TEXT   NOT NULL,
+                sub_did     TEXT   NOT NULL,
+                level       INTEGER NOT NULL,
+                jti         TEXT   NOT NULL,
+                exp         BIGINT NOT NULL,
+                created_at  TEXT   NOT NULL
+            )"#,
+            // A mirror admitted by a node that could not validate its proof is
+            // quarantined: kept on disk but hidden from serve/clone and listings
+            // until an operator releases it. Default false; only the mirror
+            // admission path sets it true.
+            "ALTER TABLE repos ADD COLUMN IF NOT EXISTS quarantined BOOLEAN NOT NULL DEFAULT FALSE",
+        ],
+    },
 ];
 
 // ── Repos ─────────────────────────────────────────────────────────────────────
@@ -831,13 +857,17 @@ impl Db {
         name: &str,
         disk_path: &str,
         machine_id: Option<&str>,
+        quarantined: bool,
     ) -> Result<()> {
         let now = Utc::now().to_rfc3339();
         let id = format!("{owner_short}/{name}");
+        // `quarantined` is set only on first insert (the admission decision).
+        // A re-sync (ON CONFLICT) preserves the existing flag — admission runs
+        // once, and an operator's later release must not be silently reverted.
         sqlx::query(
             "INSERT INTO repos (id, name, owner_did, description, is_public, default_branch,
-                                created_at, updated_at, disk_path, machine_id)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                                created_at, updated_at, disk_path, machine_id, quarantined)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
              ON CONFLICT (id) DO UPDATE SET updated_at = $8, disk_path = $9, machine_id = $10",
         )
         .bind(&id)
@@ -850,6 +880,7 @@ impl Db {
         .bind(&now)
         .bind(disk_path)
         .bind(machine_id)
+        .bind(quarantined)
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -909,6 +940,7 @@ impl Db {
              FROM repos r
              LEFT JOIN (SELECT repo_id, COUNT(*) AS cnt FROM repo_stars GROUP BY repo_id) s
                ON s.repo_id = r.id
+             WHERE r.quarantined = FALSE
              ORDER BY r.updated_at DESC",
         )
         .fetch_all(&self.pool)
@@ -953,7 +985,9 @@ impl Db {
                  -- dedup groups on, so a full did:key: form matches a bare-owner
                  -- mirror row (and vice versa) exactly as crate::api::did_matches
                  -- does. Callers bind the already-normalized key ($1).
-                 WHERE ($1::text IS NULL OR (CASE WHEN owner_did LIKE 'did:key:%' AND position(':' in substr(owner_did, 9)) = 0 THEN substr(owner_did, 9) ELSE owner_did END) = $1)
+                 -- Quarantined mirrors (admitted but unvalidated by the iCaptcha
+                 -- propagation gate) are withheld from every listing surface.
+                 WHERE quarantined = FALSE AND ($1::text IS NULL OR (CASE WHEN owner_did LIKE 'did:key:%' AND position(':' in substr(owner_did, 9)) = 0 THEN substr(owner_did, 9) ELSE owner_did END) = $1)
                  ORDER BY CASE WHEN owner_did LIKE 'did:key:%' AND position(':' in substr(owner_did, 9)) = 0 THEN substr(owner_did, 9) ELSE owner_did END, name,
                      -- mirror rows carry a slash-form id (\"{owner_short}/{name}\"),
                      -- written only by upsert_mirror_repo; canonical ids are UUIDs.
@@ -1138,6 +1172,81 @@ impl Db {
             .execute(&self.pool)
             .await?;
         Ok(result.rows_affected())
+    }
+
+    /// Persist the iCaptcha proof a repo was created with so it can travel with
+    /// the repo when it propagates (see `icaptcha::admit_mirror`). Idempotent:
+    /// re-recording the same repo's proof overwrites it.
+    pub async fn record_repo_proof(
+        &self,
+        repo_id: &str,
+        proof_token: &str,
+        sub_did: &str,
+        level: i32,
+        jti: &str,
+        exp: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO repo_icaptcha_proofs (repo_id, proof_token, sub_did, level, jti, exp, created_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             ON CONFLICT (repo_id) DO UPDATE SET
+                 proof_token = $2, sub_did = $3, level = $4, jti = $5, exp = $6, created_at = $7",
+        )
+        .bind(repo_id)
+        .bind(proof_token)
+        .bind(sub_did)
+        .bind(level)
+        .bind(jti)
+        .bind(exp)
+        .bind(Utc::now().to_rfc3339())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// The raw proof token recorded for a repo, if any.
+    pub async fn get_repo_proof_token(&self, repo_id: &str) -> Result<Option<String>> {
+        let row = sqlx::query("SELECT proof_token FROM repo_icaptcha_proofs WHERE repo_id = $1")
+            .bind(repo_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|r| r.get::<String, _>("proof_token")))
+    }
+
+    /// Whether a repo row is quarantined (admitted as a mirror but withheld from
+    /// serve/clone and listings pending operator review).
+    pub async fn is_repo_quarantined(&self, repo_id: &str) -> Result<bool> {
+        let row = sqlx::query("SELECT quarantined FROM repos WHERE id = $1")
+            .bind(repo_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row
+            .map(|r| r.get::<bool, _>("quarantined"))
+            .unwrap_or(false))
+    }
+
+    /// Set or clear a repo's quarantine flag. Returns the number of rows touched
+    /// (0 if no such repo). Backs the (deferred) operator release surface; the
+    /// admission path writes the flag via `upsert_mirror_repo`. Allowed dead
+    /// outside tests until the operator endpoint lands.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub async fn set_repo_quarantine(&self, repo_id: &str, quarantined: bool) -> Result<u64> {
+        let result = sqlx::query("UPDATE repos SET quarantined = $1 WHERE id = $2")
+            .bind(quarantined)
+            .bind(repo_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
+    /// Repo ids currently quarantined, for operator review. Allowed dead outside
+    /// tests until the operator endpoint lands.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub async fn list_quarantined_repo_ids(&self) -> Result<Vec<String>> {
+        let rows = sqlx::query("SELECT id FROM repos WHERE quarantined = TRUE ORDER BY id")
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.into_iter().map(|r| r.get::<String, _>("id")).collect())
     }
 
     pub async fn get_trust_score(&self, agent_did: &str) -> Result<f64> {
@@ -3251,7 +3360,7 @@ mod dedup_db_tests {
             "2026-01-15T00:00:00Z",
         );
         db.create_repo(&canonical).await.unwrap();
-        db.upsert_mirror_repo("z6Mkwbud", "nipmod", "/srv/mirror", None)
+        db.upsert_mirror_repo("z6Mkwbud", "nipmod", "/srv/mirror", None, false)
             .await
             .unwrap();
 
@@ -3440,7 +3549,7 @@ mod dedup_db_tests {
         ))
         .await
         .unwrap();
-        db.upsert_mirror_repo("z6Mkwbud", "nipmod", "/srv/m", None)
+        db.upsert_mirror_repo("z6Mkwbud", "nipmod", "/srv/m", None, false)
             .await
             .unwrap();
         db.create_repo(&rec(
@@ -3533,7 +3642,7 @@ mod dedup_db_tests {
     #[sqlx::test]
     async fn deduped_mirror_only_group_survives(pool: PgPool) {
         let db = db(pool).await;
-        db.upsert_mirror_repo("z6Lonely", "orphan", "/srv/m", None)
+        db.upsert_mirror_repo("z6Lonely", "orphan", "/srv/m", None, false)
             .await
             .unwrap();
 
@@ -3572,7 +3681,7 @@ mod dedup_db_tests {
         ))
         .await
         .unwrap();
-        db.upsert_mirror_repo("z6Pair", "shared", "/srv/m", None)
+        db.upsert_mirror_repo("z6Pair", "shared", "/srv/m", None, false)
             .await
             .unwrap();
         db.create_repo(&rec(
@@ -3649,5 +3758,154 @@ mod icaptcha_ledger_tests {
             !db.consume_proof_jti("fresh", 500).await.unwrap(),
             "an unexpired spent proof survives the sweep and still blocks replays"
         );
+    }
+
+    /// A repo's creation proof round-trips through the side table so it can be
+    /// served to mirroring peers; absent for an unknown repo.
+    #[sqlx::test]
+    async fn repo_proof_roundtrips(pool: PgPool) {
+        let db = db(pool).await;
+        assert_eq!(db.get_repo_proof_token("nope").await.unwrap(), None);
+
+        db.record_repo_proof("repo-1", "tok.sig", "did:key:zX", 3, "jti-1", 123)
+            .await
+            .unwrap();
+        assert_eq!(
+            db.get_repo_proof_token("repo-1").await.unwrap().as_deref(),
+            Some("tok.sig")
+        );
+
+        // Idempotent: re-recording overwrites in place.
+        db.record_repo_proof("repo-1", "tok2.sig", "did:key:zX", 4, "jti-2", 456)
+            .await
+            .unwrap();
+        assert_eq!(
+            db.get_repo_proof_token("repo-1").await.unwrap().as_deref(),
+            Some("tok2.sig")
+        );
+    }
+
+    /// Mirror admission spends a jti against a forward retention window, never the
+    /// proof's own (already-past) exp. A jti stored that way must survive a sweep
+    /// keyed at the proof's original exp, so the token cannot admit a second mirror
+    /// after cleanup. Pins the CR3/5 fix (`MIRROR_REPLAY_RETENTION_SECS`).
+    #[sqlx::test]
+    async fn mirror_jti_retention_survives_sweep_at_proof_exp(pool: PgPool) {
+        let db = db(pool).await;
+        let proof_exp = 1_000i64; // the proof is already expired on the mirror path
+        let retain_until = 9_000_000_000i64; // forward retention window
+
+        assert!(db
+            .consume_proof_jti("mirror-jti", retain_until)
+            .await
+            .unwrap());
+
+        // A sweep at (or just past) the proof's original exp must not free the row.
+        let removed = db.sweep_expired_proofs(proof_exp + 1).await.unwrap();
+        assert_eq!(
+            removed, 0,
+            "mirror replay record must outlive the proof's exp"
+        );
+
+        assert!(
+            !db.consume_proof_jti("mirror-jti", retain_until)
+                .await
+                .unwrap(),
+            "the token must stay spent so it can't admit a second mirror"
+        );
+    }
+}
+
+/// Exercises the iCaptcha propagation quarantine: the `quarantined` flag on
+/// repos and its interaction with `upsert_mirror_repo` and the listing surfaces.
+#[cfg(test)]
+mod icaptcha_quarantine_tests {
+    use super::Db;
+    use sqlx::PgPool;
+
+    async fn db(pool: PgPool) -> Db {
+        let db = Db::for_testing(pool);
+        db.run_migrations().await.unwrap();
+        db
+    }
+
+    /// A repo defaults to not-quarantined; the flag can be set and cleared, and
+    /// reads of an unknown repo are false (not an error).
+    #[sqlx::test]
+    async fn quarantine_flag_set_and_release(pool: PgPool) {
+        let db = db(pool).await;
+        db.upsert_mirror_repo("z6owner", "good", "/srv/good", None, false)
+            .await
+            .unwrap();
+
+        assert!(!db.is_repo_quarantined("z6owner/good").await.unwrap());
+        assert!(!db.is_repo_quarantined("does-not-exist").await.unwrap());
+
+        assert_eq!(
+            db.set_repo_quarantine("z6owner/good", true).await.unwrap(),
+            1
+        );
+        assert!(db.is_repo_quarantined("z6owner/good").await.unwrap());
+        assert_eq!(
+            db.list_quarantined_repo_ids().await.unwrap(),
+            vec!["z6owner/good".to_string()]
+        );
+
+        // Release.
+        assert_eq!(
+            db.set_repo_quarantine("z6owner/good", false).await.unwrap(),
+            1
+        );
+        assert!(!db.is_repo_quarantined("z6owner/good").await.unwrap());
+        assert!(db.list_quarantined_repo_ids().await.unwrap().is_empty());
+    }
+
+    /// A mirror admitted quarantined stays quarantined across a re-sync — the
+    /// admission decision is made once and an operator's later release (or the
+    /// initial quarantine) must not be reverted by ON CONFLICT.
+    #[sqlx::test]
+    async fn quarantine_preserved_on_resync(pool: PgPool) {
+        let db = db(pool).await;
+        db.upsert_mirror_repo("z6owner", "garbage", "/srv/g", None, true)
+            .await
+            .unwrap();
+        assert!(db.is_repo_quarantined("z6owner/garbage").await.unwrap());
+
+        // A later re-sync passes quarantined=false but must not clear the flag.
+        db.upsert_mirror_repo("z6owner", "garbage", "/srv/g", None, false)
+            .await
+            .unwrap();
+        assert!(
+            db.is_repo_quarantined("z6owner/garbage").await.unwrap(),
+            "re-sync must preserve the prior quarantine decision"
+        );
+    }
+
+    /// Quarantined repos are withheld from the deduped listing surfaces.
+    #[sqlx::test]
+    async fn listings_exclude_quarantined(pool: PgPool) {
+        let db = db(pool).await;
+        db.upsert_mirror_repo("z6good", "ok", "/srv/ok", None, false)
+            .await
+            .unwrap();
+        db.upsert_mirror_repo("z6bad", "spam", "/srv/spam", None, true)
+            .await
+            .unwrap();
+
+        let names: Vec<String> = db
+            .list_all_repos_deduped()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|r| r.name)
+            .collect();
+        assert!(names.contains(&"ok".to_string()));
+        assert!(
+            !names.contains(&"spam".to_string()),
+            "quarantined mirror must not appear in listings"
+        );
+
+        let with_stars = db.list_all_repos_deduped_with_stars(None).await.unwrap();
+        assert!(with_stars.iter().all(|(r, _)| r.name != "spam"));
     }
 }

--- a/crates/gitlawb-node/src/icaptcha.rs
+++ b/crates/gitlawb-node/src/icaptcha.rs
@@ -31,6 +31,15 @@ use crate::error::AppError;
 
 const PROOF_HEADER: &str = "x-icaptcha-proof";
 
+/// How long a mirror-admission `jti` stays in the replay ledger. The direct
+/// request path spends a proof against its own `exp` (it can't be presented once
+/// expired). The propagation path deliberately accepts already-expired proofs,
+/// so spending against `exp` would store an already-past expiry that the next
+/// sweep deletes — letting the same token admit another mirror minutes later.
+/// We instead retain the mirror replay record for a long, fixed window so the
+/// per-node single-use property is durable.
+const MIRROR_REPLAY_RETENTION_SECS: i64 = 365 * 24 * 60 * 60;
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Mode {
     Off,
@@ -176,9 +185,40 @@ enum Decision {
     Allow,
     /// Enforce mode and verification failed; reject with this reason.
     Reject(String),
-    /// Enforce mode and the proof verified; the caller must consume this `jti`
-    /// (and reject replays) before allowing.
-    Consume { jti: String, exp: i64 },
+    /// Enforce mode and the proof verified; the caller must consume its `jti`
+    /// (and reject replays) before allowing, then may persist it.
+    Consume(VerifiedProof),
+}
+
+/// A verified proof: the raw token plus the claims we act on. Carried by a
+/// [`ProofGuard`] so that, once consumed, the gated handler can persist it with
+/// the created repo — letting the proof travel with the repo when it propagates
+/// to peers (see [`admit_mirror`]).
+#[derive(Debug)]
+pub struct VerifiedProof {
+    token: String,
+    sub: String,
+    level: u32,
+    jti: String,
+    exp: i64,
+}
+
+impl VerifiedProof {
+    /// Persist this proof against a freshly-created repo so a mirroring peer can
+    /// re-verify it. Best-effort callers may ignore failures; the gate's
+    /// security does not depend on it (propagation just falls back to quarantine).
+    pub async fn record_for_repo(&self, db: &crate::db::Db, repo_id: &str) -> Result<(), AppError> {
+        db.record_repo_proof(
+            repo_id,
+            &self.token,
+            &self.sub,
+            self.level as i32,
+            &self.jti,
+            self.exp,
+        )
+        .await?;
+        Ok(())
+    }
 }
 
 /// A verified proof awaiting consumption. Verification (which rejects invalid or
@@ -187,25 +227,24 @@ enum Decision {
 /// The caller must `consume()` this guard immediately before the gated write.
 /// For off/shadow/inert there is nothing to consume.
 #[must_use = "a verified iCaptcha proof must be consumed before the gated action"]
-pub struct ProofGuard(Option<ConsumeJob>);
-
-struct ConsumeJob {
-    jti: String,
-    exp: i64,
-}
+pub struct ProofGuard(Option<VerifiedProof>);
 
 impl ProofGuard {
-    /// Spend the proof's `jti` (single-use). A replay is rejected. No-op when
-    /// there is nothing to consume (off/shadow/inert).
-    pub async fn consume(self, db: &crate::db::Db) -> Result<(), AppError> {
-        if let Some(job) = self.0 {
-            if !db.consume_proof_jti(&job.jti, job.exp).await? {
-                return Err(AppError::IcaptchaProofRequired(
-                    "iCaptcha proof already used (replay); solve a fresh challenge".to_string(),
-                ));
+    /// Spend the proof's `jti` (single-use) and return the verified proof so the
+    /// caller can persist it. A replay is rejected. Returns `None` when there is
+    /// nothing to consume (off/shadow/inert).
+    pub async fn consume(self, db: &crate::db::Db) -> Result<Option<VerifiedProof>, AppError> {
+        match self.0 {
+            Some(p) => {
+                if !db.consume_proof_jti(&p.jti, p.exp).await? {
+                    return Err(AppError::IcaptchaProofRequired(
+                        "iCaptcha proof already used (replay); solve a fresh challenge".to_string(),
+                    ));
+                }
+                Ok(Some(p))
             }
+            None => Ok(None),
         }
-        Ok(())
     }
 }
 
@@ -221,7 +260,7 @@ pub fn verify_request(headers: &HeaderMap, did: &str) -> Result<ProofGuard, AppE
     match decide(v, headers, did, now_secs()) {
         Decision::Allow => Ok(ProofGuard(None)),
         Decision::Reject(reason) => Err(reject_error(v, &reason)),
-        Decision::Consume { jti, exp } => Ok(ProofGuard(Some(ConsumeJob { jti, exp }))),
+        Decision::Consume(proof) => Ok(ProofGuard(Some(proof))),
     }
 }
 
@@ -247,12 +286,21 @@ fn decide(v: &Verifier, headers: &HeaderMap, did: &str, now: i64) -> Decision {
         return Decision::Allow;
     }
 
-    match verify(v, headers, did, now) {
-        Ok(claims) => match v.mode {
-            Mode::Enforce => Decision::Consume {
+    let token = headers.get(PROOF_HEADER).and_then(|h| h.to_str().ok());
+    let result = match token {
+        Some(t) => verify_token(v, t, did, now, true).map(|claims| (t, claims)),
+        None => Err("missing proof header".to_string()),
+    };
+
+    match result {
+        Ok((token, claims)) => match v.mode {
+            Mode::Enforce => Decision::Consume(VerifiedProof {
+                token: token.to_string(),
+                sub: claims.sub,
+                level: claims.level,
                 jti: claims.jti,
                 exp: claims.exp,
-            },
+            }),
             // Shadow/Off: never reject, and do not consume (observational only).
             _ => Decision::Allow,
         },
@@ -267,16 +315,34 @@ fn decide(v: &Verifier, headers: &HeaderMap, did: &str, now: i64) -> Decision {
     }
 }
 
-/// Core verification, separated for testability. Returns the validated claims.
-/// `now` is unix seconds.
+/// Header-extracting wrapper over [`verify_token`] (enforces expiry). The
+/// production path inlines this in [`decide`]; retained as the unit-test entry
+/// point that also exercises header extraction.
+#[cfg(test)]
 fn verify(v: &Verifier, headers: &HeaderMap, did: &str, now: i64) -> Result<ProofClaims, String> {
-    let key = v.key.as_ref().ok_or("verifier has no public key")?;
     let proof = headers
         .get(PROOF_HEADER)
         .and_then(|h| h.to_str().ok())
         .ok_or("missing proof header")?;
+    verify_token(v, proof, did, now, true)
+}
 
-    let (payload, sig_b64) = proof.split_once('.').ok_or("malformed proof")?;
+/// Core verification of a raw proof token, separated for testability and reuse.
+/// Checks the Ed25519 signature, the required level, and the DID binding. `exp`
+/// is only enforced when `check_exp` is true: the direct request path enforces
+/// freshness, but the propagation path ([`admit_mirror`]) does not — a proof has
+/// usually expired by the time a repo mirrors, and the origin enforced freshness
+/// at creation. `now` is unix seconds.
+fn verify_token(
+    v: &Verifier,
+    token: &str,
+    did: &str,
+    now: i64,
+    check_exp: bool,
+) -> Result<ProofClaims, String> {
+    let key = v.key.as_ref().ok_or("verifier has no public key")?;
+
+    let (payload, sig_b64) = token.split_once('.').ok_or("malformed proof")?;
     let sig_bytes = URL_SAFE_NO_PAD
         .decode(sig_b64)
         .map_err(|_| "bad signature encoding")?;
@@ -289,7 +355,7 @@ fn verify(v: &Verifier, headers: &HeaderMap, did: &str, now: i64) -> Result<Proo
         .map_err(|_| "bad payload encoding")?;
     let claims: ProofClaims = serde_json::from_slice(&claims_bytes).map_err(|_| "bad claims")?;
 
-    if claims.exp < now {
+    if check_exp && claims.exp < now {
         return Err("proof expired".to_string());
     }
     if claims.level < v.required_level {
@@ -302,6 +368,93 @@ fn verify(v: &Verifier, headers: &HeaderMap, did: &str, now: i64) -> Result<Proo
         return Err("proof subject does not match authenticated DID".to_string());
     }
     Ok(claims)
+}
+
+/// Outcome of admitting a repo mirrored from a peer.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MirrorAdmission {
+    /// Admit the mirror normally (off/shadow/inert, or a valid proof in enforce).
+    Admit,
+    /// Enforce mode and the mirror's proof is missing/invalid/replayed — mirror
+    /// it but quarantine until an operator releases it. Carries the reason.
+    Quarantine(String),
+}
+
+/// Decide whether to admit a repo being mirrored from a peer, given the proof
+/// token the origin served (`None` if it had none or the fetch failed) and the
+/// mirrored repo's owner DID.
+///
+/// Off/shadow/inert always admit (shadow logs the would-be quarantine and writes
+/// nothing). In enforce mode the proof is re-verified offline against the local
+/// public key — signature, level, and owner-DID binding, but NOT expiry — and
+/// its `jti` is consumed in the local ledger, so one solved challenge admits at
+/// most one mirror per node (a malicious origin cannot reuse one proof to bless
+/// many spam repos here).
+///
+/// LIMITATION (proof is not repo-bound): an iCaptcha proof commits only to the
+/// solver's DID (`sub`), never to a repo — the proof is minted before the repo
+/// exists. So the guarantee enforced here is "a level≥N challenge was solved by
+/// this repo's owner DID", not "the owner intended THIS repo". A malicious origin
+/// that harvests a victim's public proof (served by `get_icaptcha_proof`) can use
+/// it to get ONE spam repo nominally owned by that victim admitted per node — the
+/// per-node `jti` single-use caps the amplification at one repo per distinct
+/// harvested proof, but does not eliminate it. Fully binding a proof to a repo
+/// would require the iCaptcha service to embed a repo/target identifier in the
+/// signed challenge (a protocol change, tracked as future work).
+pub async fn admit_mirror(
+    db: &crate::db::Db,
+    token: Option<&str>,
+    owner_did: &str,
+) -> MirrorAdmission {
+    let v = match VERIFIER.get() {
+        Some(v) => v,
+        None => return MirrorAdmission::Admit, // not initialized -> inert
+    };
+    // Off, or inert because no key could be loaded: admit unconditionally.
+    if v.mode == Mode::Off || v.key.is_none() {
+        return MirrorAdmission::Admit;
+    }
+    let shadow = v.mode == Mode::Shadow;
+
+    // Quarantine in enforce; in shadow just log and admit (observational, no IO).
+    let quarantine = |reason: String| -> MirrorAdmission {
+        if shadow {
+            tracing::warn!(owner = %owner_did, reason, "iCaptcha (shadow) would quarantine mirror");
+            MirrorAdmission::Admit
+        } else {
+            MirrorAdmission::Quarantine(reason)
+        }
+    };
+
+    let token = match token {
+        Some(t) => t,
+        None => return quarantine("origin served no iCaptcha proof".to_string()),
+    };
+
+    match verify_token(v, token, owner_did, now_secs(), false) {
+        Ok(claims) => {
+            if shadow {
+                // Observational: a valid proof would admit. Do not consume, so a
+                // later switch to enforce still sees the jti as fresh.
+                return MirrorAdmission::Admit;
+            }
+            // Retain the replay record on a fixed forward window, NOT the proof's
+            // own (already-past) exp — otherwise the next sweep frees the jti and
+            // the same token could admit another mirror here.
+            let retain_until = now_secs().saturating_add(MIRROR_REPLAY_RETENTION_SECS);
+            match db.consume_proof_jti(&claims.jti, retain_until).await {
+                Ok(true) => MirrorAdmission::Admit,
+                Ok(false) => MirrorAdmission::Quarantine(
+                    "iCaptcha proof already used to admit another mirror".to_string(),
+                ),
+                Err(e) => {
+                    tracing::warn!(owner = %owner_did, err = %e, "iCaptcha mirror ledger error; quarantining");
+                    MirrorAdmission::Quarantine("iCaptcha proof ledger unavailable".to_string())
+                }
+            }
+        }
+        Err(reason) => quarantine(reason),
+    }
 }
 
 #[cfg(test)]
@@ -435,11 +588,46 @@ mod tests {
         // the caller can spend it once and reject replays.
         let v = verifier(3);
         match decide(&v, &headers_with(PROOF), SUB, IAT) {
-            Decision::Consume { jti, exp } => {
-                assert_eq!(jti, "4b5228a5bed7122dee9f47ff");
-                assert_eq!(exp, 1782573151);
+            Decision::Consume(p) => {
+                assert_eq!(p.jti, "4b5228a5bed7122dee9f47ff");
+                assert_eq!(p.exp, 1782573151);
+                assert_eq!(p.token, PROOF, "the raw token is retained for persistence");
+                assert_eq!(p.sub, SUB);
             }
             other => panic!("expected Consume, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn propagation_accepts_an_expired_proof() {
+        // The mirror-admission path verifies sig/level/DID but NOT expiry, since a
+        // proof has usually expired by the time a repo propagates. The same proof
+        // that the direct path rejects as expired must verify here.
+        let v = verifier(3);
+        let now = 9_999_999_999; // far past the proof's exp
+        assert!(
+            verify_token(&v, PROOF, SUB, now, true).is_err(),
+            "direct path (check_exp=true) rejects the expired proof"
+        );
+        assert!(
+            verify_token(&v, PROOF, SUB, now, false).is_ok(),
+            "propagation path (check_exp=false) accepts it"
+        );
+    }
+
+    #[test]
+    fn propagation_still_enforces_signature_level_and_did() {
+        let v = verifier(3);
+        // wrong owner DID
+        assert!(verify_token(&v, PROOF, "did:key:zother", IAT, false).is_err());
+        // insufficient level
+        let v5 = verifier(5);
+        assert!(verify_token(&v5, PROOF, SUB, IAT, false).is_err());
+        // tampered signature
+        let (payload, sig) = PROOF.split_once('.').unwrap();
+        let mut chars: Vec<char> = sig.chars().collect();
+        chars[0] = if chars[0] == 'A' { 'B' } else { 'A' };
+        let tampered = format!("{}.{}", payload, chars.into_iter().collect::<String>());
+        assert!(verify_token(&v, &tampered, SUB, IAT, false).is_err());
     }
 }

--- a/crates/gitlawb-node/src/server.rs
+++ b/crates/gitlawb-node/src/server.rs
@@ -382,6 +382,10 @@ pub fn build_router(state: AppState) -> Router {
             axum::routing::get(visibility::withheld_paths),
         )
         .route(
+            "/api/v1/repos/{owner}/{repo}/icaptcha-proof",
+            axum::routing::get(repos::get_icaptcha_proof),
+        )
+        .route(
             "/api/v1/repos/{owner}/{repo}/encrypted-blobs",
             axum::routing::get(crate::api::encrypted::list_encrypted_blobs),
         )

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -275,6 +275,39 @@ async fn process_batch(
         match result {
             Ok(()) => {
                 info!(repo = %item.repo, origin = %origin_url, "synced repo from peer");
+                // iCaptcha propagation gate: on a first-time mirror, re-verify the
+                // proof the repo was created with (fetched from the origin) before
+                // admitting it. A node that enforces iCaptcha quarantines a mirror
+                // it cannot validate — kept on disk but hidden from serve/clone and
+                // listings until an operator releases it. Re-syncs of an already
+                // admitted repo keep their prior decision (upsert preserves it).
+                //
+                // "First-time" is keyed on DB-row absence, NOT on-disk presence: a
+                // prior attempt could have cloned to disk but crashed before the
+                // upsert, leaving no DB row. Disk-keying would skip admission on the
+                // retry and admit it unquarantined. On a DB lookup error, default to
+                // running the gate (fail toward quarantine, never silently admit).
+                let is_new_in_db = db
+                    .get_repo(owner_short, repo_name)
+                    .await
+                    .map(|r| r.is_none())
+                    .unwrap_or(true);
+                let quarantined = if is_new_in_db {
+                    let proof =
+                        fetch_icaptcha_proof(client, &origin_url, owner_short, repo_name).await;
+                    match crate::icaptcha::admit_mirror(db, proof.as_deref(), owner_short).await {
+                        crate::icaptcha::MirrorAdmission::Admit => false,
+                        crate::icaptcha::MirrorAdmission::Quarantine(reason) => {
+                            warn!(
+                                repo = %item.repo, origin = %origin_url, reason,
+                                "quarantining mirrored repo: failed iCaptcha propagation gate"
+                            );
+                            true
+                        }
+                    }
+                } else {
+                    false
+                };
                 // Register in DB so git smart HTTP can serve the mirrored repo
                 let _ = db
                     .upsert_mirror_repo(
@@ -282,6 +315,7 @@ async fn process_batch(
                         repo_name,
                         local_path.to_str().unwrap_or(""),
                         machine_id,
+                        quarantined,
                     )
                     .await;
                 // Option B2: carry the encrypted withheld-blob envelopes too, so an
@@ -345,6 +379,25 @@ async fn fetch_withheld(
         .filter_map(|v| v.as_str().map(str::to_string))
         .collect();
     Some(globs)
+}
+
+/// Fetch the iCaptcha proof token the origin recorded for this repo, used by the
+/// mirror-admission gate. Returns `None` on any non-success / network / parse
+/// error, or when the origin has no proof for the repo (treated as "no proof" by
+/// `icaptcha::admit_mirror`, which quarantines in enforce mode).
+async fn fetch_icaptcha_proof(
+    client: &reqwest::Client,
+    origin_url: &str,
+    owner: &str,
+    repo: &str,
+) -> Option<String> {
+    let url = format!("{origin_url}/api/v1/repos/{owner}/{repo}/icaptcha-proof");
+    let resp = client.get(&url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = resp.json().await.ok()?;
+    body.get("proof")?.as_str().map(str::to_string)
 }
 
 /// Signed request path for replica registration on the origin node.

--- a/crates/gitlawb-node/src/test_support.rs
+++ b/crates/gitlawb-node/src/test_support.rs
@@ -588,7 +588,7 @@ mod tests {
             .expect("seed canonical");
         state
             .db
-            .upsert_mirror_repo(short, "shared", "/tmp/mirror", None)
+            .upsert_mirror_repo(short, "shared", "/tmp/mirror", None, false)
             .await
             .expect("seed mirror");
         state
@@ -635,7 +635,7 @@ mod tests {
             .expect("seed canonical");
         state
             .db
-            .upsert_mirror_repo(short, "shared", "/tmp/mirror", None)
+            .upsert_mirror_repo(short, "shared", "/tmp/mirror", None, false)
             .await
             .expect("seed mirror");
         state
@@ -1075,7 +1075,7 @@ mod tests {
         let state = test_state(pool).await;
         state
             .db
-            .upsert_mirror_repo(short, "mirror-repo", "/tmp/mirror", None)
+            .upsert_mirror_repo(short, "mirror-repo", "/tmp/mirror", None, false)
             .await
             .expect("seed mirror-only row");
 
@@ -1177,7 +1177,7 @@ mod tests {
             .expect("root deny rule on canonical");
         state
             .db
-            .upsert_mirror_repo(short, "secret", "/tmp/mirror", None)
+            .upsert_mirror_repo(short, "secret", "/tmp/mirror", None, false)
             .await
             .expect("seed mirror");
         state


### PR DESCRIPTION
Phase 2 of the iCaptcha work: extend the proof-of-intelligence gate from direct writes to federated propagation, so a node that enforces iCaptcha can defend against spam repos that originate on a node which does not.

The proof now travels with the repo and is re-verified at mirror time:

- Capture & persist: create_repo/fork_repo store the verified proof (raw token + claims) against the new repo so it can propagate. A new repo_icaptcha_proofs side table holds one proof per repo.

- Serve: GET /api/v1/repos/{owner}/{repo}/icaptcha-proof returns the stored token, gated on whole-repo "/" read like the other replication endpoints so a private repo's proof is never disclosed.

- Admit at mirror time: on a first-time mirror the sync worker fetches the origin's proof and icaptcha::admit_mirror re-verifies it offline — signature + level + owner-DID binding, but NOT expiry (proofs are short-lived; the origin enforced freshness at creation) — and consumes the jti in the local ledger, so one solved challenge admits at most one mirror per node (a malicious origin can't reuse one proof for many spam repos).

- Quarantine: in enforce mode a mirror that fails the gate is kept on disk but hidden from clone/serve (authorize_repo_read + both git serve handlers) and from listings (dedup CTE + federated list), via a new repos.quarantined column. Shadow logs only and writes nothing; off admits normally. Fail-safe: off/shadow/no-key always admit.

Internals: split verify_token (raw token, optional exp check) out of the header path; ProofGuard::consume now returns the VerifiedProof for persistence. DB gains record_repo_proof/get_repo_proof_token, is_repo_quarantined, and (for the deferred operator release surface) set_repo_quarantine/list_quarantined_repo_ids.

Tested: verify_token expiry-skip + signature/level/DID enforcement on the propagation path; proof round-trip; quarantine set/release, preservation across re-sync, and exclusion from listings. Full workspace green against Postgres.

Known tradeoff: a legit repo from a non-iCaptcha (or shadow) origin has no proof and is quarantined by an enforce node — recoverable via operator release. The operator release HTTP endpoint is deferred (no admin-auth surface exists yet); DB methods are in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint for retrieving iCaptcha proof information for a repository, supporting mirror verification workflows.

* **Bug Fixes**
  * Quarantined mirrors are now hidden from clone/fetch/read access and repository listings.
  * Repository creation and fork flows now preserve verification data for later use during mirroring.
  * Mirror synchronization now applies a stricter first-sync check and keeps prior quarantine decisions on re-sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->