### PR TITLE
chore(aws): codify iCaptcha enforce in the EC2 node Terraform

### DIFF
--- a/infra/aws/compose.yaml.tftpl
+++ b/infra/aws/compose.yaml.tftpl
@@ -58,6 +58,10 @@ services:
       GITLAWB_P2P_PORT: "${p2p_port}"
       GITLAWB_REPOS_DIR: /data/repos
       GITLAWB_KEY: /data/keys/identity.pem
+      # iCaptcha proof-of-intelligence gate (spam protection on create/fork/register)
+      ICAPTCHA_MODE: ${icaptcha_mode}
+      ICAPTCHA_PUBKEY: ${icaptcha_pubkey}
+      ICAPTCHA_REQUIRED_LEVEL: "${icaptcha_required_level}"
       GITLAWB_PUBLIC_URL: $${GITLAWB_PUBLIC_URL}
       GITLAWB_BOOTSTRAP_PEERS: $${GITLAWB_BOOTSTRAP_PEERS}
       GITLAWB_AUTO_SYNC: $${GITLAWB_AUTO_SYNC}

--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -290,16 +290,19 @@ locals {
   )
 
   compose_yaml = templatefile("${path.module}/compose.yaml.tftpl", {
-    image_repo     = local.image_repo
-    image_tag      = var.image_tag
-    domain_name    = var.domain_name
-    db_host        = var.use_rds ? aws_db_instance.node[0].address : ""
-    gitlawb_port   = var.gitlawb_port
-    p2p_port       = var.gitlawb_p2p_port
-    metrics_port   = var.metrics_port
-    expose_metrics = local.expose_metrics
-    pg_user        = var.postgres_user
-    pg_db          = var.postgres_db
+    image_repo              = local.image_repo
+    image_tag               = var.image_tag
+    domain_name             = var.domain_name
+    db_host                 = var.use_rds ? aws_db_instance.node[0].address : ""
+    gitlawb_port            = var.gitlawb_port
+    p2p_port                = var.gitlawb_p2p_port
+    metrics_port            = var.metrics_port
+    expose_metrics          = local.expose_metrics
+    pg_user                 = var.postgres_user
+    pg_db                   = var.postgres_db
+    icaptcha_mode           = var.icaptcha_mode
+    icaptcha_pubkey         = var.icaptcha_pubkey
+    icaptcha_required_level = var.icaptcha_required_level
   })
 
   user_data = templatefile("${path.module}/user-data.sh.tftpl", {

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -82,6 +82,28 @@ variable "image_tag" {
 }
 
 # ---------------------------------------------------------------------------
+# iCaptcha proof-of-intelligence gate (spam protection on writes)
+# ---------------------------------------------------------------------------
+
+variable "icaptcha_mode" {
+  description = "iCaptcha gate mode: off | shadow | enforce. The live gitlawb network enforces."
+  type        = string
+  default     = "enforce"
+}
+
+variable "icaptcha_pubkey" {
+  description = "base64url Ed25519 public key of the iCaptcha service, pinned so startup doesn't depend on fetching it. This is the live icaptcha.gitlawb.com key."
+  type        = string
+  default     = "xjyPNqIbvc9U-kwXW6u9mDqRJ7E2UUMOaJdUWhpEXq8"
+}
+
+variable "icaptcha_required_level" {
+  description = "Minimum iCaptcha proof level required to pass the gate."
+  type        = number
+  default     = 3
+}
+
+# ---------------------------------------------------------------------------
 # Networking / ingress
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Codify iCaptcha enforce into the AWS EC2 node Terraform so the enforce config survives instance rebuilds / user-data re-runs.

## Motivation & context

The AWS node (manila) was upgraded to v0.4.0 and switched to iCaptcha enforce by hand-editing its running `/opt/gitlawb/compose.yaml`. That manual edit would be lost if the EC2 is replaced or user-data re-runs, silently dropping enforcement. This bakes it into the Terraform.
Closes #

## Kind of change

- [ ] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)
- [x] Chore / infra

## What changed

- **`infra/aws/variables.tf`** — new vars: `icaptcha_mode` (default `enforce`), `icaptcha_pubkey` (default the pinned live `icaptcha.gitlawb.com` Ed25519 key), `icaptcha_required_level` (default `3`).
- **`infra/aws/main.tf`** — pass the three vars into the `compose.yaml.tftpl` render.
- **`infra/aws/compose.yaml.tftpl`** — set `ICAPTCHA_MODE` / `ICAPTCHA_PUBKEY` / `ICAPTCHA_REQUIRED_LEVEL` on the node service environment.

Operators can override any of these per-deployment via `terraform.tfvars`.

## How a reviewer can verify

```sh
cd infra/aws
terraform fmt -check
terraform validate    # after `terraform init`
# confirm the three ICAPTCHA_ vars are declared, passed into the templatefile, and referenced:
grep -rn 'icaptcha_' variables.tf main.tf compose.yaml.tftpl

Before you request review

- [x] Scope is one logical change; no unrelated churn
- [ ] cargo test --workspace passes locally  (N/A — infra only, no Rust changed)
- [ ] New behavior is covered by tests  (N/A — Terraform config)
- [x] cargo fmt --all and cargo clippy ... are clean  (N/A — no code changed)
- [x] Commit titles use Conventional Commits
- [x] Docs / config updated if behavior changed (this IS the config)
- [x] Checked existing PRs so this isn't a duplicate

Notes for reviewers

- No terraform apply is required to fix the live node — manila already has the config from the manual SSM edit; this just guarantees future rebuilds match.
- The pinned pubkey is a public key (safe to commit); it removes a startup dependency on fetching it from the service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable anti-spam protection for account creation, forking, and registration flows.
  * Introduced a proof-of-intelligence challenge with adjustable enforcement mode and difficulty level.
  * Enabled deployment-time configuration so the protection can be tuned without code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->