### PR TITLE
chore(node): seed Gitlawb nodes in bootstrap-peers; ignore node1 fly config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ keys/
 # Logs
 *.log
 .openclaude-profile.json
+
+# Per-operator Fly config (node1 prod config is pulled from Fly, not tracked)
+infra/fly/node1.fly.toml

--- a/bootstrap-peers.json
+++ b/bootstrap-peers.json
@@ -1,15 +1,39 @@
 {
   "$comment": "Canonical seed list for the Gitlawb network. Merged with GITLAWB_BOOTSTRAP_PEERS at startup. PRs to add public nodes welcome.",
   "version": 1,
-  "updated": "2026-05-16",
+  "updated": "2026-06-30",
   "peers": [
     {
       "name": "gitlawb",
-      "operator": "Gitlawb (Kevin)",
+      "operator": "Gitlawb",
       "did": "did:key:z6MkqDnb7Siv3Cwj7pGJq4T5EsUisECqR8KpnDLwcaZq5TPr",
       "http_url": "https://node.gitlawb.com",
       "p2p_multiaddr": null,
       "added": "2026-04-29"
+    },
+    {
+      "name": "gitlawb-node2",
+      "operator": "Gitlawb",
+      "did": null,
+      "http_url": "https://node2.gitlawb.com",
+      "p2p_multiaddr": null,
+      "added": "2026-06-30"
+    },
+    {
+      "name": "gitlawb-node3",
+      "operator": "Gitlawb",
+      "did": null,
+      "http_url": "https://node3.gitlawb.com",
+      "p2p_multiaddr": null,
+      "added": "2026-06-30"
+    },
+    {
+      "name": "gitlawb-manila",
+      "operator": "Gitlawb",
+      "did": null,
+      "http_url": "https://manila.gitlawb.com",
+      "p2p_multiaddr": null,
+      "added": "2026-06-30"
     },
     {
       "name": "rapybus-gitlawb",


### PR DESCRIPTION
## Summary

Seed all Gitlawb-operated nodes in the canonical bootstrap list (add node2, node3, and the new manila node), and stop tracking node1's per-operator Fly config.

## Motivation & context

The canonical `bootstrap-peers.json` only listed `node.gitlawb.com` among our own nodes. Adding node2/node3/manila gives new and recovering nodes a fuller set of reliable Gitlawb seeds to discover the network from. `infra/fly/node1.fly.toml` is node1's production config (pulled from Fly with `fly config save`) and shouldn't live in the repo.
Closes #

## Kind of change

- [ ] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)
- [x] Chore / config

## What changed

- **gitlawb-node** — `bootstrap-peers.json`: add `gitlawb-node2` (node2.gitlawb.com), `gitlawb-node3` (node3.gitlawb.com), and `gitlawb-manila` (manila.gitlawb.com) to the canonical seed list; normalize the existing operator label to `"Gitlawb"`; bump `updated`. New entries have `did: null` (the parser treats `did` as optional; bootstrap merges peers on `http_url`).
- `.gitignore`: ignore `infra/fly/node1.fly.toml` (node1 prod config is pulled from Fly, not tracked).

## How a reviewer can verify

```sh
python3 -c "import json; json.load(open('bootstrap-peers.json')); print('valid')"
cargo test -p gitlawb-node bootstrap

Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] cargo test --workspace passes locally
- [x] New behavior is covered by tests (existing bootstrap parser tests cover null-DID / http_url-only entries; N/A for a data-only seed addition)
- [x] cargo fmt --all and cargo clippy --workspace --all-targets -- -D warnings are clean (no code changed)
- [x] Commit titles use Conventional Commits
- [x] Docs / .env.example updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

Notes for reviewers

- DIDs for node2/node3/manila are null for now — happy to fill in their did:key values if we want seed-list identity verification.
- The new seeds take effect when nodes are next deployed (the JSON is baked into the image at build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new peer entries for additional nodes, expanding the available network list.
  * Updated an existing peer label and refreshed the peer list date.

* **Chores**
  * Updated ignore rules to exclude a local operator configuration file from tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->