### PR TITLE
fix(release): use simple release-type + generic Cargo.toml updaters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,11 @@ members = [
 [workspace.package]
 # Per-crate versions live in each crate's [package] so release-please can manage
 # them (it cannot rewrite an inherited `version.workspace = true`). They are kept
-# in lockstep by release-please's Rust workspace strategy.
+# in lockstep by release-please's generic updater: each crate's `version` line
+# carries an `# x-release-please-version` annotation and is listed under
+# `extra-files` in release-please-config.json. The release type is `simple`
+# (not `rust`) because the rust strategy unconditionally tries to rewrite this
+# virtual workspace root as a package manifest and errors out.
 edition = "2021"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"

--- a/crates/git-remote-gitlawb/Cargo.toml
+++ b/crates/git-remote-gitlawb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git-remote-gitlawb"
 description = "Git remote helper — enables 'git clone gitlawb://did:gitlawb:...'"
-version = "0.3.9"
+version = "0.3.9" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/gitlawb-attest/Cargo.toml
+++ b/crates/gitlawb-attest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gitlawb-attest"
 description = "External Attestation v1: pluggable provenance attachments for gitlawb ref-update certs"
-version = "0.3.9"
+version = "0.3.9" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/gitlawb-core/Cargo.toml
+++ b/crates/gitlawb-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gitlawb-core"
 description = "Core cryptographic primitives for the gitlawb network: DIDs, CIDs, UCAN, HTTP Signatures, ref-update certificates"
-version = "0.3.9"
+version = "0.3.9" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/gitlawb-node/Cargo.toml
+++ b/crates/gitlawb-node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gitlawb-node"
 description = "The gitlawb node daemon — git hosting over HTTP with DID auth"
-version = "0.3.9"
+version = "0.3.9" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/gl/Cargo.toml
+++ b/crates/gl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gl"
 description = "The gitlawb CLI — identity management, node control, MCP server"
-version = "0.3.9"
+version = "0.3.9" # x-release-please-version
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,11 +2,18 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "rust",
+      "release-type": "simple",
       "package-name": "gitlawb-node",
       "bump-minor-pre-major": true,
       "include-v-in-tag": true,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": [
+        { "type": "generic", "path": "crates/gitlawb-core/Cargo.toml" },
+        { "type": "generic", "path": "crates/gitlawb-node/Cargo.toml" },
+        { "type": "generic", "path": "crates/gl/Cargo.toml" },
+        { "type": "generic", "path": "crates/git-remote-gitlawb/Cargo.toml" },
+        { "type": "generic", "path": "crates/gitlawb-attest/Cargo.toml" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix the failing `release-please` job: switch the workspace from `release-type: rust` to `simple` and bump per-crate versions via the generic updater, so releases can actually be cut.

## Motivation & context

`release-type: rust` at path `.` is incompatible with our virtual workspace root. release-please's Rust strategy unconditionally appends a `CargoToml` update for the root `Cargo.toml`, and that updater throws `is not a package manifest (might be a cargo workspace)` whenever the manifest has no `[package]` section — so every Release run died on the final step.
## Kind of change

- [x] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

- `release-please-config.json`: `release-type` `rust` → `simple`; added `extra-files` listing all 5 crate `Cargo.toml`s with the generic updater.
- Added inline `# x-release-please-version` annotation to the `version` line of each crate (gitlawb-core / gitlawb-node / gl / git-remote-gitlawb / gitlawb-attest).
- Updated the explanatory comment in the root `Cargo.toml`.
- Preserves the single `vX.Y.Z` tag, all action outputs (`release_created`/`tag_name`/`version`), and the entire downstream `release.yml` unchanged. `Cargo.lock` is intentionally unmanaged (CI doesn't build `--locked`; cargo regenerates it).

## How a reviewer can verify

```sh
python3 -m json.tool release-please-config.json   # valid config
cargo metadata --no-deps --format-version 1 >/dev/null  # TOML still parses
grep -rn x-release-please-version crates/*/Cargo.toml   # 5 annotations
# On merge to main, the Release workflow's release-please step builds a release
# PR (bumping all 5 crates to the next version) instead of erroring.

Before you request review

- [x] Scope is one logical change; no unrelated churn
- [ ] cargo test --workspace passes locally
- [x] New behavior is covered by tests (required for fixes) — N/A, CI-config change validated above
- [x] cargo fmt --all and cargo clippy --workspace --all-targets -- -D warnings are clean — no source touched
- [x] Commit titles use Conventional Commits (feat(...), fix(...), docs(...))
- [x] Docs / .env.example updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

Notes for reviewers

Cargo.lock deliberately stays at the old crate versions after a release — CI never builds with --locked (only the unrelated cargo-audit install does), so cargo regenerates it in place, and each binary's --version comes from CARGO_PKG_VERSION (the bumped Cargo.toml). Annotating Cargo.lock would be fragile since cargo rewrites it and strips comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to better track version updates across workspace packages.
  * Added version markers to multiple package manifests so future release bumps are applied consistently.
  * Clarified release-management comments in the workspace manifest for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->