### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204 (#162)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,9 +2293,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
Bumps `crossbeam-epoch` from `0.9.18` to `0.9.20` to clear `RUSTSEC-2026-0204` (invalid pointer dereference in its `fmt::Pointer` impl for `Atomic`/`Shared`), which is hard-failing `cargo audit` on every branch since the advisory landed in the RustSec db.

`crossbeam-epoch` is a fully transitive dependency (`moka -> hickory-resolver -> libp2p-dns`); the advisory's prescribed fix is `>= 0.9.20`, and `moka 0.12.15` accepts `>=0.9.18, <0.10.0`, so the bump resolves with no other graph changes. Lockfile-only, single crate.

This lands on `main`, so it clears the red `cargo audit` for every open PR at once.

Verified by execution:

- `cargo audit`: exit 1 (`RUSTSEC-2026-0204`) before, exit 0 after.
- `cargo build --workspace`: compiles clean with `0.9.20`.
- `cargo test --workspace`: 829 pass, 0 fail.

Closes #162.
