### PR TITLE
fix(node): rate-limit repo/agent creation per client IP to stop DID-farm spam floods

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,15 @@ GITLAWB_GIT_SERVICE_TIMEOUT_SECS=600
 # IP per hour. 0 disables. Default 600.
 GITLAWB_PUSH_RATE_LIMIT=600
 
+# ── Creation rate limiting (repo/agent/issue/PR flood brake) ──────────────
+# Max creation requests (POST /api/v1/repos, /api/register, fork, issues,
+# pulls) per client IP per hour, in addition to the per-DID limit. The per-DID
+# limit alone is bypassed by a did:key farm (one throwaway identity per repo),
+# which is how spam-repo floods slip past it and the iCaptcha gate; the per-IP
+# brake caps a single-source flood. Uses GITLAWB_TRUSTED_PROXY below to resolve
+# the client IP. 0 disables. Default 120.
+GITLAWB_CREATE_RATE_LIMIT=120
+
 # ── Peer-sync rate limiting (per client IP, uses GITLAWB_TRUSTED_PROXY below) ─
 # /api/v1/peers/announce and /api/v1/sync/notify accept unsigned requests from
 # known peers and run at higher frequency, so a generous bucket. Separate from

--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -2578,4 +2578,51 @@ mod tests {
             "receive-pack advertisement must be throttled before the Tigris acquire"
         );
     }
+
+    /// Repo creation must be throttled by the per-IP creation limiter BEFORE
+    /// signature verification — otherwise a DID farm (one throwaway did:key per
+    /// repo, each carrying a valid but machine-solved iCaptcha proof) walks past
+    /// the per-DID limiter and floods the network, as in the recurring spam-repo
+    /// incidents. A 429 (not a 401) on an unsigned request from an exhausted IP
+    /// proves the IP brake runs outermost, ahead of auth.
+    #[sqlx::test]
+    async fn repo_creation_is_rate_limited_by_ip(pool: sqlx::PgPool) {
+        use axum::body::Body;
+        use axum::extract::ConnectInfo;
+        use axum::http::{Method, Request, StatusCode};
+        use std::net::SocketAddr;
+        use std::time::Duration;
+        use tower::ServiceExt;
+
+        let mut state = crate::test_support::test_state(pool).await;
+        // Tiny limit, keyed on the socket peer (no trusted proxy).
+        state.create_ip_rate_limiter =
+            crate::rate_limit::RateLimiter::new(1, Duration::from_secs(60));
+        state.push_limiter_trust = crate::rate_limit::TrustedProxy::None;
+
+        let peer: SocketAddr = "203.0.113.77:7000".parse().unwrap();
+        // Exhaust this peer's single-request budget up front.
+        assert!(
+            state
+                .create_ip_rate_limiter
+                .check(&peer.ip().to_string())
+                .await
+        );
+
+        let router = crate::server::build_router(state);
+        let mut req = Request::builder()
+            .method(Method::POST)
+            .uri("/api/v1/repos")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"name":"flood","is_public":true}"#))
+            .unwrap();
+        req.extensions_mut().insert(ConnectInfo(peer));
+
+        let status = router.oneshot(req).await.unwrap().status();
+        assert_eq!(
+            status,
+            StatusCode::TOO_MANY_REQUESTS,
+            "repo creation must be IP-throttled before signature verification"
+        );
+    }
 }

--- a/crates/gitlawb-node/src/auth/mod.rs
+++ b/crates/gitlawb-node/src/auth/mod.rs
@@ -514,6 +514,7 @@ mod tests {
             machine_id: None,
             repo_store: crate::git::repo_store::RepoStore::for_testing(PathBuf::from("/tmp"), pool),
             rate_limiter: RateLimiter::new(100, Duration::from_secs(60)),
+            create_ip_rate_limiter: RateLimiter::new(1000, Duration::from_secs(3600)),
             push_rate_limiter: RateLimiter::new(600, Duration::from_secs(3600)),
             push_limiter_trust: crate::rate_limit::TrustedProxy::None,
             sync_trigger_rate_limiter: RateLimiter::new(60, Duration::from_secs(3600)),

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -409,6 +409,7 @@ async fn main() -> Result<()> {
     // Periodic cleanup of expired rate limit entries + consumed-proof ledger
     {
         let rl = state.rate_limiter.clone();
+        let create_ip_rl = state.create_ip_rate_limiter.clone();
         let push_rl = state.push_rate_limiter.clone();
         let sync_trigger_rl = state.sync_trigger_rate_limiter.clone();
         let peer_write_rl = state.peer_write_rate_limiter.clone();
@@ -419,6 +420,7 @@ async fn main() -> Result<()> {
                 tokio::select! {
                     _ = tokio::time::sleep(std::time::Duration::from_secs(300)) => {
                         rl.cleanup().await;
+                        create_ip_rl.cleanup().await;
                         push_rl.cleanup().await;
                         sync_trigger_rl.cleanup().await;
                         peer_write_rl.cleanup().await;

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -287,6 +287,26 @@ async fn main() -> Result<()> {
     let rate_limiter =
         rate_limit::RateLimiter::new_bounded(10, std::time::Duration::from_secs(3600), 200_000);
 
+    // Per-client-IP flood brake for the creation endpoints. The per-DID limiter
+    // above is bypassed by a DID farm (one throwaway did:key per repo), which is
+    // exactly how the recurring spam-repo floods get past both it and the
+    // iCaptcha gate. Keyed on the resolved client IP so a single-source flood is
+    // capped regardless of how many identities it mints. Sized well above any
+    // legitimate per-IP creation rate; GITLAWB_CREATE_RATE_LIMIT overrides, 0
+    // disables. Bounded key set — the key is a client-influenced IP.
+    let create_limit = std::env::var("GITLAWB_CREATE_RATE_LIMIT")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(120);
+    let create_ip_rate_limiter = rate_limit::RateLimiter::new_bounded(
+        create_limit,
+        std::time::Duration::from_secs(3600),
+        200_000,
+    );
+    if create_limit == 0 {
+        tracing::warn!("GITLAWB_CREATE_RATE_LIMIT=0 — per-IP creation rate limiting disabled");
+    }
+
     // Push-path flood brake: max git-receive-pack requests per client IP per
     // hour (counts both the info/refs advertisement and the push POST). Sized
     // for heavy agent automation while still stopping flood traffic (the June
@@ -352,6 +372,7 @@ async fn main() -> Result<()> {
         machine_id,
         repo_store,
         rate_limiter,
+        create_ip_rate_limiter,
         push_rate_limiter,
         push_limiter_trust,
         sync_trigger_rate_limiter,

--- a/crates/gitlawb-node/src/rate_limit.rs
+++ b/crates/gitlawb-node/src/rate_limit.rs
@@ -543,4 +543,66 @@ mod tests {
         assert_eq!(post_from(&router, b).await, StatusCode::OK); // independent bucket
         assert_eq!(post_from(&router, a).await, StatusCode::TOO_MANY_REQUESTS);
     }
+
+    // ── creation-route layering: IP brake runs BEFORE auth ──────────────
+
+    /// A minimal stand-in for the creation route group: an inner "auth" layer
+    /// that rejects every request with 401 (as signature verification would for
+    /// an unsigned caller), wrapped by the per-IP creation limiter as the
+    /// outermost layer — exactly the ordering `server::build_router` applies to
+    /// `/api/v1/repos` et al. Lets us assert the security-relevant property
+    /// (flood traffic is braked before auth burns CPU) without a database, which
+    /// the full `#[sqlx::test]` route test in `api::repos` cannot cover in the
+    /// plain unit-test pass.
+    fn ip_limited_over_auth_router(limiter: IpRateLimiter) -> axum::Router {
+        async fn always_unauthorized(_req: Request, _next: Next) -> Response {
+            StatusCode::UNAUTHORIZED.into_response()
+        }
+        axum::Router::new()
+            .route(
+                "/api/v1/repos",
+                axum::routing::post(|| async { StatusCode::CREATED }),
+            )
+            .layer(axum::middleware::from_fn(always_unauthorized))
+            .layer(axum::middleware::from_fn(rate_limit_by_ip))
+            .layer(axum::Extension(limiter))
+    }
+
+    async fn post_repos_from(router: &axum::Router, peer: SocketAddr) -> StatusCode {
+        use tower::ServiceExt;
+        let mut req = axum::http::Request::builder()
+            .method(axum::http::Method::POST)
+            .uri("/api/v1/repos")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(ConnectInfo(peer));
+        router.clone().oneshot(req).await.unwrap().status()
+    }
+
+    #[tokio::test]
+    async fn creation_ip_brake_rejects_before_auth() {
+        // A DID farm mints a fresh signature per repo, so the per-DID limiter
+        // never trips; the per-IP brake is what stops the flood. It must run
+        // outermost, ahead of auth, so a flood is rejected with 429 before
+        // signature verification — otherwise every request would reach (and pay
+        // for) auth and merely 401.
+        let router = ip_limited_over_auth_router(IpRateLimiter {
+            limiter: RateLimiter::new(1, Duration::from_secs(60)),
+            trust: TrustedProxy::None,
+        });
+        let peer: SocketAddr = "203.0.113.42:7000".parse().unwrap();
+
+        // First request passes the IP brake and reaches the (failing) auth layer.
+        assert_eq!(
+            post_repos_from(&router, peer).await,
+            StatusCode::UNAUTHORIZED
+        );
+        // Budget now exhausted: the IP brake short-circuits with 429 *before*
+        // auth — proving the limiter is the outermost layer.
+        assert_eq!(
+            post_repos_from(&router, peer).await,
+            StatusCode::TOO_MANY_REQUESTS,
+            "an exhausted IP must be braked with 429 before auth runs, not leak to 401"
+        );
+    }
 }

--- a/crates/gitlawb-node/src/server.rs
+++ b/crates/gitlawb-node/src/server.rs
@@ -81,8 +81,19 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/tasks", get(tasks::list_tasks))
         .route("/api/v1/tasks/{id}", get(tasks::get_task));
 
-    // ── Rate-limited creation routes — require HTTP Signature + per-DID throttle
+    // ── Rate-limited creation routes — require HTTP Signature, plus a per-DID
+    // throttle AND a per-IP flood brake. The per-DID limiter (inner) caps a
+    // single identity; the per-IP limiter (outer) caps a DID farm that mints a
+    // fresh throwaway did:key per repo to slip past both the per-DID limit and
+    // the iCaptcha gate — the mechanism behind the recurring spam-repo floods.
+    // The per-IP layer wraps the auth layer (outermost = runs first) so flood
+    // traffic is rejected before signature verification burns CPU, matching the
+    // push path.
     let limiter = state.rate_limiter.clone();
+    let create_ip_limiter = rate_limit::IpRateLimiter {
+        limiter: state.create_ip_rate_limiter.clone(),
+        trust: state.push_limiter_trust,
+    };
     let creation_routes = add_auth_layers(
         Router::new()
             .route("/api/v1/repos", post(repos::create_repo))
@@ -96,7 +107,9 @@ pub fn build_router(state: AppState) -> Router {
             .layer(middleware::from_fn(rate_limit::rate_limit_by_did))
             .layer(axum::Extension(limiter)),
         state.clone(),
-    );
+    )
+    .layer(middleware::from_fn(rate_limit::rate_limit_by_ip))
+    .layer(axum::Extension(create_ip_limiter));
 
     // ── Write routes — require HTTP Signature (no rate limit) ─────────────
     let write_routes = add_auth_layers(

--- a/crates/gitlawb-node/src/state.rs
+++ b/crates/gitlawb-node/src/state.rs
@@ -51,6 +51,16 @@ pub struct AppState {
     pub repo_store: RepoStore,
     /// Per-DID rate limiter for creation endpoints (repos, issues, PRs)
     pub rate_limiter: RateLimiter,
+    /// Per-client-IP rate limiter for the same creation endpoints. The per-DID
+    /// limiter above cannot brake a creation flood from a DID farm — one
+    /// throwaway `did:key` per repo means each DID makes a single create call
+    /// and never trips its own bucket. A valid iCaptcha proof does not cap this
+    /// either: the enforced level draws only machine-solvable deterministic
+    /// challenges (and the caller can pin the easy type), so a bot mints a fresh
+    /// DID, solves a proof, and creates a repo unthrottled. Braking on the
+    /// resolved client IP is what actually stops a single-source flood (same
+    /// rationale as `push_rate_limiter`). Keyed by `push_limiter_trust`.
+    pub create_ip_rate_limiter: RateLimiter,
     /// Per-client-IP rate limiter for git-receive-pack. Per-DID limits cannot
     /// brake a push flood from a DID farm (one throwaway DID per repo), so the
     /// push path throttles on the resolved client IP instead.

--- a/crates/gitlawb-node/src/test_support.rs
+++ b/crates/gitlawb-node/src/test_support.rs
@@ -76,6 +76,7 @@ fn build_state(db: Arc<crate::db::Db>, pool: PgPool) -> AppState {
         machine_id: None,
         repo_store: crate::git::repo_store::RepoStore::for_testing(PathBuf::from("/tmp"), pool),
         rate_limiter: RateLimiter::new(100, Duration::from_secs(60)),
+        create_ip_rate_limiter: RateLimiter::new(1000, Duration::from_secs(3600)),
         push_rate_limiter: RateLimiter::new(600, Duration::from_secs(3600)),
         push_limiter_trust: crate::rate_limit::TrustedProxy::None,
         sync_trigger_rate_limiter: RateLimiter::new(60, Duration::from_secs(3600)),


### PR DESCRIPTION
Add a per-client-IP flood brake to the repo/agent creation endpoints. The recurring spam-repo floods pass the iCaptcha gate with valid proofs and evade the existing per-DID creation limiter by minting a fresh throwaway `did:key` per repo; this applies the same per-IP brake the push path already uses against the identical attack.

## Motivation & context

The latest spam wave (`n<digits>x<digits>` repos) is not bypassing iCaptcha — the repos carry valid, correctly-signed proofs. Two root causes combine: (1) the enforced iCaptcha level (3) draws only deterministic, machine-solvable challenges and `POST /v1/challenge` lets the caller pin the easy type, so a bot mints a fresh DID, solves a proof, and creates a repo; (2) creation is rate-limited per-DID only (10/hr/DID), which a fresh-DID-per-repo farm never trips — the same DID-farm bypass already fixed on the push path, never applied to creation. Per-IP limiting is the load-bearing fix: it caps a single-source flood regardless of identity churn or iCaptcha (computational challenges are inherently bot-solvable).

Closes #179 

## Kind of change

- [x] Bug fix
- [ ] Feature
- [x] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

Crate: **gitlawb-node**

- Add a per-client-IP `RateLimiter` (`create_ip_rate_limiter`) to `AppState`, constructed in `main` with `GITLAWB_CREATE_RATE_LIMIT` (default 120/hr/IP, `0` disables), bounded key set, keyed via the existing `GITLAWB_TRUSTED_PROXY` resolution.
- Wrap the creation route group (`/api/v1/repos`, `/api/register`, fork, issues, pulls) with `rate_limit_by_ip` as the outermost layer, so flood traffic is rejected before signature verification. The per-DID limiter stays as inner defense-in-depth.
- New test `repo_creation_is_rate_limited_by_ip`: an unsigned create from an exhausted IP returns 429 (not 401), proving the IP brake runs ahead of auth.
- Document `GITLAWB_CREATE_RATE_LIMIT` in `.env.example`.

## How a reviewer can verify

```sh
docker run -d --rm --name pg -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=gitlawb -p 55433:5432 postgres:16
export DATABASE_URL="postgres://postgres:postgres@localhost:55433/gitlawb"
cargo test -p gitlawb-node --bin gitlawb-node -- rate_limited
# -> repo_creation_is_rate_limited_by_ip ... ok
#    receive_pack_advertisement_is_rate_limited ... ok
```

Notes for reviewers

- Default 120/hr/IP is well above any legitimate single-IP creation rate but cuts the observed flood (~720/hr from one source) by ~83%. Tune via GITLAWB_CREATE_RATE_LIMIT.
- The per-IP key resolution reuses GITLAWB_TRUSTED_PROXY (already fly on the prod nodes), so on Fly it keys on Fly-Client-IP, not the edge IP.
- Follow-up (out of scope): harden the icaptcha service to ignore/constrain the caller-supplied types array and floor requiredLevel server-side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-client-IP rate limiting for repository and related creation requests.
  * Default is 120 requests per hour; set `GITLAWB_CREATE_RATE_LIMIT=0` to disable.
  * IP-based throttling now works alongside existing identity-based limits to curb creation floods earlier.
* **Tests**
  * Added coverage verifying creation requests are rate-limited by IP with `429 Too Many Requests`.
* **Chores**
  * Updated environment example to document the new creation rate limiting setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->