### PR TITLE
fix: strip Cf bidi/format controls in terminal-bound error sanitizers (#183)

### DIFF
--- a/crates/git-remote-gitlawb/src/main.rs
+++ b/crates/git-remote-gitlawb/src/main.rs
@@ -1185,7 +1185,11 @@ mod tests {
         for c in [
             '\u{202e}', '\u{202a}', '\u{202c}', '\u{2066}', '\u{2069}', '\u{200e}', '\u{061c}',
         ] {
-            assert!(!message.contains(c), "bidi U+{:04X} leaked: {message:?}", c as u32);
+            assert!(
+                !message.contains(c),
+                "bidi U+{:04X} leaked: {message:?}",
+                c as u32
+            );
         }
         assert!(
             message.contains("errok"),

--- a/crates/git-remote-gitlawb/src/main.rs
+++ b/crates/git-remote-gitlawb/src/main.rs
@@ -570,6 +570,13 @@ fn safe_error_body_excerpt(body: &str) -> String {
             continue;
         }
 
+        if gitlawb_core::sanitize::is_bidi_format(ch) {
+            // Drop Cf bidi/format controls (INV-6, #183) without marking
+            // pending_space: unlike a newline/tab they are not whitespace, so
+            // "a\u{202e}c" collapses to "ac" with no phantom gap.
+            continue;
+        }
+
         if ch.is_whitespace() {
             pending_space = true;
             continue;
@@ -1160,6 +1167,50 @@ mod tests {
     }
 
     #[test]
+    fn http_error_message_strips_bidi_format_controls() {
+        // Each Cf bidi class must be stripped (INV-6, #183), not just U+202E:
+        // override (RLO), embedding + pop (LRE/PDF), isolate (LRI/PDI), and marks
+        // (LRM/ALM). Asserted per code point so a partial predicate fails loudly.
+        // The visible words must survive and JOIN with no phantom space at the
+        // strip points: a bidi char is dropped like a control byte, but unlike a
+        // newline/tab it is not whitespace, so it must not set pending_space.
+        let body = "err\u{202e}\u{202a}\u{202c}\u{2066}\u{2069}\u{200e}\u{061c}ok";
+        let message = http_error_message(
+            "GET",
+            "/info/refs",
+            reqwest::StatusCode::BAD_GATEWAY,
+            body,
+            None,
+        );
+        for c in [
+            '\u{202e}', '\u{202a}', '\u{202c}', '\u{2066}', '\u{2069}', '\u{200e}', '\u{061c}',
+        ] {
+            assert!(!message.contains(c), "bidi U+{:04X} leaked: {message:?}", c as u32);
+        }
+        assert!(
+            message.contains("errok"),
+            "words should join with no phantom space: {message:?}"
+        );
+    }
+
+    #[test]
+    fn http_error_message_preserves_legitimate_and_rtl_text() {
+        // Must not over-strip: plain text, a genuine RTL SCRIPT letter (Arabic
+        // U+0627, category Lo), and ZWJ (U+200D, a legitimate Cf char) survive.
+        let message = http_error_message(
+            "GET",
+            "/info/refs",
+            reqwest::StatusCode::BAD_GATEWAY,
+            "ok \u{0627}\u{200D}b",
+            None,
+        );
+        assert!(
+            message.ends_with("ok \u{0627}\u{200D}b"),
+            "legitimate text was altered: {message:?}"
+        );
+    }
+
+    #[test]
     fn http_error_message_truncates_long_response_body() {
         let body = "x".repeat(MAX_ERROR_BODY_CHARS + 100);
         let message = http_error_message(
@@ -1192,6 +1243,33 @@ mod tests {
         assert!(message.contains("repository is not registered on this node"));
         let requests = server.join().unwrap();
         assert_eq!(requests.len(), 1);
+    }
+
+    #[test]
+    fn connect_error_strips_bidi_from_response_body() {
+        // Transport-path proof: a bidi override in the node's real HTTP error body
+        // must not reach the surfaced error text. Drives the full handle_connect
+        // error path, not just the safe_error_body_excerpt unit boundary (INV-6).
+        let (base_url, server) = serve_http(vec![TestResponse {
+            request_line: "GET /z6Mk/myrepo/info/refs?service=git-upload-pack HTTP/1.1",
+            status: "404 Not Found",
+            body: "not\u{202e}found",
+        }]);
+
+        let repo_base = format!("{base_url}/z6Mk/myrepo");
+        let mut stdin = std::io::Cursor::new(Vec::<u8>::new());
+        let err = handle_connect(&repo_base, "git-upload-pack", None, &mut stdin).unwrap_err();
+        let message = err.to_string();
+
+        assert!(
+            !message.contains('\u{202e}'),
+            "bidi override reached the terminal: {message:?}"
+        );
+        assert!(
+            message.contains("notfound"),
+            "body should survive with the bidi char stripped: {message:?}"
+        );
+        let _ = server.join();
     }
 
     #[test]

--- a/crates/git-remote-gitlawb/src/main.rs
+++ b/crates/git-remote-gitlawb/src/main.rs
@@ -1173,8 +1173,9 @@ mod tests {
         // (LRM/ALM). Asserted per code point so a partial predicate fails loudly.
         // The visible words must survive and JOIN with no phantom space at the
         // strip points: a bidi char is dropped like a control byte, but unlike a
-        // newline/tab it is not whitespace, so it must not set pending_space.
-        let body = "err\u{202e}\u{202a}\u{202c}\u{2066}\u{2069}\u{200e}\u{061c}ok";
+        // newline/tab it is not whitespace, so it must not set pending_space. The
+        // leading bidi char (index 0) also exercises the empty-excerpt path.
+        let body = "\u{202e}err\u{202a}\u{202c}\u{2066}\u{2069}\u{200e}\u{061c}ok";
         let message = http_error_message(
             "GET",
             "/info/refs",

--- a/crates/gitlawb-core/src/lib.rs
+++ b/crates/gitlawb-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod encrypt;
 pub mod error;
 pub mod http_sig;
 pub mod identity;
+pub mod sanitize;
 pub mod ucan;
 
 pub use error::Error;

--- a/crates/gitlawb-core/src/sanitize.rs
+++ b/crates/gitlawb-core/src/sanitize.rs
@@ -40,10 +40,15 @@ mod tests {
         // marks but not the isolates) fails loudly rather than passing.
         for c in [
             '\u{200E}', '\u{200F}', '\u{061C}', // LRM, RLM, ALM
-            '\u{202A}', '\u{202B}', '\u{202C}', '\u{202D}', '\u{202E}', // LRE, RLE, PDF, LRO, RLO
+            '\u{202A}', '\u{202B}', '\u{202C}', '\u{202D}',
+            '\u{202E}', // LRE, RLE, PDF, LRO, RLO
             '\u{2066}', '\u{2067}', '\u{2068}', '\u{2069}', // LRI, RLI, FSI, PDI
         ] {
-            assert!(is_bidi_format(c), "U+{:04X} must be a bidi-format char", c as u32);
+            assert!(
+                is_bidi_format(c),
+                "U+{:04X} must be a bidi-format char",
+                c as u32
+            );
         }
     }
 
@@ -54,7 +59,11 @@ mod tests {
         // not bidi-format. ESC is a Cc control char — owned by is_control(), not
         // this predicate, which is bidi-only.
         for c in ['a', '\u{0627}', '\u{200D}', '\u{00AD}', '\u{1b}'] {
-            assert!(!is_bidi_format(c), "U+{:04X} must NOT be a bidi-format char", c as u32);
+            assert!(
+                !is_bidi_format(c),
+                "U+{:04X} must NOT be a bidi-format char",
+                c as u32
+            );
         }
     }
 }

--- a/crates/gitlawb-core/src/sanitize.rs
+++ b/crates/gitlawb-core/src/sanitize.rs
@@ -1,0 +1,60 @@
+//! Text sanitization predicates shared across the workspace.
+//!
+//! Untrusted peer/remote bytes that reach an operator's terminal (node error
+//! bodies, node-advertised strings) must be stripped of BOTH `Cc` control bytes
+//! (`char::is_control()`) AND `Cf` bidi/format controls before display: a
+//! right-to-left override or directional isolate can visually reorder the line
+//! and spoof the text (Trojan Source, CWE-451). This is INV-6.
+//!
+//! `is_bidi_format` is the single workspace definition of the second half of
+//! that obligation. It was split out of `gl`'s local copy so the two terminal
+//! sanitizers that shipped with only the `Cc` half (#183) — and any future
+//! sanitizer — reuse one audited predicate instead of re-deriving the set.
+
+/// True for the Unicode bidirectional/directional-isolate format characters
+/// (the reordering subset of category `Cf`) that can visually reorder a terminal
+/// line. These are NOT matched by [`char::is_control()`], which covers `Cc` only.
+///
+/// This is deliberately the reordering subset, not the whole `Cf` category:
+/// legitimate `Cf` characters such as ZWJ (`U+200D`, emoji sequences) and the
+/// soft hyphen (`U+00AD`) are NOT matched, so honest international text passes
+/// through unchanged. Widening this set is a behavior change for every consumer.
+///
+/// Pair it with `!c.is_control()` in a terminal-bound sanitizer (INV-6); see the
+/// wrappers in `gl`, `git-remote-gitlawb`, and `icaptcha-client`.
+pub fn is_bidi_format(c: char) -> bool {
+    matches!(c,
+        '\u{200E}' | '\u{200F}' | '\u{061C}'   // LRM, RLM, ALM
+        | '\u{202A}'..='\u{202E}'              // LRE, RLE, PDF, LRO, RLO
+        | '\u{2066}'..='\u{2069}'              // LRI, RLI, FSI, PDI
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_every_reordering_code_point() {
+        // Asserted individually so a partial predicate (e.g. one that covers the
+        // marks but not the isolates) fails loudly rather than passing.
+        for c in [
+            '\u{200E}', '\u{200F}', '\u{061C}', // LRM, RLM, ALM
+            '\u{202A}', '\u{202B}', '\u{202C}', '\u{202D}', '\u{202E}', // LRE, RLE, PDF, LRO, RLO
+            '\u{2066}', '\u{2067}', '\u{2068}', '\u{2069}', // LRI, RLI, FSI, PDI
+        ] {
+            assert!(is_bidi_format(c), "U+{:04X} must be a bidi-format char", c as u32);
+        }
+    }
+
+    #[test]
+    fn passes_legitimate_and_control_chars() {
+        // Must NOT over-strip: plain text, a genuine RTL SCRIPT letter (Lo, not a
+        // format char), ZWJ (legitimate Cf), and soft hyphen (legitimate Cf) are
+        // not bidi-format. ESC is a Cc control char — owned by is_control(), not
+        // this predicate, which is bidi-only.
+        for c in ['a', '\u{0627}', '\u{200D}', '\u{00AD}', '\u{1b}'] {
+            assert!(!is_bidi_format(c), "U+{:04X} must NOT be a bidi-format char", c as u32);
+        }
+    }
+}

--- a/crates/gl/src/sync.rs
+++ b/crates/gl/src/sync.rs
@@ -132,21 +132,9 @@ async fn read_body_capped(mut resp: reqwest::Response, cap: usize) -> String {
 /// `char::is_control` does not cover — they can reorder the displayed line).
 fn sanitize_node_msg(s: &str) -> String {
     s.chars()
-        .filter(|c| !c.is_control() && !is_bidi_format(*c))
+        .filter(|c| !c.is_control() && !gitlawb_core::sanitize::is_bidi_format(*c))
         .take(200)
         .collect()
-}
-
-/// Unicode bidirectional and directional-isolate format characters (category
-/// `Cf`). These are not `char::is_control()` (that is category `Cc` only), but a
-/// right-to-left override or isolate can visually reorder a terminal line to
-/// spoof the error text, so they are stripped alongside the control bytes.
-fn is_bidi_format(c: char) -> bool {
-    matches!(c,
-        '\u{200E}' | '\u{200F}' | '\u{061C}'   // LRM, RLM, ALM
-        | '\u{202A}'..='\u{202E}'              // LRE, RLE, PDF, LRO, RLO
-        | '\u{2066}'..='\u{2069}'              // LRI, RLI, FSI, PDI
-    )
 }
 
 #[cfg(test)]
@@ -291,6 +279,16 @@ mod tests {
         // Length is capped at 200 chars regardless of input size.
         let long = "x".repeat(250);
         assert_eq!(sanitize_node_msg(&long).chars().count(), 200);
+    }
+
+    #[test]
+    fn sanitize_preserves_legitimate_and_rtl_text() {
+        // Must not over-strip: a plain word, a genuine RTL SCRIPT letter (Arabic
+        // U+0627, category Lo — NOT a format char), and ZWJ (U+200D, a legitimate
+        // Cf char, e.g. emoji sequences) all survive. Guards the shared predicate
+        // against being widened into a blanket Cf stripper.
+        let out = sanitize_node_msg("ok \u{0627}\u{200D}b");
+        assert_eq!(out, "ok \u{0627}\u{200D}b");
     }
 
     #[tokio::test]

--- a/crates/icaptcha-client/src/lib.rs
+++ b/crates/icaptcha-client/src/lib.rs
@@ -64,6 +64,12 @@ fn sanitize_excerpt(s: &str) -> String {
             }
             continue;
         }
+        if gitlawb_core::sanitize::is_bidi_format(ch) {
+            // Drop Cf bidi/format controls (INV-6, #183) without setting
+            // pending_space: they are not whitespace, so stripping leaves no
+            // phantom gap.
+            continue;
+        }
         if ch.is_whitespace() {
             pending_space = true;
             continue;
@@ -419,6 +425,33 @@ mod tests {
             "control survived: {clean:?}"
         );
         assert!(clean.contains("owned") && clean.contains("done"));
+    }
+
+    #[test]
+    fn sanitize_strips_bidi_format_controls() {
+        // The Cc-only test above is vacuous for Cf: it passes whether or not bidi
+        // controls survive, which is why this gap shipped (#183). Here every Cf
+        // bidi class is stripped — override (RLO), embedding + pop (LRE/PDF),
+        // isolate (LRI/PDI), marks (LRM/ALM) — asserted per code point, and the
+        // visible words JOIN with no phantom space (a bidi char is dropped like a
+        // control byte, but unlike a newline/tab it is not whitespace).
+        let out = sanitize_excerpt("err\u{202e}\u{202a}\u{202c}\u{2066}\u{2069}\u{200e}\u{061c}ok");
+        for c in [
+            '\u{202e}', '\u{202a}', '\u{202c}', '\u{2066}', '\u{2069}', '\u{200e}', '\u{061c}',
+        ] {
+            assert!(!out.contains(c), "bidi U+{:04X} leaked: {out:?}", c as u32);
+        }
+        assert_eq!(out, "errok");
+    }
+
+    #[test]
+    fn sanitize_preserves_legitimate_and_rtl_text() {
+        // Must not over-strip: plain text, a genuine RTL SCRIPT letter (Arabic
+        // U+0627, category Lo), and ZWJ (U+200D, a legitimate Cf char) survive.
+        assert_eq!(
+            sanitize_excerpt("ok \u{0627}\u{200D}b"),
+            "ok \u{0627}\u{200D}b"
+        );
     }
 
     #[test]

--- a/crates/icaptcha-client/src/lib.rs
+++ b/crates/icaptcha-client/src/lib.rs
@@ -434,8 +434,9 @@ mod tests {
         // bidi class is stripped — override (RLO), embedding + pop (LRE/PDF),
         // isolate (LRI/PDI), marks (LRM/ALM) — asserted per code point, and the
         // visible words JOIN with no phantom space (a bidi char is dropped like a
-        // control byte, but unlike a newline/tab it is not whitespace).
-        let out = sanitize_excerpt("err\u{202e}\u{202a}\u{202c}\u{2066}\u{2069}\u{200e}\u{061c}ok");
+        // control byte, but unlike a newline/tab it is not whitespace). The leading
+        // bidi char (index 0) also exercises the empty-out path.
+        let out = sanitize_excerpt("\u{202e}err\u{202a}\u{202c}\u{2066}\u{2069}\u{200e}\u{061c}ok");
         for c in [
             '\u{202e}', '\u{202a}', '\u{202c}', '\u{2066}', '\u{2069}', '\u{200e}', '\u{061c}',
         ] {

--- a/crates/icaptcha-client/src/lib.rs
+++ b/crates/icaptcha-client/src/lib.rs
@@ -463,6 +463,18 @@ mod tests {
         assert_eq!(sanitize_excerpt(&long).chars().count(), MAX_ERR_CHARS);
     }
 
+    #[test]
+    fn sanitize_bidi_chars_do_not_consume_the_length_cap() {
+        // A dropped bidi char must not count toward MAX_ERR_CHARS: it is dropped
+        // before `kept` increments, so interleaving bidi controls cannot truncate
+        // the visible output early. MAX_ERR_CHARS + 100 visible 'x', each trailed by
+        // a bidi override, must still yield exactly MAX_ERR_CHARS visible 'x' with
+        // no phantom spaces. (Would regress to fewer 'x' if bidi consumed budget, or
+        // to spaces if the drop branch wrongly set pending_space.)
+        let body = "x\u{202e}".repeat(MAX_ERR_CHARS + 100);
+        assert_eq!(sanitize_excerpt(&body), "x".repeat(MAX_ERR_CHARS));
+    }
+
     // ── P2: never talk to (or hand a key to) an untrusted node-chosen URL ──
 
     #[test]


### PR DESCRIPTION
Two terminal-bound error sanitizers filtered only `Cc` control bytes and let `Cf` bidi/format controls through to the operator's terminal, so a right-to-left override in an attacker-influenceable error line could visually reorder it (Trojan Source, CWE-451). `gl` already stripped these; `git-remote-gitlawb::safe_error_body_excerpt` and `icaptcha-client::sanitize_excerpt` did not.

## Change

- Centralize the bidi predicate as `gitlawb_core::sanitize::is_bidi_format`: the 12 reordering `Cf` code points (LRM/RLM/ALM, the LRE..RLO embedding/override range, the LRI..PDI isolate range). All three client crates already depend on `gitlawb-core`, so this adds no dependency edges and leaves one audited definition instead of three copies that can drift.
- Migrate `gl`'s local copy to the shared predicate.
- Add a drop-and-continue branch in the two affected sanitizers, dropping bidi chars without setting `pending_space` (they are not whitespace, so stripping leaves no phantom gap).

This deliberately diverges from the issue's "port into each crate" wording. Centralizing removes the exact drift that produced the gap: two divergent copies, one incomplete.

## Scope

Strips only the bidi-reordering subset, not all of `Cf`. Legitimate characters like ZWJ (`U+200D`) and soft hyphen pass through unchanged; homoglyph and other Trojan-Source vectors are out of scope.

Not addressed here (separate class, follow-up): several `gl` commands print node-advertised strings (PR/issue titles, agent model, registration errors) straight to the terminal with no sanitizer at all. Same vector, different shape, tracked separately.

## Tests

Per-class strip coverage (each `Cf` class asserted individually), a must-not-over-strip guard, a transport-path proof through `handle_connect`, and a cap-boundary test. Every strip and preserve assertion was verified load-bearing by mutation: predicate returning false, predicate over-broad, and each of the 12 arms dropped individually all go red; the real predicate is green.

Closes #183.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error-message rendering by removing hidden Unicode formatting characters that could reorder or obscure displayed text.
  * Prevented invisible characters from introducing unexpected spaces or consuming available error-message length.
  * Preserved legitimate right-to-left text and other meaningful Unicode characters.
  * Applied the improved sanitization consistently across connection, synchronization, and challenge-related error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->