### PR TITLE
fix(release): build aarch64-musl natively on arm64 runners, replace retired macos-13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,10 +116,14 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+          # Native arm64 runner: cross-compiling this target with the glibc
+          # toolchain broke aws-lc-sys, and native lets the smoke test run.
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
+          # macos-13 (the last plain Intel image) is retired and queues forever;
+          # macos-15-intel is GitHub's supported Intel label.
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-14
           - target: x86_64-pc-windows-msvc
@@ -137,16 +141,13 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.target }}
 
+      # Both musl targets build natively on a matching-arch runner, so the stock
+      # musl-gcc wrapper is all that's needed (no cross toolchain).
       - name: Install musl tools (linux)
         if: contains(matrix.target, 'linux-musl')
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
-          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
-            sudo apt-get install -y gcc-aarch64-linux-gnu
-            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-            echo "CC_aarch64_unknown_linux_musl=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-          fi
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
@@ -171,10 +172,9 @@ jobs:
           cargo build --release --target ${{ matrix.target }} $args
 
       # Run each packaged binary's --version so a broken release artifact fails the
-      # build instead of shipping. Skipped for cross-compiled targets that can't run
-      # on the host runner (aarch64 linux on an x86_64 runner).
+      # build instead of shipping. Every target builds on a matching-arch runner,
+      # so all of them can execute here.
       - name: Smoke test binaries
-        if: ${{ matrix.target != 'aarch64-unknown-linux-musl' }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Fixes the two release-pipeline failures that have blocked binary publishing since v0.4.0: the `aarch64-unknown-linux-musl` build always fails, and the `x86_64-apple-darwin` job queues forever because GitHub retired `macos-13` runners.

## Motivation & context

Release runs for v0.4.0 ([#28446773996](https://github.com/Gitlawb/node/actions/runs/28446773996)) and v0.5.0 ([#28740238410](https://github.com/Gitlawb/node/actions/runs/28740238410)) both failed the same way:

- **aarch64-linux-musl `Build` step fails.** The job cross-compiled a *musl* target with the *glibc* cross toolchain (`CC=aarch64-linux-gnu-gcc`), which `aws-lc-sys` (pulled in via rustls by the AWS SDK, libp2p-tls, and reqwest) can't build with. No aarch64-linux asset has ever shipped.
- **x86_64-apple-darwin never starts.** `macos-13` was GitHub's last plain Intel image and has been retired — the job sits `queued` indefinitely, holding the run (and the `release-main` concurrency group) open.

Because `release-binaries` fails, the downstream `npm-publish`, `homebrew-bump`, and `web-sync` jobs were skipped for both releases — nothing has been published to npm or the Homebrew tap.

## Kind of change

- [x] Tests / CI

## What changed

`.github/workflows/release.yml` only (no crate changes):

- `aarch64-unknown-linux-musl` now builds on `ubuntu-24.04-arm` (GitHub's native arm64 runners, free for public repos). The build is native, so the glibc cross-toolchain hack is deleted and the stock `musl-tools` recipe matches the x86_64 leg exactly.
- The aarch64 smoke-test skip is removed — the binaries can now execute on their build runner, so arm64 Linux artifacts get the same `--version` gate as every other target.
- `x86_64-apple-darwin` moves from retired `macos-13` to `macos-15-intel`, GitHub's supported Intel label.

## How a reviewer can verify

Reproduced the previously-failing target natively on arm64 with the exact workflow recipe (rustup target + `musl-tools`, no cross env):

```sh
docker run --rm --platform linux/arm64 -v "$PWD:/src" rust:1-bookworm bash -c '
  apt-get update -qq && apt-get install -y -qq musl-tools cmake
  rustup target add aarch64-unknown-linux-musl
  cd /src && cargo build --release --target aarch64-unknown-linux-musl \
    -p gl -p git-remote-gitlawb -p gitlawb-node
  target/aarch64-unknown-linux-musl/release/gl --version'
```

Local repro ran until the machine's disk filled: `cc-rs` picked up `aarch64-linux-musl-gcc` from stock `musl-tools` and compiled deep into aws-lc-sys's C sources (the exact crate that broke the cross build) with no errors — the recipe is also identical to the x86_64-musl leg that already passes in CI. Runner labels `ubuntu-24.04-arm` and `macos-15-intel` are documented GitHub-hosted labels for public repos; `actionlint` is clean on the edited workflow. Final proof is the v0.5.1 release run this PR unlocks.

Merging this lands a `fix(release)` commit, so release-please will cut v0.5.1 with the repaired pipeline — that release should attach all five targets and un-skip npm/Homebrew/web-sync for the first time.

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [ ] `cargo test --workspace` passes locally (N/A — workflow-only change, no Rust code touched)
- [ ] New behavior is covered by tests (N/A — CI config)
- [ ] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean (N/A — no Rust changes)
- [x] Commit titles use Conventional Commits (`feat(...)`, `fix(...)`, `docs(...)`)
- [x] Docs / `.env.example` updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Notes for reviewers

- The stuck v0.5.0 run needs a manual **Cancel** in the Actions UI — its queued macos-13 job holds the `release-main` concurrency group.
- v0.5.0 itself stays asset-incomplete (no aarch64-linux or Intel-mac archives, not on npm/Homebrew); v0.5.1 supersedes it immediately, so no backfill is attempted here.
- Windows stays `continue-on-error` best-effort, unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release binary build coverage by running certain builds on matching-architecture runners.
  * Updated smoke tests so all release targets are checked consistently.
  * Simplified Linux musl build setup by removing extra cross-compilation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->