### PR TITLE
ci: pin cargo-audit on the blocking gate, float the weekly canary

### DIFF
--- a/.github/workflows/audit-schedule.yml
+++ b/.github/workflows/audit-schedule.yml
@@ -37,7 +37,18 @@ jobs:
         with:
           key: audit-schedule
 
-      - name: Install cargo-audit
+      - name: Install cargo-audit (floating; drift canary)
+        # Deliberately UNPINNED, unlike the blocking gate in pr-checks.yml. This
+        # job is cron-only (weekly); it is never pull_request- or push-triggered,
+        # so it NEVER gates a merge no matter what it does. Floating the scanner
+        # here is the drift canary: if a newer cargo-audit regresses, at worst
+        # this weekly run reds (the install step below is unguarded) or its
+        # visibility report changes, and that is exactly the signal that latest
+        # has moved and the pinned gate should not be bumped yet. The scan result
+        # itself never fails the run (the "Full audit report" step is `|| true`
+        # and the only other hard-fail is a Cargo.lock grep). The point is that
+        # drift surfaces here without ever blocking a PR. Do NOT pin to match
+        # pr-checks.yml.
         run: cargo install --locked cargo-audit
 
       # Full advisory report with NO suppressions. Run from a scratch dir that

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -133,10 +133,30 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
         with:
-          key: audit
+          key: audit-0.22.2
 
-      - name: Install cargo-audit
-        run: cargo install --locked cargo-audit
+      - name: Install cargo-audit (pinned)
+        # Pin the scanner on this BLOCKING gate: an unpinned `cargo install`
+        # floats to the latest release, so a regressed cargo-audit could red CI
+        # repo-wide with no code change. Advisory-DB freshness is fetched at scan
+        # time, independent of the binary, so this does not weaken what the gate
+        # catches. The weekly Scheduled Audit (audit-schedule.yml) deliberately
+        # floats to latest as the drift canary; when it shows a newer cargo-audit
+        # behaving differently, bump this version (and the cache key above) as a
+        # deliberate maintainer action. If 0.22.2 is ever yanked from crates.io
+        # this step fails loud until the pin is bumped.
+        run: |
+          set -euo pipefail
+          cargo install --locked --version 0.22.2 cargo-audit
+          # Assert the pin took effect so an accidental future unpin (or a drift
+          # off 0.22.2) fails loudly here instead of silently running a different
+          # scanner. `cargo audit --version` prints "cargo-audit-audit 0.22.2".
+          installed="$(cargo audit --version)"
+          echo "cargo-audit installed: $installed"
+          echo "$installed" | grep -qE '(^| )0\.22\.2($| )' || {
+            echo "::error::cargo-audit is not the pinned 0.22.2 (got: $installed)"
+            exit 1
+          }
 
       # Hard-fail gate. Suppressions live in .cargo/audit.toml (read automatically
       # from the repo root), each with no available upstream fix. A green check


### PR DESCRIPTION
The PR-blocking `audit` job installs cargo-audit with an unpinned `cargo install --locked cargo-audit`, so the scanner floats to the latest release on every run. A regressed release then reds the gate repo-wide with no code change, the same spontaneous-breakage class the quinn-proto advisory exposed but on the scanner itself. #57 added the unpinned install; nothing has pinned it since.

**pr-checks.yml (the gate):** pinned to `--version 0.22.2` (what the unpinned install currently resolves to). `cargo install --version X` is an exact pin, not a caret, so it freezes the binary; the RustSec advisory DB is still fetched fresh at scan time, so this does not weaken what the gate catches. The step also asserts the resolved version after install, so an accidental future unpin fails loud instead of silently running a different scanner, and the cargo-audit version is now part of the rust-cache key so hits stay deterministic.

**audit-schedule.yml (weekly canary):** left deliberately unpinned. It is cron-only and never gates a merge, so floating it cannot block a PR; if a newer cargo-audit regresses, the weekly run reds or its report changes, which is the drift signal that latest has moved and the gate's pin should not be bumped yet.

If 0.22.2 is ever yanked the gate's install fails loud until bumped; that bump path is documented in the step comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI audit checks to use a pinned `cargo-audit` version for PR validation, with an added runtime version check to prevent unexpected tool changes.
  * Adjusted the scheduled audit job to use a floating scanner as a drift canary, with clearer workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->