### PR TITLE
fix(release): give crates explicit versions for release-please

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.9"
+# Per-crate versions live in each crate's [package] so release-please can manage
+# them (it cannot rewrite an inherited `version.workspace = true`). They are kept
+# in lockstep by release-please's Rust workspace strategy.
 edition = "2021"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"

--- a/crates/git-remote-gitlawb/Cargo.toml
+++ b/crates/git-remote-gitlawb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git-remote-gitlawb"
 description = "Git remote helper — enables 'git clone gitlawb://did:gitlawb:...'"
-version.workspace = true
+version = "0.3.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/gitlawb-attest/Cargo.toml
+++ b/crates/gitlawb-attest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gitlawb-attest"
 description = "External Attestation v1: pluggable provenance attachments for gitlawb ref-update certs"
-version.workspace = true
+version = "0.3.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/gitlawb-core/Cargo.toml
+++ b/crates/gitlawb-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gitlawb-core"
 description = "Core cryptographic primitives for the gitlawb network: DIDs, CIDs, UCAN, HTTP Signatures, ref-update certificates"
-version.workspace = true
+version = "0.3.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/gitlawb-node/Cargo.toml
+++ b/crates/gitlawb-node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gitlawb-node"
 description = "The gitlawb node daemon — git hosting over HTTP with DID auth"
-version.workspace = true
+version = "0.3.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/gl/Cargo.toml
+++ b/crates/gl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gl"
 description = "The gitlawb CLI — identity management, node control, MCP server"
-version.workspace = true
+version = "0.3.9"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Fixes the `Release Please` workflow, which failed with `value at path package.version is not tagged`. release-please's Rust workspace strategy versions each member crate in its own `Cargo.toml` and cannot rewrite an inherited `version.workspace = true`.

## Motivation & context

After #127 merged, the release-please run on `main` errored:

✔ found workspace with 5 members, upgrading all
Error: release-please failed: value at path package.version is not tagged

The root `Cargo.toml` is a virtual workspace and all five crates inherit `version.workspace = true`, so there is no literal version string for the Rust updater to bump.
Closes #

## Kind of change

- [ ] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [x] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

- Root `Cargo.toml`: removed `[workspace.package].version` (no longer the source of truth).
- All five crates (`gitlawb-core`, `gitlawb-node`, `gl`, `git-remote-gitlawb`, `gitlawb-attest`): replaced `version.workspace = true` with explicit `version = "0.3.9"`; they still inherit `edition`/`rust-version`/`license`/`authors`/`repository` from the workspace.
- release-please now bumps all five in lockstep and updates `Cargo.lock`. Inter-crate deps uirement), so nothing else needs syncing.

## How a reviewer can verify

```sh
cargo metadata --no-deps >/dev/null && echo "workspace resolves"
grep -rn '^version' crates/*/Cargo.toml   # each is version = "0.3.9"
grep -n 'version' Cargo.toml | head        # no version under [workspace.package]

After merge, the Release Please workflow should succeed and open a chore(main): release 0.4.0 PR.

Before you request review

- [x] Scope is one logical change; no unrelated churn
- [ ] cargo test --workspace passes locally — N/A (version-literal change; cargo metadata v
- [x] New behavior is covered by tests (required for fixes) — N/A, release tooling
- [x] cargo fmt --all and cargo clippy --workspace --all-targets -- -D warnings are clean — N/A, no code changed
- [x] Commit titles use Conventional Commits (feat(...), fix(...), docs(...))
- [x] Docs / .env.example updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

Notes for reviewers

The five crate versions are now managed by release-please and bumped together; treat them as generated. [workspace.package] still centralizes the other shared fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized crate versioning so each package now carries its own explicit release version.
  * Updated workspace settings to clarify that versions are managed per crate and kept in sync for releases.
  * This helps make versioning clearer and reduces reliance on inherited workspace values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->