### PR TITLE
fix(gl): sign the CLI's /ipfs/pins reads under the #134 auth gate

### DIFF
--- a/crates/gl/src/ipfs_cmd.rs
+++ b/crates/gl/src/ipfs_cmd.rs
@@ -49,9 +49,13 @@ async fn cmd_list(node: String, dir: Option<PathBuf>) -> Result<()> {
     // error (it already names `gl identity new`) rather than a bare 401.
     let keypair = crate::identity::load_keypair_from_dir(dir.as_deref())?;
     let client = NodeClient::new(&node, Some(keypair));
-    let resp: Value = client
-        .get_signed("/api/v1/ipfs/pins")
-        .await?
+    let resp = client.get_signed("/api/v1/ipfs/pins").await?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("node returned {status} for pins listing: {body}");
+    }
+    let resp: Value = resp
         .json()
         .await
         .context("failed to parse pins response")?;
@@ -203,6 +207,33 @@ mod tests {
             err.to_string().contains("gl identity new")
                 || err.to_string().contains("no identity found"),
             "error should name `gl identity new`, got: {err}"
+        );
+
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_cmd_list_non_success_status_is_error_not_empty() {
+        let mut server = mockito::Server::new_async().await;
+        let keystore = seed_keystore();
+
+        // A signed request the node rejects (401) must surface as an error,
+        // not be silently parsed into an empty pin list.
+        let m = server
+            .mock("GET", "/api/v1/ipfs/pins")
+            .match_header("signature", mockito::Matcher::Any)
+            .with_status(401)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"error":"unauthorized"}"#)
+            .create_async()
+            .await;
+
+        let err = cmd_list(server.url(), Some(keystore.path().to_path_buf()))
+            .await
+            .expect_err("non-2xx status should be an error");
+        assert!(
+            err.to_string().contains("401"),
+            "error should mention the status, got: {err}"
         );
 
         m.assert_async().await;

--- a/crates/gl/src/ipfs_cmd.rs
+++ b/crates/gl/src/ipfs_cmd.rs
@@ -3,6 +3,8 @@
 //! Communicates with the gitlawb node to list pinned CIDs and retrieve git
 //! objects by their content-addressed CID.
 
+use std::path::PathBuf;
+
 use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 use serde_json::Value;
@@ -21,6 +23,9 @@ pub enum IpfsCmd {
     List {
         #[arg(long, default_value = "https://node.gitlawb.com", env = "GITLAWB_NODE")]
         node: String,
+        /// Identity directory (default: ~/.gitlawb)
+        #[arg(long)]
+        dir: Option<PathBuf>,
     },
     /// Retrieve and display a git object from the node by its CIDv1
     Get {
@@ -33,15 +38,19 @@ pub enum IpfsCmd {
 
 pub async fn run(args: IpfsArgs) -> Result<()> {
     match args.cmd {
-        IpfsCmd::List { node } => cmd_list(node).await,
+        IpfsCmd::List { node, dir } => cmd_list(node, dir).await,
         IpfsCmd::Get { cid, node } => cmd_get(cid, node).await,
     }
 }
 
-async fn cmd_list(node: String) -> Result<()> {
-    let client = NodeClient::new(&node, None);
+async fn cmd_list(node: String, dir: Option<PathBuf>) -> Result<()> {
+    // #134 gates /api/v1/ipfs/pins behind auth: sign the request with the
+    // caller's identity. On no identity, propagate load_keypair_from_dir's
+    // error (it already names `gl identity new`) rather than a bare 401.
+    let keypair = crate::identity::load_keypair_from_dir(dir.as_deref())?;
+    let client = NodeClient::new(&node, Some(keypair));
     let resp: Value = client
-        .get("/api/v1/ipfs/pins")
+        .get_signed("/api/v1/ipfs/pins")
         .await?
         .json()
         .await
@@ -107,4 +116,95 @@ async fn cmd_get(cid: String, node: String) -> Result<()> {
         .context("failed to write to stdout")?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Seed a keypair into a temp dir the way `load_keypair_from_dir` expects,
+    /// then return the dir handle (keeps it alive for the test's duration).
+    fn seed_keystore() -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().unwrap();
+        let kp = gitlawb_core::identity::Keypair::generate();
+        std::fs::write(
+            dir.path().join("identity.pem"),
+            kp.to_pem().unwrap().as_bytes(),
+        )
+        .unwrap();
+        dir
+    }
+
+    #[tokio::test]
+    async fn test_cmd_list_signs_request_and_renders_pins() {
+        let mut server = mockito::Server::new_async().await;
+        let keystore = seed_keystore();
+
+        // Happy path: signed GET to /api/v1/ipfs/pins carrying the RFC 9421
+        // signature headers, node returns a populated pins body.
+        let m = server
+            .mock("GET", "/api/v1/ipfs/pins")
+            .match_header("signature", mockito::Matcher::Any)
+            .match_header("signature-input", mockito::Matcher::Any)
+            .match_header("content-digest", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"pins":[{"cid":"bafyone","sha256_hex":"abc123","pinned_at":"2026-07-02T12:00:00.123456Z"}],"count":1}"#,
+            )
+            .create_async()
+            .await;
+
+        cmd_list(server.url(), Some(keystore.path().to_path_buf()))
+            .await
+            .unwrap();
+
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_cmd_list_empty_pins() {
+        let mut server = mockito::Server::new_async().await;
+        let keystore = seed_keystore();
+
+        let m = server
+            .mock("GET", "/api/v1/ipfs/pins")
+            .match_header("signature", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"pins":[],"count":0}"#)
+            .create_async()
+            .await;
+
+        cmd_list(server.url(), Some(keystore.path().to_path_buf()))
+            .await
+            .unwrap();
+
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_cmd_list_no_identity_errors_without_request() {
+        let mut server = mockito::Server::new_async().await;
+        // Empty keystore dir: no identity.pem present.
+        let empty = tempfile::TempDir::new().unwrap();
+
+        // The endpoint must never be hit when there is no identity.
+        let m = server
+            .mock("GET", "/api/v1/ipfs/pins")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let err = cmd_list(server.url(), Some(empty.path().to_path_buf()))
+            .await
+            .expect_err("no identity should be an error");
+        assert!(
+            err.to_string().contains("gl identity new")
+                || err.to_string().contains("no identity found"),
+            "error should name `gl identity new`, got: {err}"
+        );
+
+        m.assert_async().await;
+    }
 }

--- a/crates/gl/src/ipfs_cmd.rs
+++ b/crates/gl/src/ipfs_cmd.rs
@@ -55,10 +55,7 @@ async fn cmd_list(node: String, dir: Option<PathBuf>) -> Result<()> {
         let body = resp.text().await.unwrap_or_default();
         anyhow::bail!("node returned {status} for pins listing: {body}");
     }
-    let resp: Value = resp
-        .json()
-        .await
-        .context("failed to parse pins response")?;
+    let resp: Value = resp.json().await.context("failed to parse pins response")?;
 
     let pins = resp["pins"].as_array().cloned().unwrap_or_default();
     let count = resp["count"].as_u64().unwrap_or(pins.len() as u64);

--- a/crates/gl/src/node.rs
+++ b/crates/gl/src/node.rs
@@ -685,6 +685,18 @@ mod tests {
         }
     }
 
+    // Mirror of the above for the absent-`--dir` case: `None` must never resolve to
+    // DirUnusable — it degrades to Anonymous (no default keystore) or Keyed (one
+    // present). Env-independent: only the None->DirUnusable mapping is guarded, so it
+    // holds whether or not the runner has a default `~/.gitlawb` identity.
+    #[test]
+    fn resolve_pins_auth_none_is_never_dir_unusable() {
+        assert!(
+            !matches!(resolve_pins_auth(None), PinsAuth::DirUnusable(_)),
+            "absent --dir must degrade to Anonymous (or Keyed), never DirUnusable"
+        );
+    }
+
     // The success wiring for #146: an explicit --dir with a valid identity must
     // load that key (dir -> load_keypair_from_dir -> Keyed), so the pins read is
     // signed with the selected identity rather than the default keystore.
@@ -697,9 +709,16 @@ mod tests {
             kp.to_pem().unwrap().as_bytes(),
         )
         .unwrap();
-        assert!(
-            matches!(resolve_pins_auth(Some(dir.path())), PinsAuth::Keyed(_)),
-            "an explicit --dir with a valid identity must resolve to Keyed"
+        let PinsAuth::Keyed(loaded) = resolve_pins_auth(Some(dir.path())) else {
+            panic!("an explicit --dir with a valid identity must resolve to Keyed");
+        };
+        // A bare `Keyed(_)` match would also pass if load fell through to the default
+        // keystore; assert the loaded identity is the one written to --dir so the pins
+        // read signs with the selected key, never the default.
+        assert_eq!(
+            loaded.did(),
+            kp.did(),
+            "must sign with the identity from --dir, not the default keystore"
         );
     }
 

--- a/crates/gl/src/node.rs
+++ b/crates/gl/src/node.rs
@@ -225,6 +225,18 @@ async fn fetch_pins(node: &str, keypair: Option<Keypair>) -> PinsPanel {
     }
 }
 
+/// Render the one-line pins-panel status for the `gl node status` dashboard.
+fn pins_status_line(panel: &PinsPanel) -> String {
+    match panel {
+        PinsPanel::Pins(count) => format!("  Pinned CIDs: {count}"),
+        PinsPanel::Empty => "  Pinned CIDs: 0".to_string(),
+        PinsPanel::Unavailable => "  IPFS pins: unavailable".to_string(),
+        PinsPanel::NeedsIdentity => {
+            "  IPFS pins: sign in to view (run `gl identity new`)".to_string()
+        }
+    }
+}
+
 async fn cmd_status(node: String) -> Result<()> {
     let client = NodeClient::new(&node, None);
 
@@ -360,20 +372,7 @@ async fn cmd_status(node: String) -> Result<()> {
 
     // Pins
     println!("Pins");
-    match pins_panel {
-        PinsPanel::Pins(count) => {
-            println!("  Pinned CIDs: {count}");
-        }
-        PinsPanel::Empty => {
-            println!("  Pinned CIDs: 0");
-        }
-        PinsPanel::Unavailable => {
-            println!("  IPFS pins: unavailable");
-        }
-        PinsPanel::NeedsIdentity => {
-            println!("  IPFS pins: sign in to view (run `gl identity new`)");
-        }
-    }
+    println!("{}", pins_status_line(&pins_panel));
     println!();
 
     Ok(())
@@ -569,5 +568,61 @@ mod tests {
         );
 
         m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_pins_malformed_body_returns_unavailable() {
+        let mut server = mockito::Server::new_async().await;
+        let kp = Keypair::generate();
+
+        // 2xx but the body is not valid JSON: must degrade to Unavailable,
+        // never panic.
+        let m = server
+            .mock("GET", "/api/v1/ipfs/pins")
+            .match_header("signature", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("not json{{{")
+            .create_async()
+            .await;
+
+        let panel = fetch_pins(&server.url(), Some(kp)).await;
+        assert!(
+            matches!(panel, PinsPanel::Unavailable),
+            "malformed body -> Unavailable, got {panel:?}"
+        );
+
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_pins_transport_error_returns_unavailable() {
+        // Bind then drop to obtain a definitely-closed port -> connection
+        // refused -> get_signed Err -> Unavailable (no panic).
+        let port = {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            l.local_addr().unwrap().port()
+        };
+        let kp = Keypair::generate();
+
+        let panel = fetch_pins(&format!("http://127.0.0.1:{port}"), Some(kp)).await;
+        assert!(
+            matches!(panel, PinsPanel::Unavailable),
+            "transport error -> Unavailable, got {panel:?}"
+        );
+    }
+
+    #[test]
+    fn test_pins_status_line_renders_each_state() {
+        assert_eq!(pins_status_line(&PinsPanel::Pins(3)), "  Pinned CIDs: 3");
+        assert_eq!(pins_status_line(&PinsPanel::Empty), "  Pinned CIDs: 0");
+        assert_eq!(
+            pins_status_line(&PinsPanel::Unavailable),
+            "  IPFS pins: unavailable"
+        );
+        assert_eq!(
+            pins_status_line(&PinsPanel::NeedsIdentity),
+            "  IPFS pins: sign in to view (run `gl identity new`)"
+        );
     }
 }

--- a/crates/gl/src/node.rs
+++ b/crates/gl/src/node.rs
@@ -186,8 +186,8 @@ async fn try_get_json(client: &NodeClient, path: &str) -> Option<Value> {
 /// sign in. A pins failure never aborts the dashboard.
 #[derive(Debug)]
 enum PinsPanel {
-    /// Signed read succeeded and returned pins (carries the raw JSON body).
-    Pins(Value),
+    /// Signed read succeeded and returned pins (carries the resolved count).
+    Pins(u64),
     /// Signed read succeeded but the node has no pins recorded.
     Empty,
     /// Signed read was rejected (401/other) or errored.
@@ -221,7 +221,7 @@ async fn fetch_pins(node: &str, keypair: Option<Keypair>) -> PinsPanel {
     if count == 0 {
         PinsPanel::Empty
     } else {
-        PinsPanel::Pins(body)
+        PinsPanel::Pins(count)
     }
 }
 
@@ -361,14 +361,11 @@ async fn cmd_status(node: String) -> Result<()> {
     // Pins
     println!("Pins");
     match pins_panel {
-        PinsPanel::Pins(ref pins) => {
-            let count = pins["count"]
-                .as_u64()
-                .unwrap_or_else(|| pins["pins"].as_array().map(|a| a.len() as u64).unwrap_or(0));
+        PinsPanel::Pins(count) => {
             println!("  Pinned CIDs: {count}");
         }
         PinsPanel::Empty => {
-            println!("  IPFS not configured");
+            println!("  Pinned CIDs: 0");
         }
         PinsPanel::Unavailable => {
             println!("  IPFS pins: unavailable");
@@ -499,10 +496,7 @@ mod tests {
 
         let panel = fetch_pins(&server.url(), Some(kp)).await;
         match panel {
-            PinsPanel::Pins(pins) => {
-                assert_eq!(pins["count"].as_u64(), Some(1));
-                assert_eq!(pins["pins"].as_array().map(|a| a.len()), Some(1));
-            }
+            PinsPanel::Pins(count) => assert_eq!(count, 1),
             other => panic!("expected Pins, got {other:?}"),
         }
 

--- a/crates/gl/src/node.rs
+++ b/crates/gl/src/node.rs
@@ -2,10 +2,12 @@
 
 use anyhow::Result;
 use clap::{Args, Subcommand};
+use gitlawb_core::identity::Keypair;
 use serde_json::Value;
 use std::path::PathBuf;
 
 use crate::http::NodeClient;
+use crate::identity::load_keypair_from_dir;
 use crate::node_stake;
 
 #[derive(Args)]
@@ -177,6 +179,52 @@ async fn try_get_json(client: &NodeClient, path: &str) -> Option<Value> {
     resp.json::<Value>().await.ok()
 }
 
+/// Outcome of fetching the IPFS pins panel for `gl node status`.
+///
+/// #134 gates `/api/v1/ipfs/pins` behind auth, so this panel signs its request
+/// when an identity is available and otherwise reports that the caller must
+/// sign in. A pins failure never aborts the dashboard.
+#[derive(Debug)]
+enum PinsPanel {
+    /// Signed read succeeded and returned pins (carries the raw JSON body).
+    Pins(Value),
+    /// Signed read succeeded but the node has no pins recorded.
+    Empty,
+    /// Signed read was rejected (401/other) or errored.
+    Unavailable,
+    /// No identity available; no request was issued.
+    NeedsIdentity,
+}
+
+/// Fetch the pins panel state. With a keypair, signs the `/api/v1/ipfs/pins`
+/// read and maps the outcome; without one, returns `NeedsIdentity` and issues
+/// no request. Injectable (node URL + optional keypair) so tests drive it with
+/// a mock server and never touch the default keystore.
+async fn fetch_pins(node: &str, keypair: Option<Keypair>) -> PinsPanel {
+    let Some(kp) = keypair else {
+        return PinsPanel::NeedsIdentity;
+    };
+    let client = NodeClient::new(node, Some(kp));
+    let resp = match client.get_signed("/api/v1/ipfs/pins").await {
+        Ok(r) => r,
+        Err(_) => return PinsPanel::Unavailable,
+    };
+    if !resp.status().is_success() {
+        return PinsPanel::Unavailable;
+    }
+    let Ok(body) = resp.json::<Value>().await else {
+        return PinsPanel::Unavailable;
+    };
+    let count = body["count"]
+        .as_u64()
+        .unwrap_or_else(|| body["pins"].as_array().map(|a| a.len() as u64).unwrap_or(0));
+    if count == 0 {
+        PinsPanel::Empty
+    } else {
+        PinsPanel::Pins(body)
+    }
+}
+
 async fn cmd_status(node: String) -> Result<()> {
     let client = NodeClient::new(&node, None);
 
@@ -194,13 +242,18 @@ async fn cmd_status(node: String) -> Result<()> {
     let version = info["version"].as_str().unwrap_or("unknown");
     let network = info["network"].as_str().unwrap_or("unknown");
 
+    // The pins panel signs its read (#134 gates /api/v1/ipfs/pins behind auth);
+    // load the identity gracefully so a missing keystore never aborts status.
+    let keypair = load_keypair_from_dir(None).ok();
+
     // ── Fetch remaining endpoints in parallel ─────────────────────────────
-    let (peers_val, repos_val, p2p_val, events_val, pins_val) = tokio::join!(
+    // Peers/repos/p2p/events stay anonymous; only pins is signed.
+    let (peers_val, repos_val, p2p_val, events_val, pins_panel) = tokio::join!(
         try_get_json(&client, "/api/v1/peers"),
         try_get_json(&client, "/api/v1/repos"),
         try_get_json(&client, "/api/v1/p2p/info"),
         try_get_json(&client, "/api/v1/events/ref-updates?limit=5"),
-        try_get_json(&client, "/api/v1/ipfs/pins"),
+        fetch_pins(&node, keypair),
     );
 
     // ── Render dashboard ──────────────────────────────────────────────────
@@ -307,13 +360,22 @@ async fn cmd_status(node: String) -> Result<()> {
 
     // Pins
     println!("Pins");
-    if let Some(ref pins) = pins_val {
-        let count = pins["count"]
-            .as_u64()
-            .unwrap_or_else(|| pins["pins"].as_array().map(|a| a.len() as u64).unwrap_or(0));
-        println!("  Pinned CIDs: {count}");
-    } else {
-        println!("  IPFS not configured");
+    match pins_panel {
+        PinsPanel::Pins(ref pins) => {
+            let count = pins["count"]
+                .as_u64()
+                .unwrap_or_else(|| pins["pins"].as_array().map(|a| a.len() as u64).unwrap_or(0));
+            println!("  Pinned CIDs: {count}");
+        }
+        PinsPanel::Empty => {
+            println!("  IPFS not configured");
+        }
+        PinsPanel::Unavailable => {
+            println!("  IPFS pins: unavailable");
+        }
+        PinsPanel::NeedsIdentity => {
+            println!("  IPFS pins: sign in to view (run `gl identity new`)");
+        }
     }
     println!();
 
@@ -408,4 +470,110 @@ async fn cmd_resolve(did: String, node: String) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gitlawb_core::identity::Keypair;
+
+    #[tokio::test]
+    async fn test_fetch_pins_keyed_happy_signs_and_returns_pins() {
+        let mut server = mockito::Server::new_async().await;
+        let kp = Keypair::generate();
+
+        // A keyed fetch must sign the request (RFC 9421 headers) and, on a
+        // populated 200 body, land in the Pins state carrying the pins.
+        let m = server
+            .mock("GET", "/api/v1/ipfs/pins")
+            .match_header("signature", mockito::Matcher::Any)
+            .match_header("signature-input", mockito::Matcher::Any)
+            .match_header("content-digest", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"pins":[{"cid":"bafyone","sha256_hex":"abc123","pinned_at":"2026-07-02T12:00:00Z"}],"count":1}"#,
+            )
+            .create_async()
+            .await;
+
+        let panel = fetch_pins(&server.url(), Some(kp)).await;
+        match panel {
+            PinsPanel::Pins(pins) => {
+                assert_eq!(pins["count"].as_u64(), Some(1));
+                assert_eq!(pins["pins"].as_array().map(|a| a.len()), Some(1));
+            }
+            other => panic!("expected Pins, got {other:?}"),
+        }
+
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_pins_keyed_empty_returns_empty() {
+        let mut server = mockito::Server::new_async().await;
+        let kp = Keypair::generate();
+
+        let m = server
+            .mock("GET", "/api/v1/ipfs/pins")
+            .match_header("signature", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"pins":[],"count":0}"#)
+            .create_async()
+            .await;
+
+        let panel = fetch_pins(&server.url(), Some(kp)).await;
+        assert!(
+            matches!(panel, PinsPanel::Empty),
+            "expected Empty, got {panel:?}"
+        );
+
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_pins_keyed_rejected_returns_unavailable() {
+        let mut server = mockito::Server::new_async().await;
+        let kp = Keypair::generate();
+
+        // Node rejects the signed read (401): the panel must degrade to
+        // Unavailable without panicking, so cmd_status still completes.
+        let m = server
+            .mock("GET", "/api/v1/ipfs/pins")
+            .match_header("signature", mockito::Matcher::Any)
+            .with_status(401)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"error":"unauthorized"}"#)
+            .create_async()
+            .await;
+
+        let panel = fetch_pins(&server.url(), Some(kp)).await;
+        assert!(
+            matches!(panel, PinsPanel::Unavailable),
+            "expected Unavailable, got {panel:?}"
+        );
+
+        m.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_pins_unkeyed_needs_identity_without_request() {
+        let mut server = mockito::Server::new_async().await;
+
+        // With no keypair the endpoint must never be hit.
+        let m = server
+            .mock("GET", "/api/v1/ipfs/pins")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let panel = fetch_pins(&server.url(), None).await;
+        assert!(
+            matches!(panel, PinsPanel::NeedsIdentity),
+            "expected NeedsIdentity, got {panel:?}"
+        );
+
+        m.assert_async().await;
+    }
 }

--- a/crates/gl/src/node.rs
+++ b/crates/gl/src/node.rs
@@ -22,6 +22,9 @@ pub enum NodeCmd {
     Status {
         #[arg(long, default_value = "https://node.gitlawb.com", env = "GITLAWB_NODE")]
         node: String,
+        /// Identity directory (default: ~/.gitlawb)
+        #[arg(long)]
+        dir: Option<PathBuf>,
     },
     /// Check trust score for a DID
     Trust {
@@ -123,7 +126,7 @@ pub enum NodeCmd {
 
 pub async fn run(args: NodeArgs) -> Result<()> {
     match args.cmd {
-        NodeCmd::Status { node } => cmd_status(node).await,
+        NodeCmd::Status { node, dir } => cmd_status(node, dir).await,
         NodeCmd::Trust { did, node } => cmd_trust(did, node).await,
         NodeCmd::Resolve { did, node } => cmd_resolve(did, node).await,
         NodeCmd::Register {
@@ -194,15 +197,48 @@ enum PinsPanel {
     Unavailable,
     /// No identity available; no request was issued.
     NeedsIdentity,
+    /// An explicit `--dir` was given but held no usable identity; carries the dir
+    /// so the panel can name it instead of the misleading "sign in" prompt.
+    IdentityError(PathBuf),
+}
+
+/// Identity resolved for the signed pins read, decided before the request so the
+/// dashboard can distinguish "no identity at all" from "an explicit `--dir` that
+/// could not be loaded".
+enum PinsAuth {
+    /// A usable keypair; the read will be signed.
+    Keyed(Keypair),
+    /// No identity requested and none in the default keystore.
+    Anonymous,
+    /// An explicit `--dir` was given but held no usable identity (carries the dir).
+    DirUnusable(PathBuf),
+}
+
+/// Resolve the pins-panel identity from an optional `--dir`. Mirrors `gl ipfs
+/// list`'s identity selection: an explicit `--dir` that fails to load is reported
+/// as `DirUnusable` (so the panel names the bad path) rather than collapsing to
+/// the misleading "sign in to view"; a missing default keystore (no `--dir`)
+/// degrades quietly to `Anonymous`.
+fn resolve_pins_auth(dir: Option<&std::path::Path>) -> PinsAuth {
+    match load_keypair_from_dir(dir) {
+        Ok(kp) => PinsAuth::Keyed(kp),
+        Err(_) => match dir {
+            Some(d) => PinsAuth::DirUnusable(d.to_path_buf()),
+            None => PinsAuth::Anonymous,
+        },
+    }
 }
 
 /// Fetch the pins panel state. With a keypair, signs the `/api/v1/ipfs/pins`
-/// read and maps the outcome; without one, returns `NeedsIdentity` and issues
-/// no request. Injectable (node URL + optional keypair) so tests drive it with
-/// a mock server and never touch the default keystore.
-async fn fetch_pins(node: &str, keypair: Option<Keypair>) -> PinsPanel {
-    let Some(kp) = keypair else {
-        return PinsPanel::NeedsIdentity;
+/// read and maps the outcome; with no identity it returns `NeedsIdentity`, and
+/// with an unusable explicit `--dir` it returns `IdentityError` — both without
+/// issuing a request. Injectable (node URL + resolved auth) so tests drive it
+/// with a mock server and never touch the default keystore.
+async fn fetch_pins(node: &str, auth: PinsAuth) -> PinsPanel {
+    let kp = match auth {
+        PinsAuth::Keyed(kp) => kp,
+        PinsAuth::Anonymous => return PinsPanel::NeedsIdentity,
+        PinsAuth::DirUnusable(dir) => return PinsPanel::IdentityError(dir),
     };
     let client = NodeClient::new(node, Some(kp));
     let resp = match client.get_signed("/api/v1/ipfs/pins").await {
@@ -234,10 +270,13 @@ fn pins_status_line(panel: &PinsPanel) -> String {
         PinsPanel::NeedsIdentity => {
             "  IPFS pins: sign in to view (run `gl identity new`)".to_string()
         }
+        PinsPanel::IdentityError(dir) => {
+            format!("  IPFS pins: no usable identity in {}", dir.display())
+        }
     }
 }
 
-async fn cmd_status(node: String) -> Result<()> {
+async fn cmd_status(node: String, dir: Option<PathBuf>) -> Result<()> {
     let client = NodeClient::new(&node, None);
 
     // ── Fetch node info (required — bail if unreachable) ──────────────────
@@ -254,9 +293,12 @@ async fn cmd_status(node: String) -> Result<()> {
     let version = info["version"].as_str().unwrap_or("unknown");
     let network = info["network"].as_str().unwrap_or("unknown");
 
-    // The pins panel signs its read (#134 gates /api/v1/ipfs/pins behind auth);
-    // load the identity gracefully so a missing keystore never aborts status.
-    let keypair = load_keypair_from_dir(None).ok();
+    // The pins panel signs its read (#134 gates /api/v1/ipfs/pins behind auth).
+    // `--dir` selects the same identity directory as `gl ipfs list` (#146); an
+    // explicit --dir that can't be loaded is surfaced in the panel rather than
+    // masquerading as "no identity", while a missing default keystore degrades
+    // quietly. A pins failure never aborts the dashboard.
+    let pins_auth = resolve_pins_auth(dir.as_deref());
 
     // ── Fetch remaining endpoints in parallel ─────────────────────────────
     // Peers/repos/p2p/events stay anonymous; only pins is signed.
@@ -265,7 +307,7 @@ async fn cmd_status(node: String) -> Result<()> {
         try_get_json(&client, "/api/v1/repos"),
         try_get_json(&client, "/api/v1/p2p/info"),
         try_get_json(&client, "/api/v1/events/ref-updates?limit=5"),
-        fetch_pins(&node, keypair),
+        fetch_pins(&node, pins_auth),
     );
 
     // ── Render dashboard ──────────────────────────────────────────────────
@@ -493,7 +535,7 @@ mod tests {
             .create_async()
             .await;
 
-        let panel = fetch_pins(&server.url(), Some(kp)).await;
+        let panel = fetch_pins(&server.url(), PinsAuth::Keyed(kp)).await;
         match panel {
             PinsPanel::Pins(count) => assert_eq!(count, 1),
             other => panic!("expected Pins, got {other:?}"),
@@ -516,7 +558,7 @@ mod tests {
             .create_async()
             .await;
 
-        let panel = fetch_pins(&server.url(), Some(kp)).await;
+        let panel = fetch_pins(&server.url(), PinsAuth::Keyed(kp)).await;
         assert!(
             matches!(panel, PinsPanel::Empty),
             "expected Empty, got {panel:?}"
@@ -541,7 +583,7 @@ mod tests {
             .create_async()
             .await;
 
-        let panel = fetch_pins(&server.url(), Some(kp)).await;
+        let panel = fetch_pins(&server.url(), PinsAuth::Keyed(kp)).await;
         assert!(
             matches!(panel, PinsPanel::Unavailable),
             "expected Unavailable, got {panel:?}"
@@ -561,7 +603,7 @@ mod tests {
             .create_async()
             .await;
 
-        let panel = fetch_pins(&server.url(), None).await;
+        let panel = fetch_pins(&server.url(), PinsAuth::Anonymous).await;
         assert!(
             matches!(panel, PinsPanel::NeedsIdentity),
             "expected NeedsIdentity, got {panel:?}"
@@ -586,7 +628,7 @@ mod tests {
             .create_async()
             .await;
 
-        let panel = fetch_pins(&server.url(), Some(kp)).await;
+        let panel = fetch_pins(&server.url(), PinsAuth::Keyed(kp)).await;
         assert!(
             matches!(panel, PinsPanel::Unavailable),
             "malformed body -> Unavailable, got {panel:?}"
@@ -605,7 +647,7 @@ mod tests {
         };
         let kp = Keypair::generate();
 
-        let panel = fetch_pins(&format!("http://127.0.0.1:{port}"), Some(kp)).await;
+        let panel = fetch_pins(&format!("http://127.0.0.1:{port}"), PinsAuth::Keyed(kp)).await;
         assert!(
             matches!(panel, PinsPanel::Unavailable),
             "transport error -> Unavailable, got {panel:?}"
@@ -624,5 +666,94 @@ mod tests {
             pins_status_line(&PinsPanel::NeedsIdentity),
             "  IPFS pins: sign in to view (run `gl identity new`)"
         );
+        assert_eq!(
+            pins_status_line(&PinsPanel::IdentityError(PathBuf::from("/tmp/id"))),
+            "  IPFS pins: no usable identity in /tmp/id"
+        );
+    }
+
+    // Adversarial follow-up to jatmn #146 P2: an explicit `--dir` that holds no
+    // usable identity must resolve to DirUnusable (which names the path), NOT the
+    // Anonymous "sign in to view / run `gl identity new`" case — otherwise a user
+    // who did supply an identity dir is misdirected to create one they may have.
+    #[test]
+    fn resolve_pins_auth_reports_explicit_bad_dir_as_unusable() {
+        let bad = PathBuf::from("/nonexistent/gl-id-xyz");
+        match resolve_pins_auth(Some(&bad)) {
+            PinsAuth::DirUnusable(d) => assert_eq!(d, bad),
+            _ => panic!("explicit unusable --dir must be DirUnusable, not Anonymous"),
+        }
+    }
+
+    // The success wiring for #146: an explicit --dir with a valid identity must
+    // load that key (dir -> load_keypair_from_dir -> Keyed), so the pins read is
+    // signed with the selected identity rather than the default keystore.
+    #[test]
+    fn resolve_pins_auth_loads_keyed_identity_from_explicit_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let kp = Keypair::generate();
+        std::fs::write(
+            dir.path().join("identity.pem"),
+            kp.to_pem().unwrap().as_bytes(),
+        )
+        .unwrap();
+        assert!(
+            matches!(resolve_pins_auth(Some(dir.path())), PinsAuth::Keyed(_)),
+            "an explicit --dir with a valid identity must resolve to Keyed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_pins_dir_unusable_reports_identity_error_without_request() {
+        let mut server = mockito::Server::new_async().await;
+        // An unusable explicit --dir must render the identity error and never hit
+        // the endpoint (no identity to sign with).
+        let m = server
+            .mock("GET", "/api/v1/ipfs/pins")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let bad = PathBuf::from("/nonexistent/gl-id-xyz");
+        let panel = fetch_pins(&server.url(), PinsAuth::DirUnusable(bad.clone())).await;
+        match panel {
+            PinsPanel::IdentityError(d) => assert_eq!(d, bad),
+            other => panic!("expected IdentityError, got {other:?}"),
+        }
+
+        m.assert_async().await;
+    }
+
+    // jatmn #146 P2: `gl node status` must accept the same `--dir` identity
+    // selector as `gl ipfs list`, so a user who selected an identity via --dir can
+    // authenticate the status pins panel instead of seeing "sign in to view".
+    #[test]
+    fn status_accepts_dir_identity_selector() {
+        use clap::Parser;
+        #[derive(Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            args: NodeArgs,
+        }
+        let cli = TestCli::try_parse_from([
+            "gl",
+            "status",
+            "--node",
+            "http://example",
+            "--dir",
+            "/tmp/id",
+        ])
+        .expect("`node status` must accept --dir");
+        let NodeCmd::Status { dir, .. } = cli.args.cmd else {
+            panic!("expected the Status subcommand");
+        };
+        assert_eq!(dir, Some(PathBuf::from("/tmp/id")));
+
+        // Absent --dir must stay None so the default keystore path is unchanged.
+        let cli = TestCli::try_parse_from(["gl", "status"]).expect("status parses without --dir");
+        let NodeCmd::Status { dir, .. } = cli.args.cmd else {
+            panic!("expected the Status subcommand");
+        };
+        assert_eq!(dir, None);
     }
 }


### PR DESCRIPTION
PR #134 gates `/api/v1/ipfs/pins` behind authentication (anonymous callers get 401). Two `gl` CLI call sites still hit it unsigned, so once #134 ships they break: `gl ipfs list` returns a hard 401, and the `gl node status` pins panel silently shows nothing. This signs both reads with the caller's identity through the existing `NodeClient::get_signed`, so the CLI keeps working under the gate.

Scope is pins-only:

- `gl ipfs list` now loads the identity (via `--dir`, defaulting to the standard keystore) and signs the request. With no identity it fails with the existing `gl identity new` guidance instead of a raw 401, and it now surfaces a non-2xx response as an error rather than parsing it into an empty list.
- `gl node status` loads the identity gracefully and signs only the pins panel, via an injectable `fetch_pins` helper with four states (pins, empty, unavailable, sign-in-required). The peers, repos, p2p, and events panels stay anonymous, and a pins failure never aborts the dashboard.

`/api/v1/arweave/anchors` (the other endpoint #134 gates) is never called by the CLI, so it is out of scope.

A note on behavior: the pin listing is visibility-filtered (every repo the caller can read, public plus their own private), not scoped to the caller's own objects. The auth requirement exists to stop anonymous enumeration of the node-wide pin index, so the CLI has to authenticate, but the result is the caller's readable view.

This should land in the same release as #134 so no published build ships the broken CLI.

Tests are mockito-based (no database): signed-header presence, the no-identity and non-2xx error paths, and all four node-status pins states including the transport-error and malformed-body branches. The `gl` suite passes (236 tests).

Closes the CLI regression noted in the #134 review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `gl node status` now supports an optional `--dir` selector to use a specific identity when checking node status.
  * The Pins section now shows clearer states, including pinned content, empty results, unavailable, and identity-related errors.

* **Bug Fixes**
  * Improved handling of signed pin requests and fallback behavior when no identity is available.
  * Better reporting for empty, rejected, malformed, and network-error responses in the Pins view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->