### PR TITLE
fix(node): make creation-route rate limit configurable; fix(gl): surface real errors on pr create failure

### DIFF
--- a/crates/gitlawb-node/src/config.rs
+++ b/crates/gitlawb-node/src/config.rs
@@ -152,6 +152,16 @@ pub struct Config {
     /// in flight and exits. Default: 30s.
     #[arg(long, env = "GITLAWB_SHUTDOWN_GRACE_SECS", default_value_t = 30)]
     pub shutdown_grace_secs: u64,
+
+    /// Maximum number of creation requests (repo create, issue create, PR
+    /// create, register, fork) allowed per DID within the rate-limit window.
+    #[arg(long, env = "GITLAWB_RATE_LIMIT_MAX", default_value_t = 10)]
+    pub rate_limit_max_requests: u32,
+
+    /// Rate-limit window size, in seconds, over which
+    /// `rate_limit_max_requests` applies.
+    #[arg(long, env = "GITLAWB_RATE_LIMIT_WINDOW_SECS", default_value_t = 3600)]
+    pub rate_limit_window_secs: u64,
 }
 
 impl Config {

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -190,7 +190,10 @@ async fn main() -> Result<()> {
     let repo_store =
         git::repo_store::RepoStore::new(config.repos_dir.clone(), tigris, db.pool().clone());
 
-    let rate_limiter = rate_limit::RateLimiter::new(10, std::time::Duration::from_secs(3600));
+    let rate_limiter = rate_limit::RateLimiter::new(
+        config.rate_limit_max_requests as usize,
+        std::time::Duration::from_secs(config.rate_limit_window_secs),
+    );
 
     // Initialize the iCaptcha proof gate (inert unless ICAPTCHA_MODE is set).
     icaptcha::init().await;

--- a/crates/gl/src/pr.rs
+++ b/crates/gl/src/pr.rs
@@ -234,12 +234,11 @@ async fn cmd_create(
         .await
         .context("failed to connect to node")?;
     let status = resp.status();
-    let pr: Value = resp.json().await.context("invalid JSON")?;
-
+    let raw_text = resp.text().await.context("failed to read response body")?;
     if !status.is_success() {
-        let msg = pr["message"].as_str().unwrap_or("unknown error");
-        anyhow::bail!("create PR failed ({status}): {msg}");
+        anyhow::bail!("create PR failed ({status}): {raw_text}");
     }
+    let pr: Value = serde_json::from_str(&raw_text).context("invalid JSON")?;
 
     let number = pr["number"].as_i64().unwrap_or(0);
     println!("✓ Opened PR #{number}: {title}");


### PR DESCRIPTION
Two small, independent fixes found while building an autonomous agent on gitlawb:

## 1. Configurable creation-route rate limit (gitlawb-node)

The rate limiter was hardcoded to 10 requests/hour per DID, shared across the whole creation-routes group (repo create, issue create, PR create, register, fork):

```rust
let rate_limiter = rate_limit::RateLimiter::new(10, std::time::Duration::from_secs(3600));
```

This is workable for a human clicking around, but a real agent/bot doing modest volume (or retrying after a transient error) hits the wall fast, with no way to raise it short of recompiling. We hit this directly running an ACP-hired worker agent — it also caused a real job to expire mid-SLA while rate-limited.

This PR adds two config fields following the existing clap env-var pattern already used throughout `Config`:

- `GITLAWB_RATE_LIMIT_MAX` (default 10, unchanged)
- `GITLAWB_RATE_LIMIT_WINDOW_SECS` (default 3600, unchanged)

`main.rs` now builds the limiter from config instead of the hardcoded values. No behavior changes unless a node operator explicitly opts in.

## 2. `gl pr create` masks the real error on failure

```rust
let pr: Value = resp.json().await.context("invalid JSON")?;
if !status.is_success() {
    let msg = pr["message"].as_str().unwrap_or("unknown error");
    anyhow::bail!("create PR failed ({status}): {msg}");
}
```

Calling `.json()` before checking `status` means any non-2xx response with an empty or non-JSON body (e.g. a 404 from a malformed URL) crashes with a generic "invalid JSON" error instead of the real one. Fixed by reading the raw response body first and including it in the error message when the request fails.

## Testing

Both changes verified with `cargo check -p gitlawb-node -p gl` — compiles clean, no warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable request rate limits with defaults, allowing creation throttling to be adjusted via environment settings.

* **Bug Fixes**
  * Improved create-request error messages so failures now include the HTTP status and full server response.
  * Preserved successful response handling while making error reporting clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->