### PR TITLE
Fix/db startup resilience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,23 @@ GITLAWB_REPOS_DIR=/data/repos
 # When using the bundled docker-compose, this is wired automatically.
 DATABASE_URL=postgresql://gitlawb:changeme@localhost:5432/gitlawb
 
+# ── Database pool & startup resilience ────────────────────────────────────
+# Maximum connections in the PostgreSQL pool. A cap, not a floor —
+# connections open lazily. Size against the DB server's max_connections,
+# remembering admin tooling opens its own pool.
+GITLAWB_DB_MAX_CONNECTIONS=20
+# Seconds a request waits for a pool connection before failing with 503.
+GITLAWB_DB_ACQUIRE_TIMEOUT_SECS=5
+# Upper bound on each startup connect+migrate attempt, in seconds. Keep it
+# generous enough for a peer instance to finish migrating (the migration
+# advisory lock is held across a deploy); on expiry the attempt is retried.
+GITLAWB_DB_CONNECT_TIMEOUT_SECS=60
+# Startup retry backoff while the database is unavailable: first delay and
+# ceiling, in seconds. The node stays up serving 503s (with a truthful
+# /ready) instead of crash-looping.
+GITLAWB_DB_RETRY_INITIAL_SECS=5
+GITLAWB_DB_RETRY_MAX_SECS=60
+
 # ── IPFS pinning (Pinata) ─────────────────────────────────────────────────
 # Get a JWT at https://app.pinata.cloud/developers/api-keys
 GITLAWB_PINATA_JWT=

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -488,7 +488,10 @@ pub async fn get_tree(
 // ── Git smart HTTP endpoints ──────────────────────────────────────────────
 
 fn smart_http_repo_name(repo: &str) -> Result<&str> {
-    let name = repo.trim_end_matches(".git");
+    // Strip at most one ".git" suffix: trim_end_matches strips repeatedly,
+    // which would misdirect a repo literally named "foo.git" (creatable via
+    // the peer mirror path, which skips API name validation) to repo "foo".
+    let name = repo.strip_suffix(".git").unwrap_or(repo);
     if name.is_empty() {
         return Err(AppError::BadRequest("missing repository name".into()));
     }
@@ -1914,6 +1917,10 @@ mod tests {
     #[test]
     fn smart_http_repo_name_rejects_empty_after_git_suffix() {
         assert_eq!(smart_http_repo_name("demo.git").unwrap(), "demo");
+        assert_eq!(smart_http_repo_name("demo").unwrap(), "demo");
+        // Only one suffix is stripped: a repo literally named "demo.git"
+        // stays addressable and never aliases to "demo".
+        assert_eq!(smart_http_repo_name("demo.git.git").unwrap(), "demo.git");
         assert!(matches!(
             smart_http_repo_name(".git"),
             Err(AppError::BadRequest(_))

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -487,6 +487,14 @@ pub async fn get_tree(
 
 // ── Git smart HTTP endpoints ──────────────────────────────────────────────
 
+fn smart_http_repo_name(repo: &str) -> Result<&str> {
+    let name = repo.trim_end_matches(".git");
+    if name.is_empty() {
+        return Err(AppError::BadRequest("missing repository name".into()));
+    }
+    Ok(name)
+}
+
 /// GET /:owner/:repo.git/info/refs?service=git-upload-pack|git-receive-pack
 pub async fn git_info_refs(
     State(state): State<AppState>,
@@ -496,7 +504,7 @@ pub async fn git_info_refs(
     headers: axum::http::HeaderMap,
     auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Response> {
-    let name = repo.trim_end_matches(".git");
+    let name = smart_http_repo_name(&repo)?;
     tracing::info!(owner = %owner, repo = %name, "info/refs request");
     let record = state
         .db
@@ -605,7 +613,7 @@ pub async fn git_upload_pack(
     auth: Option<Extension<AuthenticatedDid>>,
     body: Bytes,
 ) -> Result<Response> {
-    let name = repo.trim_end_matches(".git");
+    let name = smart_http_repo_name(&repo)?;
     let record = state
         .db
         .get_repo(&owner, name)
@@ -842,7 +850,7 @@ pub async fn git_receive_pack(
     Extension(auth): Extension<AuthenticatedDid>,
     body: Bytes,
 ) -> Result<Response> {
-    let name = repo.trim_end_matches(".git");
+    let name = smart_http_repo_name(&repo)?;
     tracing::info!(owner = %owner, repo = %name, "receive-pack request");
     let record = state
         .db
@@ -1901,6 +1909,19 @@ mod tests {
             matches!(rejection, Some(AppError::Forbidden(_))),
             "expected Some(Forbidden), got {rejection:?}"
         );
+    }
+
+    #[test]
+    fn smart_http_repo_name_rejects_empty_after_git_suffix() {
+        assert_eq!(smart_http_repo_name("demo.git").unwrap(), "demo");
+        assert!(matches!(
+            smart_http_repo_name(".git"),
+            Err(AppError::BadRequest(_))
+        ));
+        assert!(matches!(
+            smart_http_repo_name(""),
+            Err(AppError::BadRequest(_))
+        ));
     }
 
     #[test]

--- a/crates/gitlawb-node/src/config.rs
+++ b/crates/gitlawb-node/src/config.rs
@@ -182,6 +182,58 @@ pub struct Config {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     pub git_service_timeout_secs: u64,
+
+    /// Maximum connections in the PostgreSQL pool. This is a cap, not a floor
+    /// (connections open lazily). Size against the database server's
+    /// max_connections, remembering admin tooling opens its own pool.
+    #[arg(
+        long,
+        env = "GITLAWB_DB_MAX_CONNECTIONS",
+        default_value_t = 20,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    pub db_max_connections: u32,
+
+    /// Maximum time a request waits for a pool connection before failing with
+    /// 503, in seconds. Bounds queueing when the database is slow or down.
+    #[arg(
+        long,
+        env = "GITLAWB_DB_ACQUIRE_TIMEOUT_SECS",
+        default_value_t = 5,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    pub db_acquire_timeout_secs: u64,
+
+    /// Upper bound on each startup connect-and-migrate attempt, in seconds.
+    /// Migrations wait on a cross-instance advisory lock, so this must be
+    /// generous enough for a peer instance to finish migrating; on expiry the
+    /// attempt is retried (migrations are idempotent).
+    #[arg(
+        long,
+        env = "GITLAWB_DB_CONNECT_TIMEOUT_SECS",
+        default_value_t = 60,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    pub db_connect_timeout_secs: u64,
+
+    /// First retry delay when the database is unavailable at startup, in
+    /// seconds. Doubles each attempt up to --db-retry-max-secs.
+    #[arg(
+        long,
+        env = "GITLAWB_DB_RETRY_INITIAL_SECS",
+        default_value_t = 5,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    pub db_retry_initial_secs: u64,
+
+    /// Ceiling on the startup retry delay, in seconds.
+    #[arg(
+        long,
+        env = "GITLAWB_DB_RETRY_MAX_SECS",
+        default_value_t = 60,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    pub db_retry_max_secs: u64,
 }
 
 impl Config {

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use sqlx::{PgPool, Row};
+use sqlx::{postgres::PgPoolOptions, PgPool, Row};
+use std::time::Duration;
 use tracing::info;
 use uuid::Uuid;
 
@@ -266,7 +267,36 @@ impl Db {
     }
 
     pub async fn connect(database_url: &str) -> Result<Self> {
-        let pool = PgPool::connect(database_url).await?;
+        let max_connections = std::env::var("GITLAWB_DB_MAX_CONNECTIONS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u32>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(50);
+        let acquire_timeout_secs = std::env::var("GITLAWB_DB_ACQUIRE_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(5);
+        let connect_timeout_secs = std::env::var("GITLAWB_DB_CONNECT_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(10);
+
+        info!(
+            max_connections,
+            acquire_timeout_secs, connect_timeout_secs, "connecting to postgres"
+        );
+        let pool = tokio::time::timeout(
+            Duration::from_secs(connect_timeout_secs),
+            PgPoolOptions::new()
+                .max_connections(max_connections)
+                .acquire_timeout(Duration::from_secs(acquire_timeout_secs))
+                .connect(database_url),
+        )
+        .await
+        .context("postgres connect timed out")??;
+        info!(max_connections, "postgres pool configured");
         let db = Self { pool };
         db.migrate().await?;
         Ok(db)

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -266,40 +266,40 @@ impl Db {
         self.migrate().await
     }
 
-    pub async fn connect(database_url: &str) -> Result<Self> {
-        let max_connections = std::env::var("GITLAWB_DB_MAX_CONNECTIONS")
-            .ok()
-            .and_then(|v| v.trim().parse::<u32>().ok())
-            .filter(|&n| n > 0)
-            .unwrap_or(50);
-        let acquire_timeout_secs = std::env::var("GITLAWB_DB_ACQUIRE_TIMEOUT_SECS")
-            .ok()
-            .and_then(|v| v.trim().parse::<u64>().ok())
-            .filter(|&n| n > 0)
-            .unwrap_or(5);
-        let connect_timeout_secs = std::env::var("GITLAWB_DB_CONNECT_TIMEOUT_SECS")
-            .ok()
-            .and_then(|v| v.trim().parse::<u64>().ok())
-            .filter(|&n| n > 0)
-            .unwrap_or(10);
-
+    /// Connect the pool and run migrations. The initial connection is bounded
+    /// by `acquire_timeout` (sqlx routes pool connects through the acquire
+    /// path); migrations are unbounded here — the caller wraps the whole call
+    /// in its own attempt timeout, since the migration advisory lock can
+    /// legitimately block while another instance migrates.
+    pub async fn connect(
+        database_url: &str,
+        max_connections: u32,
+        acquire_timeout: Duration,
+    ) -> Result<Self> {
         info!(
             max_connections,
-            acquire_timeout_secs, connect_timeout_secs, "connecting to postgres"
+            acquire_timeout_secs = acquire_timeout.as_secs(),
+            "connecting to postgres"
         );
-        let pool = tokio::time::timeout(
-            Duration::from_secs(connect_timeout_secs),
-            PgPoolOptions::new()
-                .max_connections(max_connections)
-                .acquire_timeout(Duration::from_secs(acquire_timeout_secs))
-                .connect(database_url),
-        )
-        .await
-        .context("postgres connect timed out")??;
-        info!(max_connections, "postgres pool configured");
+        let pool = PgPoolOptions::new()
+            .max_connections(max_connections)
+            .acquire_timeout(acquire_timeout)
+            .connect(database_url)
+            .await
+            .context("connecting to postgres")?;
         let db = Self { pool };
         db.migrate().await?;
         Ok(db)
+    }
+
+    /// Cheap liveness probe against the pool, for readiness checks: one
+    /// `SELECT 1` that fails fast when the database is unreachable.
+    pub async fn ping(&self) -> Result<()> {
+        sqlx::query("SELECT 1")
+            .execute(&self.pool)
+            .await
+            .context("db ping")?;
+        Ok(())
     }
 
     /// Run all pending versioned migrations in order, inside a single

--- a/crates/gitlawb-node/src/error.rs
+++ b/crates/gitlawb-node/src/error.rs
@@ -51,7 +51,38 @@ pub enum AppError {
     Db(#[from] sqlx::Error),
 
     #[error("internal error: {0}")]
-    Internal(#[from] anyhow::Error),
+    Internal(anyhow::Error),
+}
+
+/// Shared error code/message for "the database is unreachable", also used by
+/// the degraded startup server (main.rs) and the readiness probe (server.rs)
+/// so clients see one vocabulary for the condition.
+pub const DB_UNAVAILABLE_CODE: &str = "db_unavailable";
+pub const DB_UNAVAILABLE_MESSAGE: &str = "database is temporarily unavailable";
+
+/// Connection-level sqlx failures that mean the database is unreachable right
+/// now (retryable, 503), as opposed to server-reported query errors.
+fn db_unavailable(e: &sqlx::Error) -> bool {
+    matches!(
+        e,
+        sqlx::Error::PoolTimedOut
+            | sqlx::Error::PoolClosed
+            | sqlx::Error::Io(_)
+            | sqlx::Error::Tls(_)
+    )
+}
+
+/// The db layer returns `anyhow::Result`, so sqlx errors reach handlers inside
+/// anyhow chains. Downcast them back out so the status mapping below can see
+/// them — without this, every database outage surfaces as a 500 instead of a
+/// 503. anyhow preserves downcastability through `.context()` layers.
+impl From<anyhow::Error> for AppError {
+    fn from(err: anyhow::Error) -> Self {
+        match err.downcast::<sqlx::Error>() {
+            Ok(sql) => AppError::Db(sql),
+            Err(err) => AppError::Internal(err),
+        }
+    }
 }
 
 impl IntoResponse for AppError {
@@ -111,10 +142,10 @@ impl IntoResponse for AppError {
             // 504, distinct from the 500 git_error and from the read-gate's 404 /
             // the auth 401, so the client can tell a deadline from a failure.
             AppError::Timeout(msg) => (StatusCode::GATEWAY_TIMEOUT, "git_timeout", msg.clone()),
-            AppError::Db(sqlx::Error::PoolTimedOut | sqlx::Error::PoolClosed) => (
+            AppError::Db(e) if db_unavailable(e) => (
                 StatusCode::SERVICE_UNAVAILABLE,
-                "db_unavailable",
-                "database is temporarily unavailable".into(),
+                DB_UNAVAILABLE_CODE,
+                DB_UNAVAILABLE_MESSAGE.into(),
             ),
             AppError::Db(e) => (StatusCode::INTERNAL_SERVER_ERROR, "db_error", e.to_string()),
             AppError::Internal(e) => (

--- a/crates/gitlawb-node/src/error.rs
+++ b/crates/gitlawb-node/src/error.rs
@@ -111,6 +111,11 @@ impl IntoResponse for AppError {
             // 504, distinct from the 500 git_error and from the read-gate's 404 /
             // the auth 401, so the client can tell a deadline from a failure.
             AppError::Timeout(msg) => (StatusCode::GATEWAY_TIMEOUT, "git_timeout", msg.clone()),
+            AppError::Db(sqlx::Error::PoolTimedOut | sqlx::Error::PoolClosed) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "db_unavailable",
+                "database is temporarily unavailable".into(),
+            ),
             AppError::Db(e) => (StatusCode::INTERNAL_SERVER_ERROR, "db_error", e.to_string()),
             AppError::Internal(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -24,11 +24,16 @@ mod test_support;
 mod visibility;
 mod webhooks;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
 use clap::Parser;
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tokio::sync::watch;
+use tokio::sync::{watch, RwLock};
 use tracing::{info, warn};
 
 use gitlawb_core::http_sig::sign_request;
@@ -37,6 +42,18 @@ use gitlawb_core::identity::Keypair;
 use config::Config;
 use db::Db;
 use state::AppState;
+
+#[derive(Clone)]
+struct DegradedState {
+    node_did: String,
+    db_startup: Arc<RwLock<DbStartupStatus>>,
+}
+
+#[derive(Default)]
+struct DbStartupStatus {
+    attempts: u64,
+    next_retry_secs: u64,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -76,21 +93,62 @@ async fn main() -> Result<()> {
         env!("CARGO_PKG_VERSION")
     );
     info!("╚══════════════════════════════════════════╝");
-    info!(did = %node_did, "node identity");
-    info!(addr = %config.bind_addr(), "listening");
-
     // Process-wide shutdown signal. One sender lives in AppState (cloned
     // into every handler); main() keeps a clone and flips it on SIGINT
     // or SIGTERM. Tasks that hold a watch::Receiver get notified at
     // their next await point.
     let (shutdown_tx, _shutdown_rx_for_main) = watch::channel(false);
+    spawn_shutdown_signal(shutdown_tx.clone());
 
-    // Connect to PostgreSQL database
-    let db = Arc::new(
-        Db::connect(&config.database_url)
-            .await
-            .context("failed to connect to database")?,
-    );
+    info!(did = %node_did, "node identity");
+    info!(addr = %config.bind_addr(), "binding degraded HTTP server");
+
+    // Bind HTTP before dependency initialization. Liveness stays up during a
+    // database outage, while readiness reports 503 until PostgreSQL is usable.
+    let degraded_listener = TcpListener::bind(config.bind_addr())
+        .await
+        .with_context(|| format!("failed to bind to {}", config.bind_addr()))?;
+    let db_startup = Arc::new(RwLock::new(DbStartupStatus::default()));
+    let (db_ready_tx, db_ready_rx) = watch::channel(false);
+    let mut degraded_handle = tokio::spawn(run_degraded_server(
+        degraded_listener,
+        node_did.to_string(),
+        Arc::clone(&db_startup),
+        db_ready_rx,
+        shutdown_tx.subscribe(),
+    ));
+
+    // Connect to PostgreSQL database. A transient outage or bad secret should
+    // not crash-loop the process and hammer the database provider.
+    let db = tokio::select! {
+        db = connect_db_with_retry(&config.database_url, Arc::clone(&db_startup), shutdown_tx.subscribe()) => {
+            match db {
+                Some(db) => db,
+                None => {
+                    db_ready_tx.send(true).ok();
+                    degraded_handle.await??;
+                    return Ok(());
+                }
+            }
+        }
+        degraded = &mut degraded_handle => {
+            if *shutdown_tx.borrow() {
+                return Ok(());
+            }
+            return match degraded {
+                Ok(Ok(())) => Err(anyhow!("degraded HTTP server stopped before database became ready")),
+                Ok(Err(err)) => Err(err.context("degraded HTTP server failed")),
+                Err(err) => Err(anyhow!("degraded HTTP server task failed: {err}")),
+            };
+        }
+    };
+
+    db_ready_tx.send(true).ok();
+    degraded_handle
+        .await
+        .context("degraded HTTP server task failed")?
+        .context("degraded HTTP server failed")?;
+    info!(addr = %config.bind_addr(), "database ready; starting full HTTP server");
 
     // Prune peer rows that point back at this node (stale self-loop entries)
     if let Some(public_url) = config.public_url.as_deref() {
@@ -285,34 +343,6 @@ async fn main() -> Result<()> {
         });
     }
 
-    // Spawn a task that flips the shutdown signal on SIGINT or SIGTERM.
-    // On Unix, both signals are handled. On Windows, only Ctrl-C is
-    // supported by tokio::signal::ctrl_c.
-    {
-        let tx = shutdown_tx.clone();
-        tokio::spawn(async move {
-            #[cfg(unix)]
-            {
-                use tokio::signal::unix::{signal as unix_signal, SignalKind};
-                let mut sigterm =
-                    unix_signal(SignalKind::terminate()).expect("install SIGTERM handler");
-                let mut sigint =
-                    unix_signal(SignalKind::interrupt()).expect("install SIGINT handler");
-                tokio::select! {
-                    _ = sigterm.recv() => info!("SIGTERM received, shutting down"),
-                    _ = sigint.recv()  => info!("SIGINT received, shutting down"),
-                }
-            }
-            #[cfg(not(unix))]
-            {
-                use tokio::signal;
-                let _ = signal::ctrl_c().await;
-                info!("Ctrl-C received, shutting down");
-            }
-            tx.send(true).ok();
-        });
-    }
-
     // Periodic cleanup of expired rate limit entries + consumed-proof ledger
     {
         let rl = state.rate_limiter.clone();
@@ -483,6 +513,193 @@ async fn main() -> Result<()> {
     serve_result?;
     info!("clean exit");
     Ok(())
+}
+
+fn spawn_shutdown_signal(tx: watch::Sender<bool>) {
+    tokio::spawn(async move {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{signal as unix_signal, SignalKind};
+            let mut sigterm =
+                unix_signal(SignalKind::terminate()).expect("install SIGTERM handler");
+            let mut sigint = unix_signal(SignalKind::interrupt()).expect("install SIGINT handler");
+            tokio::select! {
+                _ = sigterm.recv() => info!("SIGTERM received, shutting down"),
+                _ = sigint.recv()  => info!("SIGINT received, shutting down"),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            use tokio::signal;
+            let _ = signal::ctrl_c().await;
+            info!("Ctrl-C received, shutting down");
+        }
+        tx.send(true).ok();
+    });
+}
+
+async fn connect_db_with_retry(
+    database_url: &str,
+    db_startup: Arc<RwLock<DbStartupStatus>>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) -> Option<Arc<Db>> {
+    let initial_retry_secs = std::env::var("GITLAWB_DB_RETRY_INITIAL_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(5);
+    let max_retry_secs = std::env::var("GITLAWB_DB_RETRY_MAX_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(60)
+        .max(initial_retry_secs);
+    let mut attempts = 0_u64;
+
+    loop {
+        if *shutdown_rx.borrow() {
+            return None;
+        }
+
+        attempts = attempts.saturating_add(1);
+        {
+            let mut status = db_startup.write().await;
+            status.attempts = attempts;
+        }
+
+        match Db::connect(database_url).await {
+            Ok(db) => {
+                info!(attempts, "database connection established");
+                return Some(Arc::new(db));
+            }
+            Err(err) => {
+                let retry_secs =
+                    database_retry_delay_secs(initial_retry_secs, max_retry_secs, attempts);
+                {
+                    let mut status = db_startup.write().await;
+                    status.next_retry_secs = retry_secs;
+                }
+                warn!(
+                    attempts,
+                    retry_secs,
+                    err = %err,
+                    "database unavailable during startup; retrying"
+                );
+
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(retry_secs)) => {}
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_err() || *shutdown_rx.borrow() {
+                            return None;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn database_retry_delay_secs(initial_secs: u64, max_secs: u64, attempts: u64) -> u64 {
+    let exponent = attempts.saturating_sub(1).min(5) as u32;
+    initial_secs
+        .saturating_mul(2_u64.saturating_pow(exponent))
+        .min(max_secs)
+}
+
+async fn run_degraded_server(
+    listener: TcpListener,
+    node_did: String,
+    db_startup: Arc<RwLock<DbStartupStatus>>,
+    mut db_ready_rx: watch::Receiver<bool>,
+    mut shutdown_rx: watch::Receiver<bool>,
+) -> Result<()> {
+    let addr = listener.local_addr().ok();
+    let router = build_degraded_router(node_did, db_startup);
+    info!(?addr, "degraded HTTP server ready");
+
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move {
+            loop {
+                tokio::select! {
+                    changed = db_ready_rx.changed() => {
+                        if changed.is_err() || *db_ready_rx.borrow() {
+                            return;
+                        }
+                    }
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_err() || *shutdown_rx.borrow() {
+                            return;
+                        }
+                    }
+                }
+            }
+        })
+        .await?;
+
+    Ok(())
+}
+
+fn build_degraded_router(node_did: String, db_startup: Arc<RwLock<DbStartupStatus>>) -> Router {
+    let state = DegradedState {
+        node_did,
+        db_startup,
+    };
+    Router::new()
+        .route("/", get(degraded_node_info))
+        .route("/health", get(degraded_health))
+        .route("/ready", get(degraded_ready))
+        .fallback(degraded_unavailable)
+        .with_state(state)
+}
+
+async fn degraded_health(State(state): State<DegradedState>) -> Json<serde_json::Value> {
+    let status = state.db_startup.read().await;
+    Json(serde_json::json!({
+        "status": "degraded",
+        "database": "initializing",
+        "db_attempts": status.attempts,
+        "db_next_retry_secs": status.next_retry_secs,
+    }))
+}
+
+async fn degraded_ready(State(state): State<DegradedState>) -> impl IntoResponse {
+    let status = state.db_startup.read().await;
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "status": "degraded",
+            "error": "db_unavailable",
+            "message": "database is not ready",
+            "db_attempts": status.attempts,
+            "db_next_retry_secs": status.next_retry_secs,
+        })),
+    )
+}
+
+async fn degraded_node_info(State(state): State<DegradedState>) -> impl IntoResponse {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "name": "gitlawb-node",
+            "version": env!("CARGO_PKG_VERSION"),
+            "did": state.node_did,
+            "status": "degraded",
+            "database": "initializing",
+        })),
+    )
+}
+
+async fn degraded_unavailable(State(state): State<DegradedState>) -> impl IntoResponse {
+    let status = state.db_startup.read().await;
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(serde_json::json!({
+            "error": "service_unavailable",
+            "message": "node is starting; database is not ready",
+            "db_attempts": status.attempts,
+            "db_next_retry_secs": status.next_retry_secs,
+        })),
+    )
 }
 
 /// Spawn a small axum router that exposes only `GET /metrics` on its own

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -31,9 +31,10 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
 use clap::Parser;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tokio::sync::{watch, RwLock};
+use tokio::sync::watch;
 use tracing::{info, warn};
 
 use gitlawb_core::http_sig::sign_request;
@@ -46,13 +47,15 @@ use state::AppState;
 #[derive(Clone)]
 struct DegradedState {
     node_did: String,
-    db_startup: Arc<RwLock<DbStartupStatus>>,
+    db_startup: Arc<DbStartupStatus>,
 }
 
+/// Two independent counters with no cross-field invariant — atomics, not a
+/// lock, so the retry loop and the degraded handlers never contend.
 #[derive(Default)]
 struct DbStartupStatus {
-    attempts: u64,
-    next_retry_secs: u64,
+    attempts: AtomicU64,
+    next_retry_secs: AtomicU64,
 }
 
 #[tokio::main]
@@ -101,14 +104,43 @@ async fn main() -> Result<()> {
     spawn_shutdown_signal(shutdown_tx.clone());
 
     info!(did = %node_did, "node identity");
-    info!(addr = %config.bind_addr(), "binding degraded HTTP server");
+    info!(addr = %config.bind_addr(), "binding HTTP listener");
 
-    // Bind HTTP before dependency initialization. Liveness stays up during a
-    // database outage, while readiness reports 503 until PostgreSQL is usable.
-    let degraded_listener = TcpListener::bind(config.bind_addr())
+    // Bind HTTP once, before dependency initialization, and keep this socket
+    // for the life of the process. The degraded server accepts on a dup of the
+    // same socket, so the degraded→full handoff never closes the port: while
+    // the full server initializes, connections queue in the shared backlog
+    // instead of being refused.
+    let listener = TcpListener::bind(config.bind_addr())
         .await
         .with_context(|| format!("failed to bind to {}", config.bind_addr()))?;
-    let db_startup = Arc::new(RwLock::new(DbStartupStatus::default()));
+    let full_std_listener = listener.into_std()?;
+    let degraded_listener = TcpListener::from_std(
+        full_std_listener
+            .try_clone()
+            .context("failed to clone HTTP listener for degraded server")?,
+    )?;
+
+    // Metrics must stay observable during a database outage — the degraded
+    // window is exactly when dashboards need data — so this listener starts
+    // before the DB connects.
+    let metrics_handle = if !config.metrics_addr.is_empty() {
+        match spawn_metrics_server(&config.metrics_addr, shutdown_tx.subscribe()).await {
+            Ok(handle) => {
+                info!(addr = %config.metrics_addr, "metrics endpoint listening");
+                Some(handle)
+            }
+            Err(e) => {
+                warn!(err = %e, addr = %config.metrics_addr, "failed to start metrics endpoint — continuing without");
+                None
+            }
+        }
+    } else {
+        info!("metrics endpoint disabled (GITLAWB_METRICS_ADDR not set)");
+        None
+    };
+
+    let db_startup = Arc::new(DbStartupStatus::default());
     let (db_ready_tx, db_ready_rx) = watch::channel(false);
     let mut degraded_handle = tokio::spawn(run_degraded_server(
         degraded_listener,
@@ -119,14 +151,17 @@ async fn main() -> Result<()> {
     ));
 
     // Connect to PostgreSQL database. A transient outage or bad secret should
-    // not crash-loop the process and hammer the database provider.
+    // not crash-loop the process and hammer the database provider; permanent
+    // misconfiguration surfaces through error-level logs and the /ready check.
     let db = tokio::select! {
-        db = connect_db_with_retry(&config.database_url, Arc::clone(&db_startup), shutdown_tx.subscribe()) => {
+        db = connect_db_with_retry(&config, Arc::clone(&db_startup), shutdown_tx.subscribe()) => {
             match db {
                 Some(db) => db,
                 None => {
-                    db_ready_tx.send(true).ok();
-                    degraded_handle.await??;
+                    // Shutdown requested while waiting for the database. The
+                    // degraded server only serves one-shot 503s — abort it
+                    // rather than drain, so a slow client can't stall exit.
+                    degraded_handle.abort();
                     return Ok(());
                 }
             }
@@ -143,11 +178,18 @@ async fn main() -> Result<()> {
         }
     };
 
+    // Flip the degraded server into graceful shutdown, but do NOT await the
+    // drain: one slow in-flight request must not delay the full server, and
+    // the shared socket means there is no port gap to cover. The drain
+    // finishes (and logs) in the background.
     db_ready_tx.send(true).ok();
-    degraded_handle
-        .await
-        .context("degraded HTTP server task failed")?
-        .context("degraded HTTP server failed")?;
+    tokio::spawn(async move {
+        match degraded_handle.await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => warn!(err = %err, "degraded HTTP server exited with error"),
+            Err(err) => warn!(err = %err, "degraded HTTP server task failed"),
+        }
+    });
     info!(addr = %config.bind_addr(), "database ready; starting full HTTP server");
 
     // Prune peer rows that point back at this node (stale self-loop entries)
@@ -378,9 +420,10 @@ async fn main() -> Result<()> {
     }
 
     let router = server::build_router(state.clone());
-    let listener = TcpListener::bind(config.bind_addr())
-        .await
-        .with_context(|| format!("failed to bind to {}", config.bind_addr()))?;
+    // Re-register the socket bound at startup — same fd, so there was never a
+    // moment with the port closed between the degraded and full servers.
+    let listener = TcpListener::from_std(full_std_listener)
+        .context("failed to re-register HTTP listener with the runtime")?;
 
     info!("✓ node started — did:{}", node_did);
     info!("  repos dir: {}", config.repos_dir.display());
@@ -388,23 +431,6 @@ async fn main() -> Result<()> {
         "  database:  PostgreSQL ({})",
         &config.database_url.split('@').next_back().unwrap_or("?")
     );
-
-    // Optional Prometheus metrics listener on a separate port.
-    let metrics_handle = if !config.metrics_addr.is_empty() {
-        match spawn_metrics_server(&config.metrics_addr, state.clone()).await {
-            Ok(handle) => {
-                info!(addr = %config.metrics_addr, "metrics endpoint listening");
-                Some(handle)
-            }
-            Err(e) => {
-                warn!(err = %e, addr = %config.metrics_addr, "failed to start metrics endpoint — continuing without");
-                None
-            }
-        }
-    } else {
-        info!("metrics endpoint disabled (GITLAWB_METRICS_ADDR not set)");
-        None
-    };
 
     // Publish our DID record to the Kademlia DHT shortly after startup
     if let Some(p2p) = &state.p2p {
@@ -539,21 +565,14 @@ fn spawn_shutdown_signal(tx: watch::Sender<bool>) {
 }
 
 async fn connect_db_with_retry(
-    database_url: &str,
-    db_startup: Arc<RwLock<DbStartupStatus>>,
+    config: &Config,
+    db_startup: Arc<DbStartupStatus>,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> Option<Arc<Db>> {
-    let initial_retry_secs = std::env::var("GITLAWB_DB_RETRY_INITIAL_SECS")
-        .ok()
-        .and_then(|v| v.trim().parse::<u64>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(5);
-    let max_retry_secs = std::env::var("GITLAWB_DB_RETRY_MAX_SECS")
-        .ok()
-        .and_then(|v| v.trim().parse::<u64>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(60)
-        .max(initial_retry_secs);
+    let initial_retry_secs = config.db_retry_initial_secs;
+    let max_retry_secs = config.db_retry_max_secs.max(initial_retry_secs);
+    let acquire_timeout = std::time::Duration::from_secs(config.db_acquire_timeout_secs);
+    let attempt_timeout = std::time::Duration::from_secs(config.db_connect_timeout_secs);
     let mut attempts = 0_u64;
 
     loop {
@@ -562,29 +581,65 @@ async fn connect_db_with_retry(
         }
 
         attempts = attempts.saturating_add(1);
-        {
-            let mut status = db_startup.write().await;
-            status.attempts = attempts;
-        }
+        db_startup.attempts.store(attempts, Ordering::Relaxed);
 
-        match Db::connect(database_url).await {
+        // Bound the whole attempt, not just the pool connect: migrations
+        // block on a cross-instance advisory lock, and an unbounded wait
+        // there would wedge this loop — no retries, no logs, no recovery.
+        // Timing out and retrying is safe; migrations are idempotent.
+        let attempt = match tokio::time::timeout(
+            attempt_timeout,
+            Db::connect(
+                &config.database_url,
+                config.db_max_connections,
+                acquire_timeout,
+            ),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(anyhow!(
+                "connect + migrate attempt exceeded {}s (GITLAWB_DB_CONNECT_TIMEOUT_SECS); \
+                 is another instance holding the migration lock?",
+                attempt_timeout.as_secs()
+            )),
+        };
+
+        match attempt {
             Ok(db) => {
                 info!(attempts, "database connection established");
                 return Some(Arc::new(db));
             }
             Err(err) => {
-                let retry_secs =
-                    database_retry_delay_secs(initial_retry_secs, max_retry_secs, attempts);
-                {
-                    let mut status = db_startup.write().await;
-                    status.next_retry_secs = retry_secs;
+                // A bad DATABASE_URL or rejected credentials won't heal on
+                // their own. Still retry (exiting would crash-loop and hammer
+                // the provider — and take liveness down with it), but log at
+                // error level and skip straight to the maximum backoff; the
+                // /ready health check is what surfaces this to deploys.
+                let permanent = is_likely_permanent_db_error(&err);
+                let retry_secs = if permanent {
+                    max_retry_secs
+                } else {
+                    database_retry_delay_secs(initial_retry_secs, max_retry_secs, attempts)
+                };
+                db_startup
+                    .next_retry_secs
+                    .store(retry_secs, Ordering::Relaxed);
+                if permanent {
+                    tracing::error!(
+                        attempts,
+                        retry_secs,
+                        err = %err,
+                        "database rejected our configuration (bad DATABASE_URL or credentials?) — retrying, but operator action is likely required"
+                    );
+                } else {
+                    warn!(
+                        attempts,
+                        retry_secs,
+                        err = %err,
+                        "database unavailable during startup; retrying"
+                    );
                 }
-                warn!(
-                    attempts,
-                    retry_secs,
-                    err = %err,
-                    "database unavailable during startup; retrying"
-                );
 
                 tokio::select! {
                     _ = tokio::time::sleep(std::time::Duration::from_secs(retry_secs)) => {}
@@ -599,8 +654,26 @@ async fn connect_db_with_retry(
     }
 }
 
+/// Errors that indicate misconfiguration rather than a transient outage: a
+/// malformed DATABASE_URL, or a server that answered and rejected us —
+/// Postgres error class 28xxx (invalid authorization) or 3D000 (database
+/// does not exist). Best-effort: an error that anyhow can't downcast back to
+/// sqlx just counts as transient.
+fn is_likely_permanent_db_error(err: &anyhow::Error) -> bool {
+    match err.downcast_ref::<sqlx::Error>() {
+        Some(sqlx::Error::Configuration(_)) => true,
+        Some(sqlx::Error::Database(db)) => db
+            .code()
+            .map(|c| c.starts_with("28") || c.starts_with("3D"))
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
 fn database_retry_delay_secs(initial_secs: u64, max_secs: u64, attempts: u64) -> u64 {
-    let exponent = attempts.saturating_sub(1).min(5) as u32;
+    // The exponent bound only keeps the u32 cast safe — max_secs is the real
+    // (operator-configurable) cap, and saturating math handles overflow.
+    let exponent = attempts.saturating_sub(1).min(63) as u32;
     initial_secs
         .saturating_mul(2_u64.saturating_pow(exponent))
         .min(max_secs)
@@ -609,7 +682,7 @@ fn database_retry_delay_secs(initial_secs: u64, max_secs: u64, attempts: u64) ->
 async fn run_degraded_server(
     listener: TcpListener,
     node_did: String,
-    db_startup: Arc<RwLock<DbStartupStatus>>,
+    db_startup: Arc<DbStartupStatus>,
     mut db_ready_rx: watch::Receiver<bool>,
     mut shutdown_rx: watch::Receiver<bool>,
 ) -> Result<()> {
@@ -619,19 +692,11 @@ async fn run_degraded_server(
 
     axum::serve(listener, router)
         .with_graceful_shutdown(async move {
-            loop {
-                tokio::select! {
-                    changed = db_ready_rx.changed() => {
-                        if changed.is_err() || *db_ready_rx.borrow() {
-                            return;
-                        }
-                    }
-                    changed = shutdown_rx.changed() => {
-                        if changed.is_err() || *shutdown_rx.borrow() {
-                            return;
-                        }
-                    }
-                }
+            // wait_for resolves on predicate-true or sender-drop; either way
+            // this phase is over.
+            tokio::select! {
+                _ = db_ready_rx.wait_for(|ready| *ready) => {}
+                _ = shutdown_rx.wait_for(|stop| *stop) => {}
             }
         })
         .await?;
@@ -639,66 +704,49 @@ async fn run_degraded_server(
     Ok(())
 }
 
-fn build_degraded_router(node_did: String, db_startup: Arc<RwLock<DbStartupStatus>>) -> Router {
+fn build_degraded_router(node_did: String, db_startup: Arc<DbStartupStatus>) -> Router {
     let state = DegradedState {
         node_did,
         db_startup,
     };
+    // Everything answers 503 with the same body — including /health and
+    // /ready, so peer pings (which treat any 2xx /health as alive) and
+    // uptime monitors correctly see a node that cannot serve traffic.
+    // `/` additionally carries the node identity for probing peers.
     Router::new()
         .route("/", get(degraded_node_info))
-        .route("/health", get(degraded_health))
-        .route("/ready", get(degraded_ready))
         .fallback(degraded_unavailable)
         .with_state(state)
 }
 
-async fn degraded_health(State(state): State<DegradedState>) -> Json<serde_json::Value> {
-    let status = state.db_startup.read().await;
-    Json(serde_json::json!({
+/// One source of truth for the degraded 503 body, sharing the error
+/// vocabulary with error.rs so clients see the same code/message for
+/// "database unavailable" regardless of which phase produced it.
+fn degraded_body(db_startup: &DbStartupStatus) -> serde_json::Value {
+    serde_json::json!({
         "status": "degraded",
         "database": "initializing",
-        "db_attempts": status.attempts,
-        "db_next_retry_secs": status.next_retry_secs,
-    }))
-}
-
-async fn degraded_ready(State(state): State<DegradedState>) -> impl IntoResponse {
-    let status = state.db_startup.read().await;
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(serde_json::json!({
-            "status": "degraded",
-            "error": "db_unavailable",
-            "message": "database is not ready",
-            "db_attempts": status.attempts,
-            "db_next_retry_secs": status.next_retry_secs,
-        })),
-    )
+        "error": error::DB_UNAVAILABLE_CODE,
+        "message": error::DB_UNAVAILABLE_MESSAGE,
+        "db_attempts": db_startup.attempts.load(Ordering::Relaxed),
+        "db_next_retry_secs": db_startup.next_retry_secs.load(Ordering::Relaxed),
+    })
 }
 
 async fn degraded_node_info(State(state): State<DegradedState>) -> impl IntoResponse {
-    (
-        StatusCode::SERVICE_UNAVAILABLE,
-        Json(serde_json::json!({
-            "name": "gitlawb-node",
-            "version": env!("CARGO_PKG_VERSION"),
-            "did": state.node_did,
-            "status": "degraded",
-            "database": "initializing",
-        })),
-    )
+    let mut body = degraded_body(&state.db_startup);
+    if let Some(obj) = body.as_object_mut() {
+        obj.insert("name".into(), "gitlawb-node".into());
+        obj.insert("version".into(), env!("CARGO_PKG_VERSION").into());
+        obj.insert("did".into(), state.node_did.clone().into());
+    }
+    (StatusCode::SERVICE_UNAVAILABLE, Json(body))
 }
 
 async fn degraded_unavailable(State(state): State<DegradedState>) -> impl IntoResponse {
-    let status = state.db_startup.read().await;
     (
         StatusCode::SERVICE_UNAVAILABLE,
-        Json(serde_json::json!({
-            "error": "service_unavailable",
-            "message": "node is starting; database is not ready",
-            "db_attempts": status.attempts,
-            "db_next_retry_secs": status.next_retry_secs,
-        })),
+        Json(degraded_body(&state.db_startup)),
     )
 }
 
@@ -707,7 +755,10 @@ async fn degraded_unavailable(State(state): State<DegradedState>) -> impl IntoRe
 /// This is deliberately separate from the main router so the metrics port
 /// can be firewalled differently from the API port — bind to localhost
 /// or a private interface only.
-async fn spawn_metrics_server(addr: &str, state: AppState) -> Result<tokio::task::JoinHandle<()>> {
+async fn spawn_metrics_server(
+    addr: &str,
+    mut shutdown_rx: watch::Receiver<bool>,
+) -> Result<tokio::task::JoinHandle<()>> {
     use axum::{response::IntoResponse, routing::get, Router};
 
     async fn metrics_handler() -> impl IntoResponse {
@@ -731,7 +782,6 @@ async fn spawn_metrics_server(addr: &str, state: AppState) -> Result<tokio::task
         }
     }
 
-    let mut shutdown_rx = state.subscribe_shutdown();
     let listener = TcpListener::bind(addr)
         .await
         .with_context(|| format!("failed to bind metrics listener to {addr}"))?;

--- a/crates/gitlawb-node/src/server.rs
+++ b/crates/gitlawb-node/src/server.rs
@@ -485,8 +485,24 @@ async fn health() -> Json<serde_json::Value> {
     Json(json!({ "status": "ok" }))
 }
 
-async fn ready() -> Json<serde_json::Value> {
-    Json(json!({ "status": "ready" }))
+/// Readiness = "this node can serve real traffic", and every real endpoint
+/// depends on the database, so probe it rather than reporting a constant.
+/// The probe gets its own short bound so a wedged pool can't hang the health
+/// check for the full acquire timeout.
+async fn ready(State(state): State<AppState>) -> axum::response::Response {
+    let probe = tokio::time::timeout(std::time::Duration::from_secs(2), state.db.ping()).await;
+    match probe {
+        Ok(Ok(())) => Json(json!({ "status": "ready" })).into_response(),
+        _ => (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({
+                "status": "degraded",
+                "error": crate::error::DB_UNAVAILABLE_CODE,
+                "message": crate::error::DB_UNAVAILABLE_MESSAGE,
+            })),
+        )
+            .into_response(),
+    }
 }
 
 async fn node_info(State(state): State<AppState>) -> Json<serde_json::Value> {

--- a/crates/gitlawb-node/src/server.rs
+++ b/crates/gitlawb-node/src/server.rs
@@ -442,6 +442,7 @@ pub fn build_router(state: AppState) -> Router {
     let meta_routes = Router::new()
         .route("/", get(node_info))
         .route("/health", get(health))
+        .route("/ready", get(ready))
         .route("/api/v1/p2p/info", get(p2p_info))
         .route("/api/v1/stats", get(stats))
         .route("/api/v1/contracts", get(contracts_info));
@@ -482,6 +483,10 @@ pub fn build_router(state: AppState) -> Router {
 
 async fn health() -> Json<serde_json::Value> {
     Json(json!({ "status": "ok" }))
+}
+
+async fn ready() -> Json<serde_json::Value> {
+    Json(json!({ "status": "ready" }))
 }
 
 async fn node_info(State(state): State<AppState>) -> Json<serde_json::Value> {

--- a/infra/fly/fly.toml
+++ b/infra/fly/fly.toml
@@ -44,7 +44,7 @@ primary_region = "iad"
     # and a deploy with a bad DATABASE_URL fails visibly instead of going green.
     interval = "15s"
     timeout = "5s"
-    grace_period = "30s"
+    grace_period = "75s"
     method = "GET"
     path = "/ready"
 

--- a/infra/fly/fly.toml
+++ b/infra/fly/fly.toml
@@ -38,6 +38,16 @@ primary_region = "iad"
     # slots (hard_limit) — root factor in the 2026-06-12 prod outage
     idle_timeout = 120
 
+  [[http_service.checks]]
+    # Gate routing (and deploys) on real readiness: /ready probes the DB, so a
+    # node stuck retrying a dead or misconfigured database is never routed to,
+    # and a deploy with a bad DATABASE_URL fails visibly instead of going green.
+    interval = "15s"
+    timeout = "5s"
+    grace_period = "30s"
+    method = "GET"
+    path = "/ready"
+
 [[services]]
   protocol = "udp"
   internal_port = 7546


### PR DESCRIPTION
## Summary

Keep the node alive and honest through PostgreSQL outages: a degraded HTTP server
answers 503s (with real status) while the node retries the database, `/ready` now
reflects actual DB health for the whole process lifetime, and the degraded→full
handoff shares one socket so the port never closes.

## Motivation & context

A database outage or a bad `DATABASE_URL` used to crash-loop the node and hammer
the DB provider. The first cut of this branch kept the process alive but had gaps
an intensive review surfaced: the 503 mapping was unreachable dead code (outages
returned 500s), a held migration advisory lock could wedge the retry loop forever,
one slow client could block the full server from ever starting, readiness only
existed at boot, the metrics port was dark during the exact window that needed
observing, and a permanently bad secret produced a "green" deploy serving 503s
with no operator signal. This PR closes all of them.

Closes #

## Kind of change

- [x] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

All in `gitlawb-node` (plus `infra/fly/fly.toml`, `.env.example`):

- **error.rs** — `From<anyhow::Error>` now downcasts sqlx errors back out of
  anyhow chains into `AppError::Db` (the 503 arm was unreachable: every db method
  returns `anyhow::Result`, so outages surfaced as 500 `internal_error`).
  Widened the "unavailable" class to `PoolTimedOut | PoolClosed | Io | Tls` and
  exported a shared `db_unavailable` code/message used by all three surfaces.
- **main.rs** — one `TcpListener` bound at startup and shared (dup'd fd) between
  the degraded and full servers: no closed-port window during the handoff, and
  the degraded drain is no longer awaited, so a slowloris client can't block the
  full server from starting. Each connect+migrate attempt is bounded
  (`GITLAWB_DB_CONNECT_TIMEOUT_SECS`, default 60s) so a held migration advisory
  lock can't silently wedge the retry loop. Auth/catalog errors (Postgres class
  28/3D) log at error level and jump to max backoff. Degraded `/health` returns
  503 so peer pings (`is_success` on GET /health) and uptime monitors stop
  counting a DB-less node as alive. Metrics listener starts before the DB
  connects. Backoff exponent cap no longer defeats `GITLAWB_DB_RETRY_MAX_SECS`.
  Degraded handlers consolidated to one JSON body; startup counters are atomics.
- **server.rs** — `/ready` probes the pool (`SELECT 1`, 2s bound) instead of
  returning a constant 200, so mid-life outages flip it to 503 and back.
- **config.rs / db/mod.rs** — the five `GITLAWB_DB_*` knobs moved from ad-hoc
  `std::env::var` reads onto clap-derived `Config` (validated, in `--help`;
  malformed values now fail startup instead of silently defaulting). Dropped the
  outer connect timeout (dead code: sqlx bounds the initial connect via
  `acquire_timeout`). Pool default is 20 connections (lazy cap, tunable).
- **api/repos.rs** — smart-HTTP repo names strip at most one `.git` suffix
  (`trim_end_matches` strips repeatedly, aliasing a repo literally named
  `foo.git` — reachable via peer mirror ingestion — onto `foo`).
- **infra/fly/fly.toml** — `[[http_service.checks]]` on `/ready`: fly-proxy
  won't route to a machine until it's actually ready, and a deploy with a bad
  `DATABASE_URL` fails visibly instead of going green. (Per-node tomls are
  gitignored; the same block was added to the local node1/2/3 files on disk.)

## How a reviewer can verify

```sh
cargo test --workspace   # sqlx::test cases need a Postgres DATABASE_URL (CI provisions one)
cargo clippy --workspace --all-targets -- -D warnings

# Outage drill (verified end-to-end on this branch with postgres@16):
# 1. Start the node with Postgres DOWN:
#    - GET /, /health, /ready, any API route → 503 {"error":"db_unavailable",...}
#      with db_attempts / db_next_retry_secs visible; :9091/metrics → 200
# 2. Start Postgres: node connects and swaps to the full router with ZERO
#    refused connections (hammer `/` through the transition); /ready → 200
# 3. Stop Postgres mid-life: /ready → 503 and e.g. GET /api/v1/repos → 503
#    db_unavailable (was 200-ready + 500 internal_error before this PR)
# 4. Restart Postgres: /ready recovers on the next poll
# 5. Point DATABASE_URL at a nonexistent db: single ERROR-level
#    "database rejected our configuration" log, retry pinned at max backoff
# 6. gl init → git push → git clone round trip passes
```

Notes for reviewers

- The full server's /health stays a liveness-style 200 during mid-life outages
by design — /ready is the readiness signal, and peers pinging /health on
older nodes would 404 on /ready, so the ping target wasn't changed.
- Deploy semantics change: with the /ready check in fly.toml, fly deploy
now waits for readiness — a deploy during a real DB outage fails instead of
silently shipping a 503-serving machine. That's intentional.
- Pool default dropped 50 → 20: lazy cap, and 50 risked crowding a
max_connections=100 Postgres next to admin tooling; override per node with
GITLAWB_DB_MAX_CONNECTIONS.
- The degraded/readiness behavior was verified by a live outage drill (above)
rather than automated tests — the transition needs a real Postgres to
start/stop, which #[sqlx::test] can't model. Happy to add a harness in a
follow-up if wanted.
- Unit tests cover the backoff curve fix and the single-.git-suffix rule.

## Issue
Fixes #171 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary (updated)

* **New Features**
  * Added a **GET `/ready`** endpoint that checks database responsiveness.
  * Added a deployment readiness probe (Fly) that gates rollout on **`/ready`**.
  * Introduced **degraded mode** that serves 503 responses while database connection/retries run.

* **Improvements**
  * Added PostgreSQL pool sizing and startup/retry timing configuration.
  * Database-unavailable errors now return consistent **`503 Service Unavailable`** JSON status messaging.

* **Bug Fixes**
  * Improved smart-HTTP repo name normalization to remove only one `.git` suffix and added coverage for edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->