### PR TITLE
fix(node): close two spam-vector root causes (trust upsert + ungated push)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,21 @@ GITLAWB_PUBLIC_READ=true
 # Maximum git smart-HTTP pack request size, in bytes.
 GITLAWB_MAX_PACK_BYTES=2147483648
 
+# ── Push rate limiting (git-receive-pack flood brake) ─────────────────────
+# Max receive-pack requests (info/refs advertisement + push POST) per client
+# IP per hour. 0 disables. Default 600.
+GITLAWB_PUSH_RATE_LIMIT=600
+
+# Which forwarded header the edge is trusted to set, used to resolve the real
+# client IP for the push limiter. One of:
+#   (unset) — no trusted proxy: key on the socket peer address, ignore headers.
+#   fly     — behind Fly's edge (trust Fly-Client-IP).
+#   x-forwarded-for — behind a single reverse proxy like Caddy/NGINX (trust the
+#             rightmost X-Forwarded-For hop).
+# Only set this when a proxy you control actually fronts the node; trusting a
+# forwarded header on a directly-exposed node lets clients spoof the key.
+GITLAWB_TRUSTED_PROXY=
+
 # ── Sync ─────────────────────────────────────────────────────────────────
 # Enable automatic background sync from known peers
 GITLAWB_AUTO_SYNC=false

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -487,6 +487,8 @@ pub async fn git_info_refs(
     State(state): State<AppState>,
     Path((owner, repo)): Path<(String, String)>,
     Query(query): Query<InfoRefsQuery>,
+    crate::rate_limit::PeerAddr(peer): crate::rate_limit::PeerAddr,
+    headers: axum::http::HeaderMap,
     auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Response> {
     let name = repo.trim_end_matches(".git");
@@ -525,6 +527,23 @@ pub async fn git_info_refs(
         {
             tracing::debug!(repo = %name, caller = ?caller, service = %service, "info/refs read denied by visibility");
             return Err(AppError::RepoNotFound(format!("{owner}/{name}")));
+        }
+    }
+
+    // Push flood brake on the advertisement phase. A push always hits this
+    // GET first, and for receive-pack it forces a fresh Tigris download below;
+    // throttling only the receive-pack POST would leave the expensive
+    // fresh-acquire reachable unauthenticated and unlimited. Applied before the
+    // acquire so a rejected request does no Tigris work. Same per-IP limiter and
+    // trusted-proxy policy as the POST middleware (shared buckets).
+    if service == "git-receive-pack" {
+        if let Some(key) = crate::rate_limit::client_key(&headers, peer, state.push_limiter_trust) {
+            if !state.push_rate_limiter.check(&key).await {
+                tracing::warn!(repo = %name, key = %key, "receive-pack advertisement rate limited");
+                return Err(AppError::TooManyRequests(
+                    "push rate limit exceeded — try again later".into(),
+                ));
+            }
         }
     }
 
@@ -2423,6 +2442,51 @@ mod tests {
                 .contains("/did:gitlawb:z6Mkwbud/other-repo.git"),
             "clone_url should preserve the full non-key owner DID. got: {}",
             response_non_key.clone_url
+        );
+    }
+
+    /// The receive-pack *advertisement* (`GET info/refs?service=git-receive-pack`)
+    /// must be throttled by the per-IP push limiter BEFORE it does the fresh
+    /// Tigris acquire — otherwise the flood brake on the POST is bypassable via
+    /// the cheaper unauthenticated GET (PR #152 review P1). Pre-filling the
+    /// bucket makes the assertion deterministic and keeps the test off the
+    /// acquire path entirely.
+    #[sqlx::test]
+    async fn receive_pack_advertisement_is_rate_limited(pool: sqlx::PgPool) {
+        use axum::body::Body;
+        use axum::extract::ConnectInfo;
+        use axum::http::{Method, Request, StatusCode};
+        use std::net::SocketAddr;
+        use std::time::Duration;
+        use tower::ServiceExt;
+
+        let mut state = crate::test_support::test_state(pool).await;
+        // Tiny limit, keyed on the socket peer (no trusted proxy).
+        state.push_rate_limiter = crate::rate_limit::RateLimiter::new(1, Duration::from_secs(60));
+        state.push_limiter_trust = crate::rate_limit::TrustedProxy::None;
+        state
+            .db
+            .upsert_mirror_repo("z6advowner", "adv", "/tmp/adv", None, false)
+            .await
+            .unwrap();
+
+        let peer: SocketAddr = "203.0.113.55:6000".parse().unwrap();
+        // Exhaust this peer's single-request budget up front.
+        assert!(state.push_rate_limiter.check(&peer.ip().to_string()).await);
+
+        let router = crate::server::build_router(state);
+        let mut req = Request::builder()
+            .method(Method::GET)
+            .uri("/z6advowner/adv/info/refs?service=git-receive-pack")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(ConnectInfo(peer));
+
+        let status = router.oneshot(req).await.unwrap().status();
+        assert_eq!(
+            status,
+            StatusCode::TOO_MANY_REQUESTS,
+            "receive-pack advertisement must be throttled before the Tigris acquire"
         );
     }
 }

--- a/crates/gitlawb-node/src/auth/mod.rs
+++ b/crates/gitlawb-node/src/auth/mod.rs
@@ -514,6 +514,7 @@ mod tests {
             machine_id: None,
             repo_store: crate::git::repo_store::RepoStore::for_testing(PathBuf::from("/tmp"), pool),
             rate_limiter: RateLimiter::new(100, Duration::from_secs(60)),
+            push_rate_limiter: RateLimiter::new(600, Duration::from_secs(3600)),
             shutdown_tx: tokio::sync::watch::channel(false).0,
         }
     }

--- a/crates/gitlawb-node/src/auth/mod.rs
+++ b/crates/gitlawb-node/src/auth/mod.rs
@@ -515,6 +515,7 @@ mod tests {
             repo_store: crate::git::repo_store::RepoStore::for_testing(PathBuf::from("/tmp"), pool),
             rate_limiter: RateLimiter::new(100, Duration::from_secs(60)),
             push_rate_limiter: RateLimiter::new(600, Duration::from_secs(3600)),
+            push_limiter_trust: crate::rate_limit::TrustedProxy::None,
             shutdown_tx: tokio::sync::watch::channel(false).0,
         }
     }

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -1372,18 +1372,18 @@ impl Db {
         Ok(row.map(|r| r.get::<f64, _>("trust_score")).unwrap_or(0.0))
     }
 
+    /// Update an EXISTING agent's trust score; a no-op for unregistered DIDs.
+    /// Deliberately never inserts: the only path into the agents table is
+    /// `register_agent`, which sits behind the iCaptcha gate on /api/register.
+    /// This used to be an upsert, which let any authenticated push/issue/PR
+    /// re-create a deregistered DID's row with a fresh `registered_at`,
+    /// bypassing the registration gate entirely.
     pub async fn update_trust_score(&self, agent_did: &str, score: f64) -> Result<()> {
-        let now = Utc::now().to_rfc3339();
-        sqlx::query(
-            "INSERT INTO agents (did, trust_score, capabilities, registered_at)
-             VALUES ($1, $2, '[]', $3)
-             ON CONFLICT(did) DO UPDATE SET trust_score = $2",
-        )
-        .bind(agent_did)
-        .bind(score)
-        .bind(&now)
-        .execute(&self.pool)
-        .await?;
+        sqlx::query("UPDATE agents SET trust_score = $2 WHERE did = $1")
+            .bind(agent_did)
+            .bind(score)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 
@@ -4301,6 +4301,27 @@ mod icaptcha_quarantine_tests {
 
         let with_stars = db.list_all_repos_deduped_with_stars(None).await.unwrap();
         assert!(with_stars.iter().all(|(r, _)| r.name != "spam"));
+    }
+
+    /// `update_trust_score` must never create an agent row. Registration (behind
+    /// the iCaptcha gate) is the only way in; otherwise a push/issue/PR from a
+    /// deregistered DID would silently re-register it and bypass the gate.
+    #[sqlx::test]
+    async fn update_trust_score_never_creates_agent(pool: PgPool) {
+        let db = db(pool).await;
+        let did = "did:key:zNeverRegistered";
+
+        // Unregistered DID: updating its score is a no-op, not an insert.
+        db.update_trust_score(did, 0.9).await.unwrap();
+        assert!(
+            db.get_agent(did).await.unwrap().is_none(),
+            "update_trust_score must not resurrect an unregistered DID"
+        );
+
+        // Once genuinely registered, the score updates in place.
+        db.register_agent(did, &[]).await.unwrap();
+        db.update_trust_score(did, 0.9).await.unwrap();
+        assert_eq!(db.get_trust_score(did).await.unwrap(), 0.9);
     }
 }
 

--- a/crates/gitlawb-node/src/error.rs
+++ b/crates/gitlawb-node/src/error.rs
@@ -29,6 +29,9 @@ pub enum AppError {
     #[error("invalid request: {0}")]
     BadRequest(String),
 
+    #[error("too many requests: {0}")]
+    TooManyRequests(String),
+
     #[error("git error: {0}")]
     Git(String),
 
@@ -65,6 +68,9 @@ impl IntoResponse for AppError {
                 msg.clone(),
             ),
             AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, "bad_request", msg.clone()),
+            AppError::TooManyRequests(msg) => {
+                (StatusCode::TOO_MANY_REQUESTS, "rate_limited", msg.clone())
+            }
             AppError::Git(msg) => (StatusCode::INTERNAL_SERVER_ERROR, "git_error", msg.clone()),
             AppError::Db(e) => (StatusCode::INTERNAL_SERVER_ERROR, "db_error", e.to_string()),
             AppError::Internal(e) => (

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -184,6 +184,20 @@ async fn main() -> Result<()> {
 
     let rate_limiter = rate_limit::RateLimiter::new(10, std::time::Duration::from_secs(3600));
 
+    // Push-path flood brake: max git-receive-pack requests per client IP per
+    // hour. Sized for heavy agent automation (600/h = 10/min sustained) while
+    // still stopping flood traffic (the June 2026 attack pushed several times
+    // per second per IP). GITLAWB_PUSH_RATE_LIMIT overrides; 0 disables.
+    let push_limit = std::env::var("GITLAWB_PUSH_RATE_LIMIT")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(600);
+    let push_rate_limiter =
+        rate_limit::RateLimiter::new(push_limit, std::time::Duration::from_secs(3600));
+    if push_limit == 0 {
+        tracing::warn!("GITLAWB_PUSH_RATE_LIMIT=0 — per-IP push rate limiting disabled");
+    }
+
     // Initialize the iCaptcha proof gate (inert unless ICAPTCHA_MODE is set).
     icaptcha::init().await;
 
@@ -200,6 +214,7 @@ async fn main() -> Result<()> {
         machine_id,
         repo_store,
         rate_limiter,
+        push_rate_limiter,
         shutdown_tx: shutdown_tx.clone(),
     };
 
@@ -260,6 +275,7 @@ async fn main() -> Result<()> {
     // Periodic cleanup of expired rate limit entries + consumed-proof ledger
     {
         let rl = state.rate_limiter.clone();
+        let push_rl = state.push_rate_limiter.clone();
         let db = state.db.clone();
         let mut shutdown_rx = state.subscribe_shutdown();
         tokio::spawn(async move {
@@ -267,6 +283,7 @@ async fn main() -> Result<()> {
                 tokio::select! {
                     _ = tokio::time::sleep(std::time::Duration::from_secs(300)) => {
                         rl.cleanup().await;
+                        push_rl.cleanup().await;
                         let now = std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .map(|d| d.as_secs() as i64)

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -182,21 +182,36 @@ async fn main() -> Result<()> {
     let repo_store =
         git::repo_store::RepoStore::new(config.repos_dir.clone(), tigris, db.pool().clone());
 
-    let rate_limiter = rate_limit::RateLimiter::new(10, std::time::Duration::from_secs(3600));
+    // Per-DID limiter for the creation endpoints. Keyed on the authenticated
+    // DID (attacker-varied), so bound its key set to cap memory.
+    let rate_limiter =
+        rate_limit::RateLimiter::new_bounded(10, std::time::Duration::from_secs(3600), 200_000);
 
     // Push-path flood brake: max git-receive-pack requests per client IP per
-    // hour. Sized for heavy agent automation (600/h = 10/min sustained) while
-    // still stopping flood traffic (the June 2026 attack pushed several times
-    // per second per IP). GITLAWB_PUSH_RATE_LIMIT overrides; 0 disables.
+    // hour (counts both the info/refs advertisement and the push POST). Sized
+    // for heavy agent automation while still stopping flood traffic (the June
+    // 2026 attack pushed several times per second per IP). GITLAWB_PUSH_RATE_LIMIT
+    // overrides; 0 disables. Bounded key set — the key is a client-influenced IP.
     let push_limit = std::env::var("GITLAWB_PUSH_RATE_LIMIT")
         .ok()
         .and_then(|v| v.trim().parse::<usize>().ok())
         .unwrap_or(600);
-    let push_rate_limiter =
-        rate_limit::RateLimiter::new(push_limit, std::time::Duration::from_secs(3600));
+    let push_rate_limiter = rate_limit::RateLimiter::new_bounded(
+        push_limit,
+        std::time::Duration::from_secs(3600),
+        200_000,
+    );
     if push_limit == 0 {
         tracing::warn!("GITLAWB_PUSH_RATE_LIMIT=0 — per-IP push rate limiting disabled");
     }
+
+    // Which forwarded header the edge is trusted to set. Default None (trust
+    // nothing, key on the socket peer). Fly nodes set GITLAWB_TRUSTED_PROXY=fly;
+    // a node behind Caddy/NGINX sets it to x-forwarded-for.
+    let push_limiter_trust = rate_limit::TrustedProxy::from_env_value(
+        &std::env::var("GITLAWB_TRUSTED_PROXY").unwrap_or_default(),
+    );
+    tracing::info!(trust = ?push_limiter_trust, push_limit, "push rate limiter configured");
 
     // Initialize the iCaptcha proof gate (inert unless ICAPTCHA_MODE is set).
     icaptcha::init().await;
@@ -215,6 +230,7 @@ async fn main() -> Result<()> {
         repo_store,
         rate_limiter,
         push_rate_limiter,
+        push_limiter_trust,
         shutdown_tx: shutdown_tx.clone(),
     };
 
@@ -408,19 +424,25 @@ async fn main() -> Result<()> {
     let grace = std::time::Duration::from_secs(config.shutdown_grace_secs);
     info!(grace_secs = config.shutdown_grace_secs, "axum server ready");
 
-    let serve_result = axum::serve(listener, router)
-        .with_graceful_shutdown(async move {
-            let mut rx = shutdown_signal_for_axum;
-            // Wait until the watcher flips to true, then return so axum
-            // can begin draining.
-            while !*rx.borrow_and_update() {
-                if rx.changed().await.is_err() {
-                    // Sender dropped — treat as shutdown.
-                    break;
-                }
+    // `into_make_service_with_connect_info` exposes the socket peer address as
+    // `ConnectInfo<SocketAddr>` so the push limiter can key on the real client
+    // when no trusted proxy header applies (see `rate_limit::client_key`).
+    let serve_result = axum::serve(
+        listener,
+        router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(async move {
+        let mut rx = shutdown_signal_for_axum;
+        // Wait until the watcher flips to true, then return so axum
+        // can begin draining.
+        while !*rx.borrow_and_update() {
+            if rx.changed().await.is_err() {
+                // Sender dropped — treat as shutdown.
+                break;
             }
-        })
-        .await;
+        }
+    })
+    .await;
 
     // Server has stopped accepting new connections and drained in-flight
     // requests. Tear the rest of the system down.

--- a/crates/gitlawb-node/src/rate_limit.rs
+++ b/crates/gitlawb-node/src/rate_limit.rs
@@ -32,6 +32,10 @@ impl RateLimiter {
     }
 
     async fn check(&self, key: &str) -> bool {
+        // max_requests == 0 means the limiter is disabled, not "block all".
+        if self.max_requests == 0 {
+            return true;
+        }
         let now = Instant::now();
         let mut state = self.state.lock().await;
         // Look up before inserting so the common case (key already tracked)
@@ -88,6 +92,53 @@ pub async fn rate_limit_by_did(request: Request, next: Next) -> Response {
     next.run(request).await
 }
 
+/// Per-client-IP limiter for the git push path. A newtype so it can coexist
+/// with the per-DID [`RateLimiter`] in request extensions (which are keyed by
+/// type). Per-DID limits are useless against the push-flood pattern — the June
+/// 2026 attack held one throwaway DID per repo, so every DID stayed under any
+/// per-identity threshold while the node absorbed several pushes per second.
+#[derive(Clone)]
+pub struct IpRateLimiter(pub RateLimiter);
+
+/// Client IP as reported by the fronting proxy. Fly sets `Fly-Client-IP`;
+/// generic reverse proxies set `X-Forwarded-For` (first hop). Both are only
+/// trustworthy when a proxy the operator controls sets them, which is the
+/// deployment shape this node documents (Fly, or Caddy on the AWS image).
+fn client_ip(request: &Request) -> Option<String> {
+    let headers = request.headers();
+    if let Some(ip) = headers.get("fly-client-ip").and_then(|v| v.to_str().ok()) {
+        return Some(ip.trim().to_string());
+    }
+    headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.split(',').next())
+        .map(|ip| ip.trim().to_string())
+        .filter(|ip| !ip.is_empty())
+}
+
+/// Throttle by client IP. Fail-open when no IP header is present (direct
+/// connections without a fronting proxy) — the limiter is a flood brake, not
+/// an auth boundary, and rejecting proxy-less deployments outright would break
+/// self-hosted nodes.
+pub async fn rate_limit_by_ip(request: Request, next: Next) -> Response {
+    let limiter = request.extensions().get::<IpRateLimiter>().cloned();
+
+    if let (Some(limiter), Some(ip)) = (limiter, client_ip(&request)) {
+        if !limiter.0.check(&ip).await {
+            tracing::warn!(ip = %ip, path = %request.uri().path(), "push rate limit exceeded");
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                [("retry-after", "60")],
+                "push rate limit exceeded — try again later",
+            )
+                .into_response();
+        }
+    }
+
+    next.run(request).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -133,5 +184,33 @@ mod tests {
         limiter.cleanup().await;
         let state = limiter.state.lock().await;
         assert!(state.is_empty());
+    }
+
+    fn request_with_headers(pairs: &[(&str, &str)]) -> Request {
+        let mut builder = axum::http::Request::builder().uri("/x/y/git-receive-pack");
+        for (k, v) in pairs {
+            builder = builder.header(*k, *v);
+        }
+        builder.body(axum::body::Body::empty()).unwrap()
+    }
+
+    #[test]
+    fn client_ip_prefers_fly_header() {
+        let req = request_with_headers(&[
+            ("fly-client-ip", "203.0.113.7"),
+            ("x-forwarded-for", "198.51.100.1, 10.0.0.1"),
+        ]);
+        assert_eq!(client_ip(&req).as_deref(), Some("203.0.113.7"));
+    }
+
+    #[test]
+    fn client_ip_falls_back_to_first_forwarded_hop() {
+        let req = request_with_headers(&[("x-forwarded-for", " 198.51.100.1 , 10.0.0.1")]);
+        assert_eq!(client_ip(&req).as_deref(), Some("198.51.100.1"));
+    }
+
+    #[test]
+    fn client_ip_none_without_proxy_headers() {
+        assert_eq!(client_ip(&request_with_headers(&[])), None);
     }
 }

--- a/crates/gitlawb-node/src/rate_limit.rs
+++ b/crates/gitlawb-node/src/rate_limit.rs
@@ -26,11 +26,18 @@ pub struct RateLimiter {
     state: Arc<Mutex<HashMap<String, Window>>>,
     max_requests: usize,
     window: Duration,
-    /// Hard cap on tracked keys. When full, expired keys are evicted inline;
-    /// if still full, a request under a *new* key is rejected rather than
-    /// inserted — so the map can never exceed this bound and a rejected
-    /// request never allocates a new entry.
+    /// Hard cap on tracked keys. When full, expired keys are evicted (at most
+    /// once per [`sweep_interval`](Self::sweep_interval), see below); if still
+    /// full, a request under a *new* key is rejected rather than inserted — so
+    /// the map can never exceed this bound and a rejected request never
+    /// allocates a new entry.
     max_keys: usize,
+    /// Timestamp of the last inline capacity sweep. The eviction scan is
+    /// O(max_keys), so under a distinct-key flood (when the map sits at the
+    /// cap) running it on every miss would serialize all traffic behind a full
+    /// scan. Gating it to at most once per interval amortizes that cost; the
+    /// background [`cleanup`](Self::cleanup) loop still reclaims on its own.
+    last_sweep: Arc<Mutex<Instant>>,
 }
 
 impl RateLimiter {
@@ -51,7 +58,16 @@ impl RateLimiter {
             max_requests,
             window,
             max_keys: max_keys.max(1),
+            last_sweep: Arc::new(Mutex::new(Instant::now())),
         }
+    }
+
+    /// How often the inline capacity sweep may run: at most once per second, or
+    /// once per window when the window is shorter. Bounds post-flood staleness
+    /// (a full map self-heals within one interval) without paying the O(max_keys)
+    /// scan on every capacity miss.
+    fn sweep_interval(&self) -> Duration {
+        self.window.min(Duration::from_secs(1))
     }
 
     pub(crate) async fn check(&self, key: &str) -> bool {
@@ -78,11 +94,20 @@ impl RateLimiter {
         // New key. Enforce the cap BEFORE inserting so a flood of distinct keys
         // cannot grow the map, and a rejected request never allocates an entry.
         if state.len() >= self.max_keys {
-            state.retain(|_, w| {
-                w.timestamps
-                    .retain(|t| now.duration_since(*t) < self.window);
-                !w.timestamps.is_empty()
-            });
+            // Reclaim expired keys, but at most once per sweep interval — the
+            // scan is O(max_keys) and the map sits at the cap precisely during a
+            // distinct-key flood, so sweeping per miss would serialize traffic
+            // behind a full scan. Between sweeps a new key is simply rejected.
+            let mut last_sweep = self.last_sweep.lock().await;
+            if now.duration_since(*last_sweep) >= self.sweep_interval() {
+                state.retain(|_, w| {
+                    w.timestamps
+                        .retain(|t| now.duration_since(*t) < self.window);
+                    !w.timestamps.is_empty()
+                });
+                *last_sweep = now;
+            }
+            drop(last_sweep);
             if state.len() >= self.max_keys {
                 return false;
             }
@@ -347,6 +372,25 @@ mod tests {
         let state = limiter.state.lock().await;
         assert!(state.contains_key("new"));
         assert!(!state.contains_key("old"));
+    }
+
+    #[tokio::test]
+    async fn capacity_sweep_is_amortized_within_interval() {
+        // The O(max_keys) eviction scan must not run on every capacity miss.
+        // With a 1s sweep interval, the resident (unexpired) key is never
+        // evicted by a burst of misses, so repeated new keys are all rejected
+        // without disturbing existing state.
+        let limiter = RateLimiter::new_bounded(100, Duration::from_secs(1), 1);
+        assert!(limiter.check("resident").await);
+        for i in 0..100 {
+            assert!(
+                !limiter.check(&format!("flood-{i}")).await,
+                "new key must be rejected while the single slot is held"
+            );
+        }
+        let state = limiter.state.lock().await;
+        assert_eq!(state.len(), 1, "no flood key was ever inserted");
+        assert!(state.contains_key("resident"));
     }
 
     // ── client_key / trusted-proxy resolution (P1 + P2) ─────────────────

--- a/crates/gitlawb-node/src/rate_limit.rs
+++ b/crates/gitlawb-node/src/rate_limit.rs
@@ -1,14 +1,20 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use axum::extract::Request;
-use axum::http::StatusCode;
+use axum::extract::{ConnectInfo, Request};
+use axum::http::{HeaderMap, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use tokio::sync::Mutex;
 
 use crate::auth::AuthenticatedDid;
+
+/// Default ceiling on the number of distinct keys a limiter tracks. Bounds the
+/// limiter's own memory so a caller that can vary the key (many DIDs, or a
+/// spoofable IP header) cannot grow the map without limit.
+const DEFAULT_MAX_KEYS: usize = 100_000;
 
 #[derive(Clone)]
 struct Window {
@@ -20,42 +26,73 @@ pub struct RateLimiter {
     state: Arc<Mutex<HashMap<String, Window>>>,
     max_requests: usize,
     window: Duration,
+    /// Hard cap on tracked keys. When full, expired keys are evicted inline;
+    /// if still full, a request under a *new* key is rejected rather than
+    /// inserted — so the map can never exceed this bound and a rejected
+    /// request never allocates a new entry.
+    max_keys: usize,
 }
 
 impl RateLimiter {
+    // Retained for tests and callers that don't need a tight key bound;
+    // production limiters use `new_bounded`.
+    #[allow(dead_code)]
     pub fn new(max_requests: usize, window: Duration) -> Self {
+        Self::new_bounded(max_requests, window, DEFAULT_MAX_KEYS)
+    }
+
+    /// Like [`new`] but with an explicit cap on the number of distinct keys.
+    /// Production limiters keyed on client-influenced values (per-DID, per-IP)
+    /// set this so the limiter's own state cannot be turned into a
+    /// memory-exhaustion vector.
+    pub fn new_bounded(max_requests: usize, window: Duration, max_keys: usize) -> Self {
         Self {
             state: Arc::new(Mutex::new(HashMap::new())),
             max_requests,
             window,
+            max_keys: max_keys.max(1),
         }
     }
 
-    async fn check(&self, key: &str) -> bool {
+    pub(crate) async fn check(&self, key: &str) -> bool {
         // max_requests == 0 means the limiter is disabled, not "block all".
         if self.max_requests == 0 {
             return true;
         }
         let now = Instant::now();
         let mut state = self.state.lock().await;
-        // Look up before inserting so the common case (key already tracked)
-        // doesn't allocate a String per request.
-        if !state.contains_key(key) {
-            state.insert(
-                key.to_string(),
-                Window {
-                    timestamps: Vec::new(),
-                },
-            );
+
+        // Fast path: an already-tracked key never allocates and never grows the
+        // map, so it is unaffected by the key cap.
+        if let Some(window) = state.get_mut(key) {
+            window
+                .timestamps
+                .retain(|t| now.duration_since(*t) < self.window);
+            if window.timestamps.len() >= self.max_requests {
+                return false;
+            }
+            window.timestamps.push(now);
+            return true;
         }
-        let window = state.get_mut(key).expect("window just ensured");
-        window
-            .timestamps
-            .retain(|t| now.duration_since(*t) < self.window);
-        if window.timestamps.len() >= self.max_requests {
-            return false;
+
+        // New key. Enforce the cap BEFORE inserting so a flood of distinct keys
+        // cannot grow the map, and a rejected request never allocates an entry.
+        if state.len() >= self.max_keys {
+            state.retain(|_, w| {
+                w.timestamps
+                    .retain(|t| now.duration_since(*t) < self.window);
+                !w.timestamps.is_empty()
+            });
+            if state.len() >= self.max_keys {
+                return false;
+            }
         }
-        window.timestamps.push(now);
+        state.insert(
+            key.to_string(),
+            Window {
+                timestamps: vec![now],
+            },
+        );
         true
     }
 
@@ -92,47 +129,128 @@ pub async fn rate_limit_by_did(request: Request, next: Next) -> Response {
     next.run(request).await
 }
 
-/// Per-client-IP limiter for the git push path. A newtype so it can coexist
-/// with the per-DID [`RateLimiter`] in request extensions (which are keyed by
-/// type). Per-DID limits are useless against the push-flood pattern — the June
-/// 2026 attack held one throwaway DID per repo, so every DID stayed under any
-/// per-identity threshold while the node absorbed several pushes per second.
-#[derive(Clone)]
-pub struct IpRateLimiter(pub RateLimiter);
-
-/// Client IP as reported by the fronting proxy. Fly sets `Fly-Client-IP`;
-/// generic reverse proxies set `X-Forwarded-For` (first hop). Both are only
-/// trustworthy when a proxy the operator controls sets them, which is the
-/// deployment shape this node documents (Fly, or Caddy on the AWS image).
-fn client_ip(request: &Request) -> Option<String> {
-    let headers = request.headers();
-    if let Some(ip) = headers.get("fly-client-ip").and_then(|v| v.to_str().ok()) {
-        return Some(ip.trim().to_string());
-    }
-    headers
-        .get("x-forwarded-for")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.split(',').next())
-        .map(|ip| ip.trim().to_string())
-        .filter(|ip| !ip.is_empty())
+/// Which forwarded header (if any) the operator's edge is trusted to set. Only
+/// a proxy the operator controls may be believed; a raw client can put any
+/// value in `Fly-Client-IP` / `X-Forwarded-For`, so trusting them unconditionally
+/// lets a flooder rotate the header and never fill a bucket. Configured via
+/// `GITLAWB_TRUSTED_PROXY`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TrustedProxy {
+    /// No trusted proxy: ignore forwarded headers, key on the socket peer IP.
+    /// Safe default for direct/self-hosted nodes.
+    None,
+    /// Behind Fly's edge, which sets (and overwrites any client-supplied)
+    /// `Fly-Client-IP`.
+    Fly,
+    /// Behind a single reverse proxy (e.g. Caddy on the AWS image) that appends
+    /// the real client as the rightmost `X-Forwarded-For` hop.
+    XForwardedFor,
 }
 
-/// Throttle by client IP. Fail-open when no IP header is present (direct
-/// connections without a fronting proxy) — the limiter is a flood brake, not
-/// an auth boundary, and rejecting proxy-less deployments outright would break
-/// self-hosted nodes.
+impl TrustedProxy {
+    /// Parse `GITLAWB_TRUSTED_PROXY`. Unknown/empty → `None` (trust nothing).
+    pub fn from_env_value(s: &str) -> Self {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "fly" | "fly-client-ip" => TrustedProxy::Fly,
+            "xff" | "x-forwarded-for" | "caddy" => TrustedProxy::XForwardedFor,
+            _ => TrustedProxy::None,
+        }
+    }
+}
+
+fn trimmed_nonempty(v: &str) -> Option<String> {
+    let t = v.trim();
+    (!t.is_empty()).then(|| t.to_string())
+}
+
+/// Resolve the rate-limit key for a request. In a trusted-proxy mode the
+/// operator's edge header is preferred; when that header is missing or empty we
+/// fall back to the socket peer address rather than skipping the limiter (a
+/// malformed header must never disable the brake). With no trusted proxy the
+/// socket peer is always used and forwarded headers are ignored entirely.
+/// Returns `None` only when neither a trusted header nor a peer address is
+/// available (e.g. a synthetic test request with no `ConnectInfo`).
+pub fn client_key(
+    headers: &HeaderMap,
+    peer: Option<SocketAddr>,
+    trust: TrustedProxy,
+) -> Option<String> {
+    let from_header = match trust {
+        TrustedProxy::None => None,
+        TrustedProxy::Fly => headers
+            .get("fly-client-ip")
+            .and_then(|v| v.to_str().ok())
+            .and_then(trimmed_nonempty),
+        // Rightmost hop = the value appended by the immediately-upstream trusted
+        // proxy. The leftmost hop is client-controlled and must not be trusted.
+        TrustedProxy::XForwardedFor => headers
+            .get("x-forwarded-for")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.rsplit(',').next())
+            .and_then(trimmed_nonempty),
+    };
+    from_header.or_else(|| peer.map(|p| p.ip().to_string()))
+}
+
+/// Per-client-IP limiter for the git push path, carrying the trusted-proxy
+/// policy. A newtype so it can live in request extensions (keyed by type)
+/// alongside the per-DID [`RateLimiter`]. Per-DID limits are useless against a
+/// push flood from a DID farm (one throwaway DID per repo), so the push path
+/// throttles on the resolved client IP instead.
+#[derive(Clone)]
+pub struct IpRateLimiter {
+    pub limiter: RateLimiter,
+    pub trust: TrustedProxy,
+}
+
+/// Infallible extractor for the socket peer address from `ConnectInfo`. Yields
+/// `None` when the server was started without connect-info (e.g. `oneshot` in
+/// tests), so a handler never 500s on its absence — the limiter simply falls
+/// back per [`client_key`].
+pub struct PeerAddr(pub Option<SocketAddr>);
+
+impl<S: Send + Sync> axum::extract::FromRequestParts<S> for PeerAddr {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(PeerAddr(
+            parts
+                .extensions
+                .get::<ConnectInfo<SocketAddr>>()
+                .map(|c| c.0),
+        ))
+    }
+}
+
+/// The shared 429 response for the push flood brake.
+pub fn too_many_requests() -> Response {
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        [("retry-after", "60")],
+        "push rate limit exceeded — try again later",
+    )
+        .into_response()
+}
+
+/// Throttle the git push path by resolved client IP. The socket peer address is
+/// read from `ConnectInfo` (see `into_make_service_with_connect_info` in
+/// `main`). Only skips the limiter when no key can be resolved at all.
 pub async fn rate_limit_by_ip(request: Request, next: Next) -> Response {
     let limiter = request.extensions().get::<IpRateLimiter>().cloned();
+    let peer = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|c| c.0);
 
-    if let (Some(limiter), Some(ip)) = (limiter, client_ip(&request)) {
-        if !limiter.0.check(&ip).await {
-            tracing::warn!(ip = %ip, path = %request.uri().path(), "push rate limit exceeded");
-            return (
-                StatusCode::TOO_MANY_REQUESTS,
-                [("retry-after", "60")],
-                "push rate limit exceeded — try again later",
-            )
-                .into_response();
+    if let Some(limiter) = limiter {
+        if let Some(key) = client_key(request.headers(), peer, limiter.trust) {
+            if !limiter.limiter.check(&key).await {
+                tracing::warn!(key = %key, path = %request.uri().path(), "push rate limit exceeded");
+                return too_many_requests();
+            }
         }
     }
 
@@ -186,31 +304,197 @@ mod tests {
         assert!(state.is_empty());
     }
 
-    fn request_with_headers(pairs: &[(&str, &str)]) -> Request {
-        let mut builder = axum::http::Request::builder().uri("/x/y/git-receive-pack");
-        for (k, v) in pairs {
-            builder = builder.header(*k, *v);
+    #[tokio::test]
+    async fn zero_limit_disables() {
+        let limiter = RateLimiter::new(0, Duration::from_secs(60));
+        for _ in 0..1000 {
+            assert!(limiter.check("k").await);
         }
-        builder.body(axum::body::Body::empty()).unwrap()
+    }
+
+    // ── key-cap / memory-bound (P2) ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn caps_tracked_keys_and_rejects_new_ones_when_full() {
+        // Cap of 2 distinct keys; generous request budget so rejection is due to
+        // the key cap, not the per-key limit.
+        let limiter = RateLimiter::new_bounded(100, Duration::from_secs(60), 2);
+        assert!(limiter.check("a").await);
+        assert!(limiter.check("b").await);
+        // Third distinct key would grow the map past the cap → rejected.
+        assert!(!limiter.check("c").await);
+        // The map never exceeded the cap, and the rejected key was NOT inserted.
+        let state = limiter.state.lock().await;
+        assert_eq!(state.len(), 2);
+        assert!(!state.contains_key("c"));
+    }
+
+    #[tokio::test]
+    async fn known_key_unaffected_by_cap() {
+        let limiter = RateLimiter::new_bounded(100, Duration::from_secs(60), 1);
+        assert!(limiter.check("a").await); // fills the single slot
+        assert!(limiter.check("a").await); // same key still served
+        assert!(!limiter.check("b").await); // new key rejected — cap full
+    }
+
+    #[tokio::test]
+    async fn expired_keys_evicted_to_admit_new_when_full() {
+        let limiter = RateLimiter::new_bounded(100, Duration::from_millis(40), 1);
+        assert!(limiter.check("old").await);
+        tokio::time::sleep(Duration::from_millis(55)).await;
+        // "old" is now expired; a new key triggers inline eviction and is admitted.
+        assert!(limiter.check("new").await);
+        let state = limiter.state.lock().await;
+        assert!(state.contains_key("new"));
+        assert!(!state.contains_key("old"));
+    }
+
+    // ── client_key / trusted-proxy resolution (P1 + P2) ─────────────────
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                axum::http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        h
+    }
+
+    fn peer(s: &str) -> Option<SocketAddr> {
+        Some(s.parse().unwrap())
     }
 
     #[test]
-    fn client_ip_prefers_fly_header() {
-        let req = request_with_headers(&[
+    fn none_mode_ignores_headers_and_uses_peer() {
+        // Even a well-formed Fly header is ignored without a trusted proxy.
+        let h = headers(&[("fly-client-ip", "203.0.113.7")]);
+        assert_eq!(
+            client_key(&h, peer("198.51.100.9:4000"), TrustedProxy::None).as_deref(),
+            Some("198.51.100.9")
+        );
+    }
+
+    #[test]
+    fn fly_mode_trusts_fly_header() {
+        let h = headers(&[
             ("fly-client-ip", "203.0.113.7"),
-            ("x-forwarded-for", "198.51.100.1, 10.0.0.1"),
+            ("x-forwarded-for", "1.2.3.4"),
         ]);
-        assert_eq!(client_ip(&req).as_deref(), Some("203.0.113.7"));
+        assert_eq!(
+            client_key(&h, peer("10.0.0.1:1"), TrustedProxy::Fly).as_deref(),
+            Some("203.0.113.7")
+        );
     }
 
     #[test]
-    fn client_ip_falls_back_to_first_forwarded_hop() {
-        let req = request_with_headers(&[("x-forwarded-for", " 198.51.100.1 , 10.0.0.1")]);
-        assert_eq!(client_ip(&req).as_deref(), Some("198.51.100.1"));
+    fn fly_mode_empty_header_falls_back_to_peer_not_skip() {
+        // Empty Fly-Client-IP must NOT collapse traffic onto Some("") nor skip
+        // the limiter — it falls back to the real peer.
+        let h = headers(&[("fly-client-ip", "")]);
+        assert_eq!(
+            client_key(&h, peer("198.51.100.9:4000"), TrustedProxy::Fly).as_deref(),
+            Some("198.51.100.9")
+        );
     }
 
     #[test]
-    fn client_ip_none_without_proxy_headers() {
-        assert_eq!(client_ip(&request_with_headers(&[])), None);
+    fn xff_mode_uses_rightmost_hop_not_client_controlled_first() {
+        // Client prepends spoofed hops; only the rightmost (proxy-appended) is trusted.
+        let h = headers(&[("x-forwarded-for", "9.9.9.9, 8.8.8.8, 198.51.100.9")]);
+        assert_eq!(
+            client_key(&h, peer("10.0.0.1:1"), TrustedProxy::XForwardedFor).as_deref(),
+            Some("198.51.100.9")
+        );
+    }
+
+    #[test]
+    fn xff_mode_empty_leading_hop_does_not_disable_brake() {
+        // "X-Forwarded-For: ,1.2.3.4" — rightmost hop is used; never None-skips.
+        let h = headers(&[("x-forwarded-for", ",1.2.3.4")]);
+        assert_eq!(
+            client_key(&h, peer("10.0.0.1:1"), TrustedProxy::XForwardedFor).as_deref(),
+            Some("1.2.3.4")
+        );
+    }
+
+    #[test]
+    fn malformed_xff_falls_back_to_peer() {
+        let h = headers(&[("x-forwarded-for", " , ")]);
+        assert_eq!(
+            client_key(&h, peer("198.51.100.9:4000"), TrustedProxy::XForwardedFor).as_deref(),
+            Some("198.51.100.9")
+        );
+    }
+
+    #[test]
+    fn trusted_proxy_parsing() {
+        assert_eq!(TrustedProxy::from_env_value("fly"), TrustedProxy::Fly);
+        assert_eq!(
+            TrustedProxy::from_env_value("X-Forwarded-For"),
+            TrustedProxy::XForwardedFor
+        );
+        assert_eq!(
+            TrustedProxy::from_env_value("caddy"),
+            TrustedProxy::XForwardedFor
+        );
+        assert_eq!(TrustedProxy::from_env_value(""), TrustedProxy::None);
+        assert_eq!(TrustedProxy::from_env_value("garbage"), TrustedProxy::None);
+    }
+
+    // ── middleware 429 path ─────────────────────────────────────────────
+
+    /// A minimal router with the push limiter layered over an OK handler,
+    /// driven via `oneshot`. `ConnectInfo` is attached to each request directly
+    /// (as the production make-service does) so the middleware resolves a peer.
+    fn ip_limited_router(limiter: IpRateLimiter) -> axum::Router {
+        axum::Router::new()
+            .route(
+                "/o/r/git-receive-pack",
+                axum::routing::post(|| async { StatusCode::OK }),
+            )
+            .layer(axum::middleware::from_fn(rate_limit_by_ip))
+            .layer(axum::Extension(limiter))
+    }
+
+    async fn post_from(router: &axum::Router, peer: SocketAddr) -> StatusCode {
+        use tower::ServiceExt;
+        let mut req = axum::http::Request::builder()
+            .method(axum::http::Method::POST)
+            .uri("/o/r/git-receive-pack")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(ConnectInfo(peer));
+        router.clone().oneshot(req).await.unwrap().status()
+    }
+
+    #[tokio::test]
+    async fn middleware_returns_429_over_limit() {
+        let router = ip_limited_router(IpRateLimiter {
+            limiter: RateLimiter::new(2, Duration::from_secs(60)),
+            trust: TrustedProxy::None,
+        });
+        let peer: SocketAddr = "203.0.113.7:5000".parse().unwrap();
+        // Two requests inside the budget, the third over it (shared Arc state).
+        assert_eq!(post_from(&router, peer).await, StatusCode::OK);
+        assert_eq!(post_from(&router, peer).await, StatusCode::OK);
+        assert_eq!(
+            post_from(&router, peer).await,
+            StatusCode::TOO_MANY_REQUESTS
+        );
+    }
+
+    #[tokio::test]
+    async fn middleware_isolates_distinct_peers() {
+        let router = ip_limited_router(IpRateLimiter {
+            limiter: RateLimiter::new(1, Duration::from_secs(60)),
+            trust: TrustedProxy::None,
+        });
+        let a: SocketAddr = "203.0.113.1:1".parse().unwrap();
+        let b: SocketAddr = "203.0.113.2:1".parse().unwrap();
+        assert_eq!(post_from(&router, a).await, StatusCode::OK);
+        assert_eq!(post_from(&router, b).await, StatusCode::OK); // independent bucket
+        assert_eq!(post_from(&router, a).await, StatusCode::TOO_MANY_REQUESTS);
     }
 }

--- a/crates/gitlawb-node/src/server.rs
+++ b/crates/gitlawb-node/src/server.rs
@@ -175,6 +175,11 @@ pub fn build_router(state: AppState) -> Router {
     // HTTP Signature is enforced on receive-pack (push) — the git-remote-gitlawb
     // helper signs requests with RFC 9421 signatures using the agent's keypair.
     let pack_limit = state.config.max_pack_bytes;
+    // Per-IP throttle wraps the auth layer (outermost = runs first): flood
+    // traffic is rejected before signature verification burns CPU. Per-DID
+    // limiting is deliberately NOT used here — a DID farm (one throwaway
+    // identity per repo, as in the June 2026 push flood) never trips it.
+    let push_limiter = rate_limit::IpRateLimiter(state.push_rate_limiter.clone());
     let git_write_routes = add_auth_layers(
         Router::new()
             .route(
@@ -184,7 +189,9 @@ pub fn build_router(state: AppState) -> Router {
             .layer(DefaultBodyLimit::disable())
             .layer(RequestBodyLimitLayer::new(pack_limit)),
         state.clone(),
-    );
+    )
+    .layer(middleware::from_fn(rate_limit::rate_limit_by_ip))
+    .layer(axum::Extension(push_limiter));
 
     // ── IPFS content-addressed retrieval and pin listing ──────────────────
     // `/ipfs/{cid}` carries `optional_signature` so `get_by_cid` sees the caller

--- a/crates/gitlawb-node/src/server.rs
+++ b/crates/gitlawb-node/src/server.rs
@@ -179,7 +179,10 @@ pub fn build_router(state: AppState) -> Router {
     // traffic is rejected before signature verification burns CPU. Per-DID
     // limiting is deliberately NOT used here — a DID farm (one throwaway
     // identity per repo, as in the June 2026 push flood) never trips it.
-    let push_limiter = rate_limit::IpRateLimiter(state.push_rate_limiter.clone());
+    let push_limiter = rate_limit::IpRateLimiter {
+        limiter: state.push_rate_limiter.clone(),
+        trust: state.push_limiter_trust,
+    };
     let git_write_routes = add_auth_layers(
         Router::new()
             .route(

--- a/crates/gitlawb-node/src/state.rs
+++ b/crates/gitlawb-node/src/state.rs
@@ -51,6 +51,10 @@ pub struct AppState {
     pub repo_store: RepoStore,
     /// Per-DID rate limiter for creation endpoints (repos, issues, PRs)
     pub rate_limiter: RateLimiter,
+    /// Per-client-IP rate limiter for git-receive-pack. Per-DID limits cannot
+    /// brake a push flood from a DID farm (one throwaway DID per repo), so the
+    /// push path throttles on the proxy-reported client IP instead.
+    pub push_rate_limiter: RateLimiter,
     /// Process-wide graceful-shutdown signal. Sending `true` causes every
     /// task that holds a `watch::Receiver` to exit at its next await point.
     /// Used by:

--- a/crates/gitlawb-node/src/state.rs
+++ b/crates/gitlawb-node/src/state.rs
@@ -53,8 +53,11 @@ pub struct AppState {
     pub rate_limiter: RateLimiter,
     /// Per-client-IP rate limiter for git-receive-pack. Per-DID limits cannot
     /// brake a push flood from a DID farm (one throwaway DID per repo), so the
-    /// push path throttles on the proxy-reported client IP instead.
+    /// push path throttles on the resolved client IP instead.
     pub push_rate_limiter: RateLimiter,
+    /// Which forwarded header (if any) the edge is trusted to set, for
+    /// resolving the push limiter's client-IP key. See `GITLAWB_TRUSTED_PROXY`.
+    pub push_limiter_trust: crate::rate_limit::TrustedProxy,
     /// Process-wide graceful-shutdown signal. Sending `true` causes every
     /// task that holds a `watch::Receiver` to exit at its next await point.
     /// Used by:

--- a/crates/gitlawb-node/src/test_support.rs
+++ b/crates/gitlawb-node/src/test_support.rs
@@ -76,6 +76,7 @@ fn build_state(db: Arc<crate::db::Db>, pool: PgPool) -> AppState {
         machine_id: None,
         repo_store: crate::git::repo_store::RepoStore::for_testing(PathBuf::from("/tmp"), pool),
         rate_limiter: RateLimiter::new(100, Duration::from_secs(60)),
+        push_rate_limiter: RateLimiter::new(600, Duration::from_secs(3600)),
         shutdown_tx: tokio::sync::watch::channel(false).0,
     }
 }

--- a/crates/gitlawb-node/src/test_support.rs
+++ b/crates/gitlawb-node/src/test_support.rs
@@ -77,6 +77,7 @@ fn build_state(db: Arc<crate::db::Db>, pool: PgPool) -> AppState {
         repo_store: crate::git::repo_store::RepoStore::for_testing(PathBuf::from("/tmp"), pool),
         rate_limiter: RateLimiter::new(100, Duration::from_secs(60)),
         push_rate_limiter: RateLimiter::new(600, Duration::from_secs(3600)),
+        push_limiter_trust: crate::rate_limit::TrustedProxy::None,
         shutdown_tx: tokio::sync::watch::channel(false).0,
     }
 }

--- a/infra/aws/compose.yaml.tftpl
+++ b/infra/aws/compose.yaml.tftpl
@@ -58,10 +58,12 @@ services:
       GITLAWB_P2P_PORT: "${p2p_port}"
       GITLAWB_REPOS_DIR: /data/repos
       GITLAWB_KEY: /data/keys/identity.pem
-      # Behind the Caddy reverse-proxy sidecar, which appends the real client as
-      # the rightmost X-Forwarded-For hop. Lets the push rate limiter key on the
-      # true client IP rather than Caddy's container address.
-      GITLAWB_TRUSTED_PROXY: x-forwarded-for
+      # Only trust X-Forwarded-For when the Caddy sidecar above is actually
+      # deployed (domain_name != ""). Caddy appends the real client as the
+      # rightmost hop, letting the push rate limiter key on the true client IP
+      # rather than Caddy's container address. Without Caddy, this header is
+      # fully client-controlled and must not be trusted.
+      GITLAWB_TRUSTED_PROXY: "${domain_name != "" ? "x-forwarded-for" : ""}"
       # iCaptcha proof-of-intelligence gate (spam protection on create/fork/register)
       ICAPTCHA_MODE: ${icaptcha_mode}
       ICAPTCHA_PUBKEY: ${icaptcha_pubkey}

--- a/infra/aws/compose.yaml.tftpl
+++ b/infra/aws/compose.yaml.tftpl
@@ -58,6 +58,10 @@ services:
       GITLAWB_P2P_PORT: "${p2p_port}"
       GITLAWB_REPOS_DIR: /data/repos
       GITLAWB_KEY: /data/keys/identity.pem
+      # Behind the Caddy reverse-proxy sidecar, which appends the real client as
+      # the rightmost X-Forwarded-For hop. Lets the push rate limiter key on the
+      # true client IP rather than Caddy's container address.
+      GITLAWB_TRUSTED_PROXY: x-forwarded-for
       # iCaptcha proof-of-intelligence gate (spam protection on create/fork/register)
       ICAPTCHA_MODE: ${icaptcha_mode}
       ICAPTCHA_PUBKEY: ${icaptcha_pubkey}

--- a/infra/fly/fly.toml
+++ b/infra/fly/fly.toml
@@ -16,6 +16,10 @@ primary_region = "iad"
   GITLAWB_BOOTSTRAP_PEERS = "https://node.gitlawb.com,https://node2.gitlawb.com,https://node3.gitlawb.com"
   GITLAWB_AUTO_SYNC = "true"
   GITLAWB_MAX_PACK_BYTES = "524288000"
+  # On Fly: the edge sets Fly-Client-IP (overwriting any client-supplied value),
+  # so the push rate limiter keys on the real client. Without this the limiter
+  # would fall back to the socket peer (Fly's proxy) and over-throttle.
+  GITLAWB_TRUSTED_PROXY = "fly"
 
 [http_service]
   internal_port = 7545


### PR DESCRIPTION

The June 2026 spam wave kept re-materializing after cleanup because two paths let an unauthenticated-by-captcha actor keep operating:

1. `update_trust_score` was an upsert. Any authenticated push/issue/PR from a DID with no agent row silently INSERTed one with a fresh `registered_at`, bypassing the iCaptcha gate on /api/register — so deregistered spam DIDs came back the moment they pushed. Make it an UPDATE-only no-op for unregistered DIDs; registration is the sole way into the agents table. Regression test added.

2. `git-receive-pack` had no rate limit. The per-DID limiter on the creation routes can't brake a push flood from a DID farm (one throwaway identity per repo), so the node absorbed several pushes/sec per IP, each a Tigris round-trip + peer-notify fan-out. Add a per- client-IP limiter (Fly-Client-IP / X-Forwarded-For) on the push path, default 600/h, `GITLAWB_PUSH_RATE_LIMIT` override, 0 disables. Fails open without a proxy header so self-hosted nodes aren't broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-client-IP “push-path flood brake” for `git-receive-pack`, enforced during both `info/refs` (advertisement) and receive phases.
  * Over-limit requests now return **429 Too Many Requests** with `retry-after`.
  * Added configurable push throttling via `GITLAWB_PUSH_RATE_LIMIT` (default 600; `0` disables) and trusted-proxy IP selection via `GITLAWB_TRUSTED_PROXY` (including rightmost `X-Forwarded-For` in trusted modes).

* **Bug Fixes**
  * Trust score updates no longer create agent records for unknown DIDs.
  * Rate limiting reliably disables when set to `0` and doesn’t break on malformed/missing forwarded-IP headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->