### PR TITLE
fix(remote): include HTTP error response body

### DIFF
--- a/crates/git-remote-gitlawb/src/main.rs
+++ b/crates/git-remote-gitlawb/src/main.rs
@@ -209,7 +209,7 @@ fn handle_connect<R: Read>(
 
     if !refs_resp.status().is_success() {
         let status = refs_resp.status();
-        let body = refs_resp.text().unwrap_or_default();
+        let body = read_error_body(refs_resp);
         bail!(
             "{}",
             http_error_message(
@@ -307,7 +307,7 @@ fn handle_connect<R: Read>(
 
     if !pack_resp.status().is_success() {
         let status = pack_resp.status();
-        let body = pack_resp.text().unwrap_or_default();
+        let body = read_error_body(pack_resp);
         let path = format!("/{service}");
         bail!("{}", http_error_message("POST", &path, status, &body, None));
     }
@@ -444,6 +444,20 @@ fn url_path(url: &str) -> String {
         .unwrap_or_else(|| "/".to_string())
 }
 
+const MAX_ERROR_BODY_BYTES: u64 = 4096;
+const MAX_ERROR_BODY_CHARS: usize = 2000;
+
+fn read_error_body(mut response: reqwest::blocking::Response) -> String {
+    let mut body = Vec::new();
+    let mut limited = (&mut response).take(MAX_ERROR_BODY_BYTES);
+
+    if limited.read_to_end(&mut body).is_err() {
+        return String::new();
+    }
+
+    String::from_utf8_lossy(&body).into_owned()
+}
+
 fn http_error_message(
     method: &str,
     path: &str,
@@ -452,17 +466,54 @@ fn http_error_message(
     empty_body_hint: Option<&str>,
 ) -> String {
     let mut message = format!("{method} {path} returned {status}");
-    let body = body.trim();
+    let body = safe_error_body_excerpt(body);
 
     if !body.is_empty() {
         message.push_str(": ");
-        message.push_str(body);
+        message.push_str(&body);
     } else if let Some(hint) = empty_body_hint {
         message.push(' ');
         message.push_str(hint);
     }
 
     message
+}
+
+fn safe_error_body_excerpt(body: &str) -> String {
+    let mut excerpt = String::new();
+    let mut pending_space = false;
+    let mut kept_chars = 0;
+
+    for ch in body.trim().chars() {
+        if kept_chars >= MAX_ERROR_BODY_CHARS {
+            break;
+        }
+
+        if ch.is_control() {
+            if matches!(ch, '\n' | '\r' | '\t') {
+                pending_space = true;
+            }
+            continue;
+        }
+
+        if ch.is_whitespace() {
+            pending_space = true;
+            continue;
+        }
+
+        if pending_space && !excerpt.is_empty() {
+            excerpt.push(' ');
+            kept_chars += 1;
+            if kept_chars >= MAX_ERROR_BODY_CHARS {
+                break;
+            }
+        }
+        excerpt.push(ch);
+        kept_chars += 1;
+        pending_space = false;
+    }
+
+    excerpt
 }
 
 // ── Keypair loading ───────────────────────────────────────────────────────────
@@ -629,6 +680,39 @@ mod tests {
             url_path("http://127.0.0.1:7545/z6Mk/myrepo/git-receive-pack"),
             "/z6Mk/myrepo/git-receive-pack"
         );
+    }
+
+    #[test]
+    fn http_error_message_sanitizes_response_body_controls() {
+        let message = http_error_message(
+            "GET",
+            "/info/refs",
+            reqwest::StatusCode::BAD_GATEWAY,
+            "\u{1b}[2Jrepository\r\nis\tblocked\u{7}",
+            None,
+        );
+
+        assert!(message.contains("repository is blocked"));
+        assert!(!message.contains('\u{1b}'));
+        assert!(!message.contains('\u{7}'));
+        assert!(!message.contains('\r'));
+        assert!(!message.contains('\n'));
+    }
+
+    #[test]
+    fn http_error_message_truncates_long_response_body() {
+        let body = "x".repeat(MAX_ERROR_BODY_CHARS + 100);
+        let message = http_error_message(
+            "POST",
+            "/git-receive-pack",
+            reqwest::StatusCode::FORBIDDEN,
+            &body,
+            None,
+        );
+        let prefix = "POST /git-receive-pack returned 403 Forbidden: ";
+
+        assert_eq!(message.len(), prefix.len() + MAX_ERROR_BODY_CHARS);
+        assert!(message.starts_with(prefix));
     }
 
     #[test]

--- a/crates/git-remote-gitlawb/src/main.rs
+++ b/crates/git-remote-gitlawb/src/main.rs
@@ -179,11 +179,11 @@ fn run_helper(repo_base: &str, keypair: Option<&Keypair>) -> Result<()> {
 
 // ── HTTP proxy for git smart protocol ────────────────────────────────────────
 
-fn handle_connect(
+fn handle_connect<R: Read>(
     repo_base: &str,
     service: &str,
     keypair: Option<&Keypair>,
-    stdin: &mut io::BufReader<io::Stdin>,
+    stdin: &mut R,
 ) -> Result<()> {
     match service {
         "git-upload-pack" | "git-receive-pack" => {}
@@ -208,9 +208,17 @@ fn handle_connect(
         .with_context(|| format!("GET {refs_url}"))?;
 
     if !refs_resp.status().is_success() {
+        let status = refs_resp.status();
+        let body = refs_resp.text().unwrap_or_default();
         bail!(
-            "GET /info/refs returned {} — is the repo registered on this node?",
-            refs_resp.status()
+            "{}",
+            http_error_message(
+                "GET",
+                "/info/refs",
+                status,
+                &body,
+                Some("— is the repo registered on this node?")
+            )
         );
     }
 
@@ -298,7 +306,10 @@ fn handle_connect(
         .with_context(|| format!("POST {post_url}"))?;
 
     if !pack_resp.status().is_success() {
-        bail!("POST /{} returned {}", service, pack_resp.status());
+        let status = pack_resp.status();
+        let body = pack_resp.text().unwrap_or_default();
+        let path = format!("/{service}");
+        bail!("{}", http_error_message("POST", &path, status, &body, None));
     }
 
     let pack_bytes = pack_resp.bytes().context("reading pack response")?;
@@ -347,7 +358,7 @@ fn parse_gitlawb_url(url: &str) -> Result<(String, String, String)> {
 ///
 /// We also handle the flush-only case (`"0000"`) that git sends when it already
 /// has everything it needs (up-to-date clone).
-fn read_upload_pack_request(stdin: &mut io::BufReader<io::Stdin>) -> Result<Vec<u8>> {
+fn read_upload_pack_request<R: Read>(stdin: &mut R) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
 
     loop {
@@ -433,6 +444,27 @@ fn url_path(url: &str) -> String {
         .unwrap_or_else(|| "/".to_string())
 }
 
+fn http_error_message(
+    method: &str,
+    path: &str,
+    status: reqwest::StatusCode,
+    body: &str,
+    empty_body_hint: Option<&str>,
+) -> String {
+    let mut message = format!("{method} {path} returned {status}");
+    let body = body.trim();
+
+    if !body.is_empty() {
+        message.push_str(": ");
+        message.push_str(body);
+    } else if let Some(hint) = empty_body_hint {
+        message.push(' ');
+        message.push_str(hint);
+    }
+
+    message
+}
+
 // ── Keypair loading ───────────────────────────────────────────────────────────
 
 fn load_keypair() -> Option<Keypair> {
@@ -476,6 +508,81 @@ fn resolve_key_path() -> std::path::PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::{TcpListener, TcpStream};
+    use std::thread::JoinHandle;
+
+    struct TestResponse {
+        request_line: &'static str,
+        status: &'static str,
+        body: &'static str,
+    }
+
+    fn serve_http(responses: Vec<TestResponse>) -> (String, JoinHandle<Vec<String>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let handle = std::thread::spawn(move || {
+            let mut requests = Vec::new();
+
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let request = read_http_request(&mut stream);
+                assert!(
+                    request.starts_with(response.request_line),
+                    "unexpected request:\n{request}"
+                );
+
+                let response_text = format!(
+                    "HTTP/1.1 {}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    response.status,
+                    response.body.len(),
+                    response.body
+                );
+                stream.write_all(response_text.as_bytes()).unwrap();
+                requests.push(request);
+            }
+
+            requests
+        });
+
+        (base_url, handle)
+    }
+
+    fn read_http_request(stream: &mut TcpStream) -> String {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 512];
+        let mut header_len = None;
+
+        loop {
+            let n = stream.read(&mut chunk).unwrap();
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&chunk[..n]);
+
+            if header_len.is_none() {
+                header_len = buf.windows(4).position(|w| w == b"\r\n\r\n").map(|p| p + 4);
+            }
+
+            if let Some(header_len) = header_len {
+                let header = String::from_utf8_lossy(&buf[..header_len]);
+                let content_len = header
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or(0);
+
+                if buf.len() >= header_len + content_len {
+                    break;
+                }
+            }
+        }
+
+        String::from_utf8_lossy(&buf).into_owned()
+    }
 
     #[test]
     fn parse_standard_url() {
@@ -522,6 +629,52 @@ mod tests {
             url_path("http://127.0.0.1:7545/z6Mk/myrepo/git-receive-pack"),
             "/z6Mk/myrepo/git-receive-pack"
         );
+    }
+
+    #[test]
+    fn connect_get_error_includes_response_body() {
+        let (base_url, server) = serve_http(vec![TestResponse {
+            request_line: "GET /z6Mk/myrepo/info/refs?service=git-upload-pack HTTP/1.1",
+            status: "404 Not Found",
+            body: r#"{"message":"repository is not registered on this node"}"#,
+        }]);
+
+        let repo_base = format!("{base_url}/z6Mk/myrepo");
+        let mut stdin = std::io::Cursor::new(Vec::<u8>::new());
+        let err = handle_connect(&repo_base, "git-upload-pack", None, &mut stdin).unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("GET /info/refs returned 404 Not Found"));
+        assert!(message.contains("repository is not registered on this node"));
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 1);
+    }
+
+    #[test]
+    fn connect_post_error_includes_response_body() {
+        let (base_url, server) = serve_http(vec![
+            TestResponse {
+                request_line: "GET /z6Mk/myrepo/info/refs?service=git-receive-pack HTTP/1.1",
+                status: "200 OK",
+                body: "",
+            },
+            TestResponse {
+                request_line: "POST /z6Mk/myrepo/git-receive-pack HTTP/1.1",
+                status: "403 Forbidden",
+                body: r#"{"error":"forbidden","message":"push rejected: only the repo owner may push"}"#,
+            },
+        ]);
+
+        let repo_base = format!("{base_url}/z6Mk/myrepo");
+        let mut stdin = std::io::Cursor::new(b"0000".to_vec());
+        let err = handle_connect(&repo_base, "git-receive-pack", None, &mut stdin).unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("POST /git-receive-pack returned 403 Forbidden"));
+        assert!(message.contains("push rejected: only the repo owner may push"));
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[1].contains("\r\n\r\n0000"));
     }
 
     fn args(items: &[&str]) -> Vec<String> {


### PR DESCRIPTION
Closes #77

## Summary
- include non-empty HTTP response bodies in remote-helper GET and POST error messages
- keep the existing empty-body hint for missing `info/refs` responses
- add local HTTP tests for both failing ref advertisement and failing pack exchange paths

## Tests
- `cargo fmt --all -- --check`
- `cargo +stable-x86_64-pc-windows-gnu test -p git-remote-gitlawb`
- `cargo +stable-x86_64-pc-windows-gnu clippy -p git-remote-gitlawb --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for smart-protocol proxy failures by including a sanitized, truncated excerpt of the server response.
  * Enhanced handling of unsuccessful `GET /info/refs` and `POST /{service}` responses, with clearer guidance when the server body is missing or empty.
* **Tests**
  * Updated the local HTTP test harness to capture and assert raw incoming request text.
  * Added/expanded coverage for error-message sanitization and truncation, including request-specific failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->