### PR TITLE
test(node): invariant deny-prober (driven registry + completeness cross-check)

### DIFF
--- a/crates/gitlawb-node/src/test_harness.rs
+++ b/crates/gitlawb-node/src/test_harness.rs
@@ -169,6 +169,16 @@ impl TestNode {
         record.id
     }
 
+    /// Mark `branch` as protected on `repo_id`, so a non-owner push to it is
+    /// rejected by the branch-protection gate (used by the deny-prober's
+    /// protected-push probe — #195, F3).
+    pub async fn seed_protected_branch(&self, repo_id: &str, branch: &str, created_by: &str) {
+        self.db
+            .protect_branch(repo_id, branch, created_by)
+            .await
+            .expect("seed protected branch");
+    }
+
     /// Seed an open PR `number` in `repo_id`, authored by `author_did`. The
     /// author-or-owner close gate (`close_pr`) loads the PR *before* it runs, so a
     /// deny-prober row for `.../pulls/{number}/close` needs the PR to exist or a

--- a/crates/gitlawb-node/src/test_harness.rs
+++ b/crates/gitlawb-node/src/test_harness.rs
@@ -26,7 +26,7 @@ use uuid::Uuid;
 use gitlawb_core::identity::Keypair;
 
 use crate::config::Config;
-use crate::db::{Db, RepoRecord, VisibilityMode};
+use crate::db::{Db, PullRequest, RepoRecord, VisibilityMode};
 use crate::rate_limit::{RateLimiter, TrustedProxy};
 use crate::state::AppState;
 
@@ -167,6 +167,41 @@ impl TestNode {
         };
         self.db.create_repo(&record).await.expect("seed repo");
         record.id
+    }
+
+    /// Seed an open PR `number` in `repo_id`, authored by `author_did`. The
+    /// author-or-owner close gate (`close_pr`) loads the PR *before* it runs, so a
+    /// deny-prober row for `.../pulls/{number}/close` needs the PR to exist or a
+    /// stranger gets a 404 (absent entity) instead of the 403 the gate emits.
+    pub async fn seed_pr(&self, repo_id: &str, number: i64, author_did: &str) {
+        let now = Utc::now().to_rfc3339();
+        let pr = PullRequest {
+            id: Uuid::new_v4().to_string(),
+            repo_id: repo_id.to_string(),
+            number,
+            title: "seed pr".to_string(),
+            body: None,
+            author_did: author_did.to_string(),
+            source_branch: "feature".to_string(),
+            target_branch: "main".to_string(),
+            status: "open".to_string(),
+            merged_by_did: None,
+            merged_at: None,
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        self.db.create_pr(&pr).await.expect("seed pr");
+    }
+
+    /// Seed issue `issue_id` (a git-ref JSON blob authored by `author_did`) in the
+    /// repo's bare on-disk store. Like [`Self::seed_pr`], the `close_issue`
+    /// owner-or-author gate loads the issue before it runs, so the deny-prober row
+    /// for `.../issues/{id}/close` needs the issue present to reach the 403.
+    pub fn seed_issue(&self, owner_did: &str, name: &str, issue_id: &str, author_did: &str) {
+        let slug = owner_did.replace([':', '/'], "_");
+        let bare = self.repos_dir.join(&slug).join(format!("{name}.git"));
+        let json = format!(r#"{{"author":"{author_did}"}}"#);
+        crate::git::issues::create_issue(&bare, issue_id, &json).expect("seed issue");
     }
 
     /// Add a path-scoped visibility rule restricting `path_glob` to

--- a/crates/gitlawb-node/tests/deny_harness.rs
+++ b/crates/gitlawb-node/tests/deny_harness.rs
@@ -11,6 +11,8 @@ mod support;
 use std::process::Command;
 
 use support::assert::assert_denied;
+use support::probe::{probes_for, Expect, Fixture, Probe, Signer};
+use support::routes::deny_bearing_routes;
 use support::signing::signed_request;
 
 use gitlawb_core::cid::Cid;
@@ -403,6 +405,142 @@ async fn anon_clone_excludes_withheld_subtree_blobs(pool: sqlx::PgPool) {
     assert!(
         listing.contains(&public_oid),
         "public blob {public_oid} must be present (withhold is subtree-scoped); listing:\n{listing}"
+    );
+}
+
+// ── U3: drive the whole deny-bearing route registry over the real stack ───────
+
+/// Send one [`Probe`] against the running node, signing as the probe's identity.
+/// Anon requests are unsigned; Owner/Stranger requests carry a real RFC-9421
+/// signature for the fixture's owner / stranger keypair.
+async fn send_probe(
+    client: &reqwest::Client,
+    base_url: &str,
+    fixture: &Fixture,
+    probe: &Probe,
+) -> reqwest::Response {
+    let rb = match probe.signer {
+        Signer::Anon => client
+            .request(probe.method.clone(), format!("{base_url}{}", probe.path))
+            .body(probe.body.clone()),
+        Signer::Owner => signed_request(
+            client,
+            probe.method.clone(),
+            base_url,
+            &probe.path,
+            probe.body.clone(),
+            &fixture.owner,
+        ),
+        Signer::Stranger => signed_request(
+            client,
+            probe.method.clone(),
+            base_url,
+            &probe.path,
+            probe.body.clone(),
+            &fixture.stranger,
+        ),
+    };
+    let rb = if probe.json {
+        rb.header("content-type", "application/json")
+    } else {
+        rb
+    };
+    rb.send().await.unwrap_or_else(|e| {
+        panic!(
+            "probe failed to send: {} [{} {}]: {e}",
+            probe.label, probe.method, probe.path
+        )
+    })
+}
+
+/// Walk every deny-bearing route (U1 registry), expand each into its hostile
+/// probe plus positive twin (U2), and drive them against a real node: the
+/// hostile request must return the exact deny status and leak nothing, and the
+/// twin must reach the handler (owner-gate: not 403; read-gate: 2xx). This is
+/// the runtime discharge of INV-1/INV-2/INV-8 across the whole registry, not one
+/// hand-written case at a time.
+///
+/// Terminal anti-vacuous-green invariant: exactly one hostile probe per row is
+/// driven and the count equals the registry size, so a row that silently
+/// produced no probe fails here instead of the sweep passing by testing nothing.
+#[sqlx::test]
+async fn deny_bearing_registry_denies_hostile_and_admits_authorized(pool: sqlx::PgPool) {
+    let node = spawn_node(pool).await;
+    // A bounded timeout so a wedged route fails the suite rather than hanging it.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap();
+    let fixture = Fixture::seed(&node).await;
+
+    let rows = deny_bearing_routes();
+    assert!(
+        !rows.is_empty(),
+        "deny-bearing route registry is empty — nothing to sweep"
+    );
+
+    let mut hostile_driven = 0usize;
+    let mut twins_driven = 0usize;
+
+    for row in rows {
+        let probes = probes_for(row, &fixture);
+        assert!(
+            !probes.is_empty(),
+            "row {} {} produced no probes",
+            row.method,
+            row.path
+        );
+        for probe in &probes {
+            let ctx = format!("{} [{} {}]", probe.label, probe.method, probe.path);
+            let resp = send_probe(&client, &node.base_url, &fixture, probe).await;
+            let status = resp.status();
+            match &probe.expect {
+                Expect::Deny(code) => {
+                    hostile_driven += 1;
+                    assert_eq!(
+                        status.as_u16(),
+                        *code,
+                        "hostile probe must deny with {code}, got {status}: {ctx}"
+                    );
+                    // INV-8 shape guard: rechecks the status and that the body is
+                    // neither an empty-200-as-success nor carrying withheld data.
+                    assert_denied(resp, *code, &[]).await;
+                }
+                Expect::Not403 => {
+                    twins_driven += 1;
+                    assert_ne!(
+                        status.as_u16(),
+                        403,
+                        "owner-reachability twin must reach the handler (not 403): {ctx}"
+                    );
+                }
+                Expect::Ok2xx(token) => {
+                    twins_driven += 1;
+                    assert!(
+                        status.is_success(),
+                        "read-reachability twin must be 2xx, got {status}: {ctx}"
+                    );
+                    if let Some(tok) = token {
+                        let body = resp.text().await.unwrap_or_default();
+                        assert!(
+                            body.contains(tok),
+                            "read twin 2xx body missing expected token {tok:?}: {ctx}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    assert_eq!(
+        hostile_driven,
+        rows.len(),
+        "expected exactly one hostile probe per deny-bearing row ({} rows), drove {hostile_driven}",
+        rows.len()
+    );
+    assert!(
+        twins_driven >= 1,
+        "no positive twins were driven — the reachability proof is missing"
     );
 }
 

--- a/crates/gitlawb-node/tests/deny_harness.rs
+++ b/crates/gitlawb-node/tests/deny_harness.rs
@@ -374,6 +374,191 @@ async fn withheld_path_blob_read_is_denied(pool: sqlx::PgPool) {
     );
 }
 
+// ── U3: get_pr_diff SECOND (per-path) gate — a diff touching a withheld path ──
+
+/// Build a git v0 receive-pack body creating `refs/heads/<branch>` at a fresh
+/// commit that adds `files` on top of the existing `main`, force-updating main to
+/// a deterministic base so `<branch>` shares history with main. Returns the body
+/// bytes plus the new feature tip. Shells out to the local `git`.
+fn build_branch_push_body(
+    server_main_tip: &str,
+    branch: &str,
+    files: &[(&str, &str)],
+) -> Vec<u8> {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let work = std::env::temp_dir().join(format!(
+        "gl-u3-prdiff-{}-{}",
+        std::process::id(),
+        server_main_tip
+    ));
+    let _ = std::fs::remove_dir_all(&work);
+    std::fs::create_dir_all(&work).unwrap();
+    let run = |args: &[&str]| -> String {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(&work)
+            .output()
+            .expect("git runs");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+    run(&["init", "-q", "-b", "main"]);
+    run(&["config", "user.email", "t@t"]);
+    run(&["config", "user.name", "t"]);
+    std::fs::write(work.join("base.txt"), "prdiff base").unwrap();
+    run(&["add", "base.txt"]);
+    run(&["commit", "-q", "-m", "base"]);
+    let new_main = run(&["rev-parse", "HEAD"]);
+    run(&["checkout", "-q", "-b", branch]);
+    for (p, c) in files {
+        let full = work.join(p);
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&full, c).unwrap();
+        run(&["add", p]);
+    }
+    run(&["commit", "-q", "-m", "feature"]);
+    let feature_tip = run(&["rev-parse", "HEAD"]);
+
+    let mut child = Command::new("git")
+        .args(["pack-objects", "--stdout", "--revs"])
+        .current_dir(&work)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .as_ref()
+        .unwrap()
+        .write_all(format!("{new_main}\n{feature_tip}\n").as_bytes())
+        .unwrap();
+    let pack = child.wait_with_output().unwrap().stdout;
+
+    let zero = "0".repeat(server_main_tip.len());
+    let l1 = format!("{server_main_tip} {new_main} refs/heads/main\0report-status\n");
+    let l2 = format!("{zero} {feature_tip} refs/heads/{branch}\n");
+    let mut body: Vec<u8> = Vec::new();
+    body.extend(format!("{:04x}{l1}", l1.len() + 4).into_bytes());
+    body.extend(format!("{:04x}{l2}", l2.len() + 4).into_bytes());
+    body.extend_from_slice(b"0000");
+    body.extend_from_slice(&pack);
+    let _ = std::fs::remove_dir_all(&work);
+    body
+}
+
+/// get_pr_diff has a SECOND, path-scoped gate after the repo-root read: it
+/// iterates the diff's touched paths and 404s if any is withheld (pulls.rs
+/// visibility_check loop). On a PUBLIC repo with a `/secret/**` withhold rule and a
+/// PR whose diff touches `secret/x.txt`, an anon caller PASSES the public repo-root
+/// gate but must be DENIED by the per-path gate (404), leaking neither the withheld
+/// content nor its OID; the owner sees the full diff. This drives the per-path gate
+/// the private-repo registry row cannot reach (there, the root gate fires first for
+/// every non-owner), so reverting the visibility_check Deny-return turns this RED.
+#[sqlx::test]
+async fn get_pr_diff_withheld_path_is_denied(pool: sqlx::PgPool) {
+    let node = spawn_node(pool).await;
+    let client = reqwest::Client::new();
+    let owner = Keypair::generate();
+    let owner_did = owner.did().to_string();
+
+    let repo_id = node.seed_repo(&owner_did, "prdiff-repo", true).await;
+    let oids = node.seed_bare_repo(
+        &owner_did,
+        "prdiff-repo",
+        &[("public/a.txt", "public seed")],
+        "sha1",
+    );
+    node.withhold_path(&repo_id, "/secret/**", &[], &owner_did)
+        .await;
+
+    // Push a `feature` branch whose diff vs main touches the withheld secret path.
+    let body = build_branch_push_body(
+        &oids["HEAD"],
+        "feature",
+        &[("secret/x.txt", "TOPSECRET-PRDIFF-PATH")],
+    );
+    let push = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &format!("/{owner_did}/prdiff-repo/git-receive-pack"),
+        body,
+        &owner,
+    )
+    .header("content-type", "application/x-git-receive-pack-request")
+    .send()
+    .await
+    .expect("push sends");
+    assert_eq!(push.status().as_u16(), 200, "owner push must land");
+
+    // Open a PR main <- feature (as owner, a reader of the public repo).
+    let create = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &format!("/api/v1/repos/{owner_did}/prdiff-repo/pulls"),
+        br#"{"title":"prdiff","source_branch":"feature","target_branch":"main"}"#.to_vec(),
+        &owner,
+    )
+    .header("content-type", "application/json")
+    .send()
+    .await
+    .expect("create PR sends");
+    assert_eq!(create.status().as_u16(), 201, "PR create must return 201");
+    let pr: serde_json::Value = create.json().await.unwrap();
+    let number = pr["number"].as_i64().expect("PR number");
+
+    // Anon PASSES the public repo-root gate, then the per-path gate DENIES the diff
+    // (it touches the withheld secret path): 404, leaking no content or OID.
+    let secret_oid = oids
+        .get("secret/x.txt")
+        .cloned()
+        .unwrap_or_default(); // seed_bare_repo didn't seed it; the pushed one is unknown here.
+    let resp = client
+        .get(format!(
+            "{}/api/v1/repos/{owner_did}/prdiff-repo/pulls/{number}/diff",
+            node.base_url
+        ))
+        .send()
+        .await
+        .expect("anon diff read sends");
+    let mut withheld = vec!["TOPSECRET-PRDIFF-PATH"];
+    if !secret_oid.is_empty() {
+        withheld.push(secret_oid.as_str());
+    }
+    assert_denied(resp, 404, &withheld).await;
+
+    // Owner sees the full diff (the per-path gate admits the reader).
+    let resp = signed_request(
+        &client,
+        reqwest::Method::GET,
+        &node.base_url,
+        &format!("/api/v1/repos/{owner_did}/prdiff-repo/pulls/{number}/diff"),
+        Vec::new(),
+        &owner,
+    )
+    .send()
+    .await
+    .expect("owner diff read sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "owner must see the full PR diff (per-path gate admits the reader)"
+    );
+    assert!(
+        resp.text().await.unwrap().contains("TOPSECRET-PRDIFF-PATH"),
+        "the owner's diff returns the touched file content"
+    );
+}
+
 // ── U8: INV-2 — an anonymous clone/fetch excludes withheld subtree blobs ──────
 
 /// The replication/clone surface, the one `oneshot` cannot serve: a public repo
@@ -1106,45 +1291,16 @@ mod completeness {
         // Reasons fall into a few honest classes, so a reviewer can see WHY a
         // read-gated endpoint is not driven for its 404 rather than trusting a name.
         const READ_GATE_NOT_DRIVEN: &[(&str, &str)] = &[
-            // Deferred GET reads: verified to read-gate on "/", but the owner-2xx
-            // twin needs a seeded sub-entity the fixture does not yet create, so
-            // they land with the fixture expansion that seeds them.
-            (
-                "get_issue",
-                "deferred: owner-2xx twin needs seeded sub-entity",
-            ),
-            ("get_pr", "deferred: owner-2xx twin needs seeded sub-entity"),
-            (
-                "get_pr_diff",
-                "deferred: owner-2xx twin needs seeded sub-entity",
-            ),
-            (
-                "list_issue_comments",
-                "deferred: owner-2xx twin needs seeded sub-entity",
-            ),
-            (
-                "list_reviews",
-                "deferred: owner-2xx twin needs seeded sub-entity",
-            ),
-            (
-                "list_comments",
-                "deferred: owner-2xx twin needs seeded sub-entity",
-            ),
-            (
-                "get_cert",
-                "deferred: owner-2xx twin needs seeded sub-entity",
-            ),
-            (
-                "get_bounty",
-                "deferred: owner-2xx twin needs seeded sub-entity",
-            ),
+            // get_issue / get_pr / get_pr_diff / list_issue_comments / list_reviews /
+            // list_comments / get_cert / get_bounty / get_tree are now DRIVEN as real
+            // ReadGate rows in deny_bearing_routes() (#195, U3), each with a per-read
+            // withheld marker; they were removed from this allowlist when they landed.
+            //
+            // get_encrypted_blob stays: its owner-2xx twin needs a live IPFS backend
+            // (`ipfs_pin::cat`) the harness has no stub for, so it cannot be driven as
+            // a 2xx twin here. U4 moves it to a structural external-dependency class.
             (
                 "get_encrypted_blob",
-                "deferred: owner-2xx twin needs seeded sub-entity",
-            ),
-            // Path-scoped get_tree/{*path} needs a seeded sub-directory for its twin.
-            (
-                "get_tree",
                 "deferred: owner-2xx twin needs seeded sub-entity",
             ),
             // Read-gates but is a mutation, not a 404-deny GET: create/write paths

--- a/crates/gitlawb-node/tests/deny_harness.rs
+++ b/crates/gitlawb-node/tests/deny_harness.rs
@@ -380,11 +380,7 @@ async fn withheld_path_blob_read_is_denied(pool: sqlx::PgPool) {
 /// commit that adds `files` on top of the existing `main`, force-updating main to
 /// a deterministic base so `<branch>` shares history with main. Returns the body
 /// bytes plus the new feature tip. Shells out to the local `git`.
-fn build_branch_push_body(
-    server_main_tip: &str,
-    branch: &str,
-    files: &[(&str, &str)],
-) -> Vec<u8> {
+fn build_branch_push_body(server_main_tip: &str, branch: &str, files: &[(&str, &str)]) -> Vec<u8> {
     use std::io::Write;
     use std::process::{Command, Stdio};
 
@@ -518,10 +514,7 @@ async fn get_pr_diff_withheld_path_is_denied(pool: sqlx::PgPool) {
 
     // Anon PASSES the public repo-root gate, then the per-path gate DENIES the diff
     // (it touches the withheld secret path): 404, leaking no content or OID.
-    let secret_oid = oids
-        .get("secret/x.txt")
-        .cloned()
-        .unwrap_or_default(); // seed_bare_repo didn't seed it; the pushed one is unknown here.
+    let secret_oid = oids.get("secret/x.txt").cloned().unwrap_or_default(); // seed_bare_repo didn't seed it; the pushed one is unknown here.
     let resp = client
         .get(format!(
             "{}/api/v1/repos/{owner_did}/prdiff-repo/pulls/{number}/diff",
@@ -1001,7 +994,10 @@ mod completeness {
     const READ_GATE_NOT_DRIVEN: &[(&str, NotDrivenReason)] = &[
         // Owner-2xx twin needs a live IPFS backend (`ipfs_pin::cat`) the harness has
         // no stub for — an honest external-dependency exclusion (#195, KTD-5).
-        ("get_encrypted_blob", NotDrivenReason::ExternalDependencyUnavailable),
+        (
+            "get_encrypted_blob",
+            NotDrivenReason::ExternalDependencyUnavailable,
+        ),
         // Read-gates but is a mutation, not a 404-deny GET.
         ("create_review", NotDrivenReason::ReadGatingMutation),
         ("create_comment", NotDrivenReason::ReadGatingMutation),

--- a/crates/gitlawb-node/tests/deny_harness.rs
+++ b/crates/gitlawb-node/tests/deny_harness.rs
@@ -951,6 +951,77 @@ mod completeness {
     use super::deny_bearing_routes;
     use crate::support::routes::{GateClass, Principal};
 
+    /// The CLOSED set of structural reasons a read-gate handler may sit out of the
+    /// runtime 404 sweep (#195, U4/R4). This replaces the free-text `reason`
+    /// strings the old allowlist carried: a "deferred / needs seeding" prose excuse
+    /// no longer type-checks. Every `READ_GATE_NOT_DRIVEN` entry must name one of
+    /// these variants, so a reviewer sees a STRUCTURAL class (why the read is not a
+    /// drivable 404-deny GET), never a soft deferral that hides an undriven private
+    /// read. A drivable GET (the nine U3 reads) cannot be parked here because none
+    /// of these classes fits it — and the driven-not-relabeled assertion below
+    /// makes that a hard failure rather than a judgment call.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum NotDrivenReason {
+        /// A create/write path that read-gates the caller before mutating, not a
+        /// 404-deny GET. Its owner/author behaviour is covered by the mutation
+        /// authz guard in `src/api/mod.rs`, not this GET-read sweep.
+        ReadGatingMutation,
+        /// A git smart-HTTP read (`info/refs`, `git-upload-pack`): its
+        /// withheld-subtree 404/exclusion is driven by the U7/U8 real-clone cases,
+        /// not the API GET sweep.
+        GitSmartHttpRead,
+        /// A content-addressed read (`/ipfs/{cid}`): its 404 deny + no-leak is
+        /// driven by the U5b/U8 anon_ipfs/clone cases in this file.
+        ContentAddressedRead,
+        /// A global list-FILTER: returns 200 with unreadable rows removed, never a
+        /// 404, so it is not a deny-bearing read at all.
+        GlobalListFilter,
+        /// The owner-2xx twin needs a live external dependency the harness lacks:
+        /// `get_encrypted_blob` reads through `ipfs_pin::cat` with no harness stub,
+        /// so it cannot be driven as a 2xx twin here. An honest exclusion, not a
+        /// deferral (#195, KTD-5).
+        ExternalDependencyUnavailable,
+    }
+
+    /// Read-gate handlers NOT driven as a `ReadGate` row, each carrying a CLOSED
+    /// structural reason ([`NotDrivenReason`]) — never free-text. This is the
+    /// enforced form of the prose that used to live in routes.rs; a handler leaving
+    /// the sweep must be moved here under a structural class, never with a soft
+    /// "deferred / needs seeding" excuse (which no longer type-checks).
+    ///
+    /// Single source of truth: both the marker-scan guard
+    /// (`every_read_gate_handler_is_driven_or_explicitly_allowlisted`) and the
+    /// route-table cross-check (`mounted_repo_gets_are_driven_excused_or_declared_public`)
+    /// read this, so the two cannot drift.
+    ///
+    /// get_issue / get_pr / get_pr_diff / list_issue_comments / list_reviews /
+    /// list_comments / get_cert / get_bounty / get_tree are DRIVEN as real ReadGate
+    /// rows in deny_bearing_routes() (#195, U3); the driven-not-relabeled assertion
+    /// bars any of them from being quietly re-parked here.
+    const READ_GATE_NOT_DRIVEN: &[(&str, NotDrivenReason)] = &[
+        // Owner-2xx twin needs a live IPFS backend (`ipfs_pin::cat`) the harness has
+        // no stub for — an honest external-dependency exclusion (#195, KTD-5).
+        ("get_encrypted_blob", NotDrivenReason::ExternalDependencyUnavailable),
+        // Read-gates but is a mutation, not a 404-deny GET.
+        ("create_review", NotDrivenReason::ReadGatingMutation),
+        ("create_comment", NotDrivenReason::ReadGatingMutation),
+        ("create_pr", NotDrivenReason::ReadGatingMutation),
+        ("create_issue", NotDrivenReason::ReadGatingMutation),
+        ("create_issue_comment", NotDrivenReason::ReadGatingMutation),
+        ("create_bounty", NotDrivenReason::ReadGatingMutation),
+        ("claim_bounty", NotDrivenReason::ReadGatingMutation),
+        ("fork_repo", NotDrivenReason::ReadGatingMutation),
+        ("star_repo", NotDrivenReason::ReadGatingMutation),
+        ("unstar_repo", NotDrivenReason::ReadGatingMutation),
+        // Content-addressed read: driven by the U5b/U8 anon_ipfs/clone cases.
+        ("get_by_cid", NotDrivenReason::ContentAddressedRead),
+        // Git smart-HTTP reads: driven by the U7/U8 real-clone cases.
+        ("git_info_refs", NotDrivenReason::GitSmartHttpRead),
+        ("git_upload_pack", NotDrivenReason::GitSmartHttpRead),
+        // Global list-FILTER: 200 with unreadable rows removed, never a 404.
+        ("list_all_bounties", NotDrivenReason::GlobalListFilter),
+    ];
+
     /// Every `.route("<path>", <method>(<handler>)…)` mount in `src`, as
     /// (METHOD, path). Multiline-aware: most mounts put the path on the line after
     /// `.route(`, so a per-line scan false-greens. Walks balanced parens from each
@@ -1283,91 +1354,9 @@ mod completeness {
     /// like the owner scan, so a new module is covered too.
     #[test]
     fn every_read_gate_handler_is_driven_or_explicitly_allowlisted() {
-        // Read-gate handlers NOT driven as a ReadGate row, each with the reason it
-        // is out of the runtime 404 sweep. This is the enforced form of the prose
-        // that used to live at routes.rs:351-365; a handler leaving the sweep must
-        // be moved here with a reason, never silently.
-        //
-        // Reasons fall into a few honest classes, so a reviewer can see WHY a
-        // read-gated endpoint is not driven for its 404 rather than trusting a name.
-        const READ_GATE_NOT_DRIVEN: &[(&str, &str)] = &[
-            // get_issue / get_pr / get_pr_diff / list_issue_comments / list_reviews /
-            // list_comments / get_cert / get_bounty / get_tree are now DRIVEN as real
-            // ReadGate rows in deny_bearing_routes() (#195, U3), each with a per-read
-            // withheld marker; they were removed from this allowlist when they landed.
-            //
-            // get_encrypted_blob stays: its owner-2xx twin needs a live IPFS backend
-            // (`ipfs_pin::cat`) the harness has no stub for, so it cannot be driven as
-            // a 2xx twin here. U4 moves it to a structural external-dependency class.
-            (
-                "get_encrypted_blob",
-                "deferred: owner-2xx twin needs seeded sub-entity",
-            ),
-            // Read-gates but is a mutation, not a 404-deny GET: create/write paths
-            // that call authorize_repo_read on the caller before mutating. Their
-            // owner-gate/author behaviour is covered by the mutation authz guard in
-            // src/api/mod.rs, not this GET-read sweep.
-            (
-                "create_review",
-                "read-gates but is a mutation, not a 404-deny GET",
-            ),
-            (
-                "create_comment",
-                "read-gates but is a mutation, not a 404-deny GET",
-            ),
-            (
-                "create_pr",
-                "read-gates but is a mutation, not a 404-deny GET",
-            ),
-            (
-                "create_issue",
-                "read-gates but is a mutation, not a 404-deny GET",
-            ),
-            (
-                "create_issue_comment",
-                "read-gates but is a mutation, not a 404-deny GET",
-            ),
-            (
-                "create_bounty",
-                "read-gates but is a mutation, not a 404-deny GET",
-            ),
-            (
-                "claim_bounty",
-                "read-gates but is a mutation, not a 404-deny GET",
-            ),
-            (
-                "fork_repo",
-                "read-gates but is a mutation, not a 404-deny GET",
-            ),
-            (
-                "star_repo",
-                "read-gates but is a mutation, not a 404-deny GET",
-            ),
-            (
-                "unstar_repo",
-                "read-gates but is a mutation, not a 404-deny GET",
-            ),
-            // Content-addressed read: its 404 deny + no-leak is already driven by
-            // the U5b/U8 anon_ipfs/clone cases in this file.
-            ("get_by_cid", "covered by U5b/U8 anon_ipfs/clone cases"),
-            // Git smart-HTTP reads: their withheld-subtree 404/exclusion is driven
-            // by the U7/U8 real-clone cases, not the API GET sweep.
-            (
-                "git_info_refs",
-                "git smart-HTTP read: covered by U7/U8 clone cases",
-            ),
-            (
-                "git_upload_pack",
-                "git smart-HTTP read: covered by U7/U8 clone cases",
-            ),
-            // Global list-FILTER: returns 200 with unreadable rows removed, never a
-            // 404, so it is not a deny-bearing read at all (matches the EXCLUDED
-            // class the prose called out).
-            (
-                "list_all_bounties",
-                "global list-filter: 200 with unreadable rows removed, never 404",
-            ),
-        ];
+        // The allowlist is the module-level `READ_GATE_NOT_DRIVEN` (single source of
+        // truth, shared with the route-table cross-check). Its entries carry a closed
+        // `NotDrivenReason`, so a soft "deferred" excuse cannot be added.
 
         let driven_read_handlers: HashSet<&str> = deny_bearing_routes()
             .iter()
@@ -1433,6 +1422,222 @@ mod completeness {
                  read-gate marker (renamed, removed, or gate dropped?) — update the list"
             );
         }
+
+        // DRIVEN-NOT-RELABELED (#195, U4/R5). The nine reads U3 drove must each be a
+        // driven `ReadGate` row AND absent from `READ_GATE_NOT_DRIVEN`, so none can
+        // be quietly re-parked under a mislabeled structural reason. A structural
+        // class (mutation / git / content-addressed / list-filter / external-dep)
+        // does not fit any of these nine, but a reviewer could still mistype one in;
+        // this makes that a hard failure rather than a judgment call. Together with
+        // the closed `NotDrivenReason` enum, a drivable private read cannot leave the
+        // sweep: either the class does not compile, or this assertion fires.
+        const U3_DRIVEN_READS: &[&str] = &[
+            "get_issue",
+            "get_pr",
+            "get_pr_diff",
+            "list_issue_comments",
+            "list_reviews",
+            "list_comments",
+            "get_cert",
+            "get_bounty",
+            "get_tree",
+        ];
+        for name in U3_DRIVEN_READS {
+            assert!(
+                driven_read_handlers.contains(name),
+                "U3 drove `{name}` as a private read, but it is no longer a ReadGate \
+                 row in deny_bearing_routes() — a driven read was dropped or renamed"
+            );
+            assert!(
+                !allowlisted.contains(name),
+                "`{name}` is a U3-driven private read but was re-parked in \
+                 READ_GATE_NOT_DRIVEN — a drivable 404-deny GET may not be excused \
+                 under a structural reason; drive it, do not relabel it"
+            );
+        }
+    }
+
+    /// The repo-scoped GET mounts the [`scrape_mounts`] route-table walk does NOT
+    /// treat as read-gated — genuinely public repo listings that fetch the repo and
+    /// return metadata WITHOUT an `authorize_repo_read` / `visibility_check` call
+    /// (verified in their handlers). They carry no read gate, so the cross-check
+    /// below must not demand they be driven or structurally excused. Keyed by path
+    /// (the unit `scrape_mounts` yields) so a new gate added to one of these later
+    /// still surfaces via the marker scan; this list only says "no gate today".
+    const PUBLIC_REPO_GETS: &[&str] = &[
+        "/api/v1/repos/{owner}/{repo}/hooks", // list_webhooks
+        "/api/v1/repos/{owner}/{repo}/branches/protected", // list_protected_branches
+        "/api/v1/repos/{owner}/{repo}/replicas", // list_replicas
+    ];
+
+    /// True for a mounted path that is scoped to a single repo — the API form
+    /// `/api/v1/repos/{owner}/{repo}/…` and the bare git form `/{owner}/{repo}/…`.
+    /// These are the paths whose GET, if read-gated, must be driven or excused; a
+    /// collection/global path (`/api/v1/repos`, `/api/v1/bounties`, `/api/v1/agents`
+    /// …) is out of scope for the repo-read cross-check.
+    fn is_repo_scoped_path(path: &str) -> bool {
+        if let Some(rest) = path.strip_prefix("/api/v1/repos/") {
+            // `.../{owner}/{repo}/…` — at least owner + repo + a trailing segment,
+            // and NOT the `/api/v1/repos/federated` or bare `/api/v1/repos` forms
+            // (those have no `{owner}` placeholder).
+            return rest.starts_with("{owner}/{repo}/");
+        }
+        // Bare git form: `/{owner}/{repo}/info/refs` etc. It is repo-scoped when the
+        // first two segments are the owner/repo placeholders.
+        let segs: Vec<&str> = path.trim_start_matches('/').split('/').collect();
+        segs.len() >= 3 && segs[0] == "{owner}" && segs[1] == "{repo}"
+    }
+
+    /// Extract the handler name from a single `.route("path", …get(handler)…)` mount
+    /// body: the last `::`-tail ident inside the FIRST routing-method call for the
+    /// requested HTTP method. Returns `None` if the method is not mounted on this
+    /// route. Reuses the same balanced-paren mount slice `scrape_mounts` walks.
+    fn handler_for_mount(call: &str, method: &str) -> Option<String> {
+        let needle = format!("{}(", method.to_lowercase());
+        let mut k = 0;
+        while let Some(rel) = call[k..].find(&needle) {
+            let at = k + rel;
+            let boundary = call[..at]
+                .chars()
+                .last()
+                .map(|c| !(c.is_alphanumeric() || c == '_'))
+                .unwrap_or(true);
+            if boundary {
+                // The handler is the first path-expression after `get(`; take up to
+                // the closing `)` and keep the final `::`-segment ident.
+                let inner_start = at + needle.len();
+                let inner = &call[inner_start..];
+                let end = inner.find([')', ',']).unwrap_or(inner.len());
+                let expr = inner[..end].trim();
+                let name: String = expr
+                    .rsplit("::")
+                    .next()
+                    .unwrap_or(expr)
+                    .chars()
+                    .take_while(|c| c.is_alphanumeric() || *c == '_')
+                    .collect();
+                if !name.is_empty() {
+                    return Some(name);
+                }
+            }
+            k = at + needle.len();
+        }
+        None
+    }
+
+    /// Like [`scrape_mounts`] but also captures the handler name, so a mounted
+    /// (METHOD, path) can be resolved to its handler for the read-gate cross-check.
+    /// Same balanced-paren walk as `scrape_mounts`.
+    fn scrape_mounts_with_handler(src: &str) -> Vec<(String, String, String)> {
+        let bytes = src.as_bytes();
+        let mut out = Vec::new();
+        let mut i = 0;
+        while let Some(rel) = src[i..].find(".route(") {
+            let open = i + rel + ".route(".len();
+            let mut depth = 1i32;
+            let mut j = open;
+            while j < src.len() && depth > 0 {
+                match bytes[j] {
+                    b'(' => depth += 1,
+                    b')' => depth -= 1,
+                    _ => {}
+                }
+                j += 1;
+            }
+            let call = &src[open..j.saturating_sub(1)];
+            i = j;
+            let Some(qs) = call.find('"') else { continue };
+            let Some(qe) = call[qs + 1..].find('"') else {
+                continue;
+            };
+            let path = &call[qs + 1..qs + 1 + qe];
+            for m in ["get", "post", "put", "delete", "patch"] {
+                let needle = format!("{m}(");
+                let mut k = 0;
+                while let Some(mrel) = call[k..].find(&needle) {
+                    let at = k + mrel;
+                    let boundary = call[..at]
+                        .chars()
+                        .last()
+                        .map(|c| !(c.is_alphanumeric() || c == '_'))
+                        .unwrap_or(true);
+                    if boundary {
+                        if let Some(h) = handler_for_mount(call, m) {
+                            out.push((m.to_uppercase(), path.to_string(), h));
+                        }
+                    }
+                    k = at + needle.len();
+                }
+            }
+        }
+        out
+    }
+
+    /// SCRAPE-MOUNTS CROSS-CHECK (#195, U4/R5, INV-21b). The read-gate orphan guard
+    /// above derives its required set from a SOURCE-MARKER scan of `src/api`; this
+    /// derives it instead from the MOUNTED ROUTE TABLE (`server.rs`). Every mounted
+    /// repo-scoped GET must be EITHER a driven `ReadGate` row, OR a deny-bearing GET
+    /// of another class already in the registry (`list_visibility` is an owner-gated
+    /// GET), OR structurally excused in `READ_GATE_NOT_DRIVEN`, OR a declared public
+    /// repo-GET (`PUBLIC_REPO_GETS`). A mounted repo-GET that is none of these fails
+    /// HERE — which catches a read that gates via a helper the marker scan does not
+    /// recognize: it would still be mounted, so it must be classified rather than
+    /// slipping past silently.
+    #[test]
+    fn mounted_repo_gets_are_driven_excused_or_declared_public() {
+        let server = include_str!("../src/server.rs");
+        let mounts = scrape_mounts_with_handler(server);
+
+        // Integrity floor: the handler-aware walk must find roughly as many mounts
+        // as the plain scrape; if it collapsed, the cross-check would pass vacuously.
+        assert!(
+            mounts.len() >= 90,
+            "handler-aware mount scrape found only {} routes — the parser likely broke (floor 90)",
+            mounts.len()
+        );
+
+        // Every path that is a driven ReadGate row, and every deny-bearing GET path
+        // of any class (so the owner-gated `list_visibility` GET is accounted for).
+        let driven_read_paths: HashSet<&str> = deny_bearing_routes()
+            .iter()
+            .filter(|r| r.gate == GateClass::ReadGate)
+            .map(|r| r.path)
+            .collect();
+        let deny_bearing_get_paths: HashSet<&str> = deny_bearing_routes()
+            .iter()
+            .filter(|r| r.method == "GET")
+            .map(|r| r.path)
+            .collect();
+        let excused_handlers: HashSet<&str> =
+            READ_GATE_NOT_DRIVEN.iter().map(|(h, _)| *h).collect();
+        let public_paths: HashSet<&str> = PUBLIC_REPO_GETS.iter().copied().collect();
+
+        let mut repo_gets_seen = 0usize;
+        for (method, path, handler) in &mounts {
+            if method != "GET" || !is_repo_scoped_path(path) {
+                continue;
+            }
+            repo_gets_seen += 1;
+            let classified = driven_read_paths.contains(path.as_str())
+                || deny_bearing_get_paths.contains(path.as_str())
+                || excused_handlers.contains(handler.as_str())
+                || public_paths.contains(path.as_str());
+            assert!(
+                classified,
+                "mounted repo-scoped GET `{path}` (handler `{handler}`) is neither a \
+                 driven ReadGate row, a deny-bearing GET row, structurally excused in \
+                 READ_GATE_NOT_DRIVEN, nor a declared public repo-GET — classify it \
+                 (it may gate via a helper the source-marker scan does not recognize)"
+            );
+        }
+
+        // Non-vacuous floor: the tree mounts well over a dozen repo-scoped GETs; if
+        // the filter found almost none, the loop above proved nothing.
+        assert!(
+            repo_gets_seen >= 15,
+            "found only {repo_gets_seen} mounted repo-scoped GETs — the path filter \
+             or the scrape likely broke (floor 15)"
+        );
     }
 
     // ── F3 unit tests: the inline owner-gate did_matches discriminator ───────────

--- a/crates/gitlawb-node/tests/deny_harness.rs
+++ b/crates/gitlawb-node/tests/deny_harness.rs
@@ -503,8 +503,13 @@ async fn deny_bearing_registry_denies_hostile_and_admits_authorized(pool: sqlx::
                         "hostile probe must deny with {code}, got {status}: {ctx}"
                     );
                     // INV-8 shape guard: rechecks the status and that the body is
-                    // neither an empty-200-as-success nor carrying withheld data.
-                    assert_denied(resp, *code, &[]).await;
+                    // neither an empty-200-as-success nor carrying withheld data. The
+                    // probe's `withheld` tokens (the private repo's secret bytes and
+                    // blob OID on read-gate probes) are passed through, so a 404 that
+                    // spilled the private content fails here instead of being counted
+                    // as a clean denial.
+                    let tokens: Vec<&str> = probe.withheld.iter().map(String::as_str).collect();
+                    assert_denied(resp, *code, &tokens).await;
                 }
                 Expect::Not403 => {
                     twins_driven += 1;
@@ -737,8 +742,125 @@ mod completeness {
         out
     }
 
+    /// Like [`handlers_with_marker`] but selects handlers whose body satisfies a
+    /// PREDICATE rather than a substring — used for the inline owner-gate
+    /// did_matches idiom (F3), whose "first arg is the caller, second is
+    /// owner_did" shape a plain substring cannot express. Same fn-segmentation as
+    /// `handlers_with_marker` so a match cannot leak across into the next handler.
+    fn handlers_matching(src: &str, pred: fn(&str) -> bool) -> HashSet<String> {
+        let decls = [
+            "\npub async fn ",
+            "\npub(crate) async fn ",
+            "\nasync fn ",
+            "\npub(crate) fn ",
+            "\npub fn ",
+            "\nfn ",
+        ];
+        let mut starts: Vec<usize> = Vec::new();
+        for d in decls {
+            let mut k = 0;
+            while let Some(r) = src[k..].find(d) {
+                starts.push(k + r + 1);
+                k = k + r + d.len();
+            }
+        }
+        starts.sort_unstable();
+        let mut out = HashSet::new();
+        for (idx, &s) in starts.iter().enumerate() {
+            let end = starts.get(idx + 1).copied().unwrap_or(src.len());
+            let seg = &src[s..end];
+            let Some(fnpos) = seg.find("fn ") else {
+                continue;
+            };
+            let name: String = seg[fnpos + 3..]
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if name.is_empty() {
+                continue;
+            }
+            if pred(seg) {
+                out.insert(name);
+            }
+        }
+        out
+    }
+
     fn short_handler(h: &str) -> &str {
         h.rsplit("::").next().unwrap_or(h)
+    }
+
+    /// Like [`handlers_with_marker`] but ignores markers that appear only inside a
+    /// full-line `//` comment. The owner-gate markers never show up in prose, but
+    /// the read-gate markers (`authorize_repo_read(` / `visibility_check(`) do:
+    /// several docstrings and a test comment name them (repos.rs's
+    /// `owner_push_rejection` / `dedupe_canonical_repos` regions, the fork
+    /// docstring), and a raw `contains` would misattribute those to the nearest
+    /// preceding fn and force a phantom non-handler onto the read-gate allowlist.
+    /// Mirrors `authz_guard::fn_body`'s comment-stripping so the scan sees code,
+    /// not prose.
+    fn handlers_with_code_marker(src: &str, markers: &[&str]) -> HashSet<String> {
+        let stripped: String = src
+            .lines()
+            .map(|l| {
+                if l.trim_start().starts_with("//") {
+                    ""
+                } else {
+                    l
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        handlers_with_marker(&stripped, markers)
+    }
+
+    /// True when `body` contains an INLINE owner-gate `did_matches` call: one
+    /// whose FIRST arg is the caller (`caller` / `&caller` / `&auth.0`) AND whose
+    /// SECOND arg is `&record.owner_did`. That two-arg shape is the discriminator
+    /// (F3): `require_owner`/`require_repo_owner` are the named markers, but
+    /// protect_branch / unprotect_branch owner-gate with this raw idiom instead, so
+    /// a plain marker misses them and a future owner-only handler using the same
+    /// pattern could slip past the registry while U4 stayed green.
+    ///
+    /// It must NOT fire on the signer-self / author forms that share the helper:
+    /// register_replica's `did_matches(replica_did, &record.owner_did)` (first arg
+    /// is the replica, not the caller — signer-self by design), close_pr's
+    /// `did_matches(&auth.0, &pr.author_did)`, and the bounty/task self forms
+    /// (`&bounty.creator_did`, delegator/assignee dids). Whitespace and newlines
+    /// inside the arg list are tolerated so a reformatted call still matches.
+    fn has_owner_did_matches(body: &str) -> bool {
+        let bytes = body.as_bytes();
+        let mut i = 0;
+        while let Some(rel) = body[i..].find("did_matches(") {
+            let open = i + rel + "did_matches(".len();
+            // Walk to the matching close paren, splitting the top-level args on the
+            // first depth-0 comma (there are exactly two args).
+            let mut depth = 1i32;
+            let mut comma: Option<usize> = None;
+            let mut j = open;
+            while j < body.len() && depth > 0 {
+                match bytes[j] {
+                    b'(' => depth += 1,
+                    b')' => depth -= 1,
+                    b',' if depth == 1 && comma.is_none() => comma = Some(j),
+                    _ => {}
+                }
+                j += 1;
+            }
+            i = j;
+            let close = j.saturating_sub(1);
+            let Some(comma) = comma else { continue };
+            let arg1 = body[open..comma].split_whitespace().collect::<String>();
+            let arg2 = body[comma + 1..close]
+                .split_whitespace()
+                .collect::<String>();
+            let caller_first = arg1 == "caller" || arg1 == "&caller" || arg1 == "&auth.0";
+            let owner_second = arg2 == "&record.owner_did";
+            if caller_first && owner_second {
+                return true;
+            }
+        }
+        false
     }
 
     #[test]
@@ -766,13 +888,18 @@ mod completeness {
             );
         }
 
-        // ORPHAN GUARD: every handler carrying an unambiguous owner-gate marker
-        // (`require_repo_owner` / `require_owner`) must be a registry owner-gate
+        // ORPHAN GUARD: every handler that owner-gates must be a registry owner-gate
         // row, so a newly added owner-gated mutation cannot escape the runtime
         // sweep. The api dir is read at test time (like authz_guard's completeness
-        // scan) so a brand-new module is covered too. `did_matches` is deliberately
-        // NOT a marker here: it is shared with the signer-self bucket and would
-        // misclassify; close_pr/close_issue/protect are already covered as rows.
+        // scan) so a brand-new module is covered too. Two owner-gate shapes are
+        // recognized:
+        //   (1) the named markers `require_repo_owner(` / `require_owner(`, and
+        //   (2) the INLINE `did_matches(caller, &record.owner_did)` idiom (F3) that
+        //       protect_branch / unprotect_branch use instead of a named helper.
+        // Only the SECOND-arg-is-owner_did form of did_matches is treated as an
+        // owner gate; the signer-self / author forms (register_replica's
+        // did_matches(replica_did, …), close_pr's did_matches(&auth.0, &author_did))
+        // are deliberately NOT matched, so they don't false-orphan.
         let registry_owner_handlers: HashSet<&str> = deny_bearing_routes()
             .iter()
             .filter(|r| r.gate == GateClass::OwnerGate)
@@ -789,13 +916,23 @@ mod completeness {
                     &src,
                     &["require_repo_owner(", "require_owner("],
                 ));
+                // Fold in the inline did_matches-owner idiom (F3).
+                owner_marked.extend(handlers_matching(&src, has_owner_did_matches));
             }
         }
-        // The gate helpers' own definition lines contain the marker string; they
-        // are helpers, not mounted handlers, so drop them.
+        // The gate helpers' own definitions carry the owner-gate idiom (the named
+        // marker string, and visibility::require_owner's body is itself a
+        // `did_matches(caller, &record.owner_did)` check); they are helpers, not
+        // mounted handlers, so drop them.
         owner_marked.remove("require_owner");
         owner_marked.remove("require_repo_owner");
-
+        // git_receive_pack also carries the inline did_matches-owner idiom, but for
+        // a SECONDARY gate: its branch-protection push check (repos.rs), not a
+        // whole-handler owner gate. It IS already a registry row — driven for its
+        // 401 signature deny (SignatureRequired class), not a 403 — so it is not an
+        // owner-gate orphan. Drop it so the owner-orphan assert (which only knows
+        // the OwnerGate rows) does not misflag a route that is already swept.
+        owner_marked.remove("git_receive_pack");
         // Non-vacuous floor: if the marker scan silently found nothing (a parser
         // regression), the orphan loop below would pass by checking zero handlers.
         // The tree has 10 owner-marker handlers today; 6 trips only on a real break.
@@ -810,6 +947,290 @@ mod completeness {
                 registry_owner_handlers.contains(h.as_str()),
                 "handler `{h}` carries an owner-gate marker but is not an owner-gate \
                  row in deny_bearing_routes() — add it so the runtime sweep drives its 403"
+            );
+        }
+    }
+
+    /// READ-GATE ORPHAN GUARD (F1). The owner-gate orphan guard above stops an
+    /// owner-gated mount from escaping the sweep; this is its read-gate twin. Every
+    /// handler carrying a read-gate marker (`authorize_repo_read(` /
+    /// `visibility_check(` — the two markers repos.rs/issues.rs/pulls.rs/
+    /// bounties.rs/certs.rs/labels.rs/changelog.rs/events.rs/encrypted.rs/stars.rs/
+    /// visibility.rs all use, verified there is no third) must be EITHER a
+    /// `ReadGate` row in `deny_bearing_routes()` (driven for its 404) OR an explicit
+    /// entry in `READ_GATE_NOT_DRIVEN` with a reason. That enumerated allowlist
+    /// REPLACES the old free-text "DEFERRED / EXCLUDED" prose in routes.rs: it is
+    /// now enforced code, so removing or bypassing the read gate on any of these
+    /// endpoints (or adding a brand-new read-gated handler) trips this instead of
+    /// leaving the real-node sweep silently green. The api dir is read at test time,
+    /// like the owner scan, so a new module is covered too.
+    #[test]
+    fn every_read_gate_handler_is_driven_or_explicitly_allowlisted() {
+        // Read-gate handlers NOT driven as a ReadGate row, each with the reason it
+        // is out of the runtime 404 sweep. This is the enforced form of the prose
+        // that used to live at routes.rs:351-365; a handler leaving the sweep must
+        // be moved here with a reason, never silently.
+        //
+        // Reasons fall into a few honest classes, so a reviewer can see WHY a
+        // read-gated endpoint is not driven for its 404 rather than trusting a name.
+        const READ_GATE_NOT_DRIVEN: &[(&str, &str)] = &[
+            // Deferred GET reads: verified to read-gate on "/", but the owner-2xx
+            // twin needs a seeded sub-entity the fixture does not yet create, so
+            // they land with the fixture expansion that seeds them.
+            (
+                "get_issue",
+                "deferred: owner-2xx twin needs seeded sub-entity",
+            ),
+            ("get_pr", "deferred: owner-2xx twin needs seeded sub-entity"),
+            (
+                "get_pr_diff",
+                "deferred: owner-2xx twin needs seeded sub-entity",
+            ),
+            (
+                "list_issue_comments",
+                "deferred: owner-2xx twin needs seeded sub-entity",
+            ),
+            (
+                "list_reviews",
+                "deferred: owner-2xx twin needs seeded sub-entity",
+            ),
+            (
+                "list_comments",
+                "deferred: owner-2xx twin needs seeded sub-entity",
+            ),
+            (
+                "get_cert",
+                "deferred: owner-2xx twin needs seeded sub-entity",
+            ),
+            (
+                "get_bounty",
+                "deferred: owner-2xx twin needs seeded sub-entity",
+            ),
+            (
+                "get_encrypted_blob",
+                "deferred: owner-2xx twin needs seeded sub-entity",
+            ),
+            // Path-scoped get_tree/{*path} needs a seeded sub-directory for its twin.
+            (
+                "get_tree",
+                "deferred: owner-2xx twin needs seeded sub-entity",
+            ),
+            // Read-gates but is a mutation, not a 404-deny GET: create/write paths
+            // that call authorize_repo_read on the caller before mutating. Their
+            // owner-gate/author behaviour is covered by the mutation authz guard in
+            // src/api/mod.rs, not this GET-read sweep.
+            (
+                "create_review",
+                "read-gates but is a mutation, not a 404-deny GET",
+            ),
+            (
+                "create_comment",
+                "read-gates but is a mutation, not a 404-deny GET",
+            ),
+            (
+                "create_pr",
+                "read-gates but is a mutation, not a 404-deny GET",
+            ),
+            (
+                "create_issue",
+                "read-gates but is a mutation, not a 404-deny GET",
+            ),
+            (
+                "create_issue_comment",
+                "read-gates but is a mutation, not a 404-deny GET",
+            ),
+            (
+                "create_bounty",
+                "read-gates but is a mutation, not a 404-deny GET",
+            ),
+            (
+                "claim_bounty",
+                "read-gates but is a mutation, not a 404-deny GET",
+            ),
+            (
+                "fork_repo",
+                "read-gates but is a mutation, not a 404-deny GET",
+            ),
+            (
+                "star_repo",
+                "read-gates but is a mutation, not a 404-deny GET",
+            ),
+            (
+                "unstar_repo",
+                "read-gates but is a mutation, not a 404-deny GET",
+            ),
+            // Content-addressed read: its 404 deny + no-leak is already driven by
+            // the U5b/U8 anon_ipfs/clone cases in this file.
+            ("get_by_cid", "covered by U5b/U8 anon_ipfs/clone cases"),
+            // Git smart-HTTP reads: their withheld-subtree 404/exclusion is driven
+            // by the U7/U8 real-clone cases, not the API GET sweep.
+            (
+                "git_info_refs",
+                "git smart-HTTP read: covered by U7/U8 clone cases",
+            ),
+            (
+                "git_upload_pack",
+                "git smart-HTTP read: covered by U7/U8 clone cases",
+            ),
+            // Global list-FILTER: returns 200 with unreadable rows removed, never a
+            // 404, so it is not a deny-bearing read at all (matches the EXCLUDED
+            // class the prose called out).
+            (
+                "list_all_bounties",
+                "global list-filter: 200 with unreadable rows removed, never 404",
+            ),
+            // Repo-root GET reads that gate on "/" but are not yet driven as rows.
+            // They COULD be driven (no sub-entity needed); left out for now with an
+            // explicit reason rather than a silent omission — the whole point of the
+            // guard is that this decision is forced and reviewable.
+            (
+                "get_star_status",
+                "repo-root read: not yet driven as a ReadGate row",
+            ),
+            (
+                "get_icaptcha_proof",
+                "repo-root read: not yet driven as a ReadGate row",
+            ),
+            (
+                "replicate_encrypted_blobs",
+                "repo-root read: not yet driven as a ReadGate row",
+            ),
+        ];
+
+        let driven_read_handlers: HashSet<&str> = deny_bearing_routes()
+            .iter()
+            .filter(|r| r.gate == GateClass::ReadGate)
+            .map(|r| short_handler(r.handler))
+            .collect();
+        let allowlisted: HashSet<&str> = READ_GATE_NOT_DRIVEN.iter().map(|(h, _)| *h).collect();
+
+        let api_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src/api");
+        let mut read_marked: HashSet<String> = HashSet::new();
+        for entry in std::fs::read_dir(api_dir).expect("read api dir") {
+            let path = entry.expect("dir entry").path();
+            // Skip api/mod.rs: it holds the gate HELPERS themselves
+            // (`authorize_repo_read`, `visibility_check`, `require_repo_owner`, …),
+            // not mounted route handlers — every mounted read handler lives in a
+            // sibling module (repos.rs, issues.rs, …). Scanning mod.rs would attach
+            // the marker to helper definitions and force phantom allowlist entries.
+            if path.file_name().is_some_and(|f| f == "mod.rs") {
+                continue;
+            }
+            if path.extension().is_some_and(|e| e == "rs") {
+                let src = std::fs::read_to_string(&path).expect("read api file");
+                // Comment-stripped scan: the read-gate markers appear in several
+                // docstrings, and a raw scan would allowlist phantom non-handlers.
+                read_marked.extend(handlers_with_code_marker(
+                    &src,
+                    &["authorize_repo_read(", "visibility_check("],
+                ));
+            }
+        }
+        // The read-gate helper `visibility_check` is re-declared/aliased in
+        // visibility.rs's own use-path; drop the helper name if the scan attaches
+        // the marker to it (it is a helper, not a mounted handler) — the mirror of
+        // the owner scan dropping require_owner / require_repo_owner.
+        read_marked.remove("authorize_repo_read");
+        read_marked.remove("visibility_check");
+
+        // Non-vacuous floor: the tree has 41 read-gate-marked handlers today. If the
+        // marker scan silently found far fewer, the orphan loop below would pass by
+        // checking almost nothing; 30 trips only on a real parser break.
+        assert!(
+            read_marked.len() >= 30,
+            "read-gate marker scan found only {} handlers — the scan likely broke (floor 30)",
+            read_marked.len()
+        );
+
+        for h in &read_marked {
+            let name = h.as_str();
+            assert!(
+                driven_read_handlers.contains(name) || allowlisted.contains(name),
+                "handler `{name}` carries a read-gate marker but is neither a ReadGate \
+                 row in deny_bearing_routes() nor in READ_GATE_NOT_DRIVEN — drive its \
+                 404 or add it to the allowlist with a reason"
+            );
+        }
+
+        // Staleness: every allowlist entry must still be a real read-gate handler,
+        // so a rename/removal can't leave a dead exemption that masks a future gap.
+        for (name, _reason) in READ_GATE_NOT_DRIVEN {
+            assert!(
+                read_marked.contains(*name),
+                "READ_GATE_NOT_DRIVEN lists `{name}`, which no longer carries a \
+                 read-gate marker (renamed, removed, or gate dropped?) — update the list"
+            );
+        }
+    }
+
+    // ── F3 unit tests: the inline owner-gate did_matches discriminator ───────────
+    //
+    // These pin `has_owner_did_matches` against the EXACT real bodies (positive and
+    // negative), so the two-arg discriminator can't silently regress into matching
+    // the signer-self / author forms that share the helper.
+
+    #[test]
+    fn has_owner_did_matches_catches_the_protect_branch_owner_idiom() {
+        // protect.rs:28 form: first arg the caller, second `&record.owner_did`.
+        let body = "let caller = &auth.0;\n\
+                    if !crate::api::did_matches(caller, &record.owner_did) {\n\
+                        return Err(AppError::Forbidden(\"only the owner\".into()));\n\
+                    }";
+        assert!(
+            has_owner_did_matches(body),
+            "the protect_branch owner idiom must be recognized"
+        );
+    }
+
+    #[test]
+    fn has_owner_did_matches_catches_the_auth0_owner_form() {
+        // The `&auth.0` first-arg spelling (repos.rs's branch-protection check),
+        // tolerating a newline before the second arg.
+        let body =
+            "if x\n    && !crate::api::did_matches(&auth.0,\n        &record.owner_did)\n    {";
+        assert!(
+            has_owner_did_matches(body),
+            "the &auth.0 / owner_did form must be recognized across a newline"
+        );
+    }
+
+    #[test]
+    fn has_owner_did_matches_ignores_register_replica_signer_self() {
+        // replicas.rs:52: FIRST arg is `replica_did`, NOT the caller — signer-self
+        // by design. The second arg is owner_did, so a naive "second arg is
+        // owner_did" check would wrongly flag it. It must NOT match.
+        let body = "if crate::api::did_matches(replica_did, &record.owner_did) {\n\
+                        // the signer is registering itself as a replica\n\
+                    }";
+        assert!(
+            !has_owner_did_matches(body),
+            "register_replica's signer-self did_matches must NOT be treated as an owner gate"
+        );
+    }
+
+    #[test]
+    fn has_owner_did_matches_ignores_close_pr_author_form() {
+        // pulls.rs:277: caller-first but SECOND arg is `&pr.author_did`, not
+        // owner_did — the owner-or-author close gate. Must NOT match as owner-only.
+        let body = "let is_author = crate::api::did_matches(&auth.0, &pr.author_did);";
+        assert!(
+            !has_owner_did_matches(body),
+            "close_pr's author did_matches must NOT be treated as an owner gate"
+        );
+    }
+
+    #[test]
+    fn has_owner_did_matches_ignores_bounty_and_task_self_forms() {
+        // bounties.rs / tasks.rs: caller-first, but the second arg is a
+        // creator/delegator/assignee did, never owner_did.
+        for body in [
+            "if !crate::api::did_matches(&auth.0, &bounty.creator_did) {",
+            "if !crate::api::did_matches(&auth.0, &body.delegator_did) {",
+            "if !crate::api::did_matches(&auth.0, &body.assignee_did) {",
+        ] {
+            assert!(
+                !has_owner_did_matches(body),
+                "self/author did_matches form must NOT be treated as an owner gate: {body}"
             );
         }
     }

--- a/crates/gitlawb-node/tests/deny_harness.rs
+++ b/crates/gitlawb-node/tests/deny_harness.rs
@@ -512,6 +512,33 @@ async fn send_probe(
             probe.body.clone(),
             &fixture.stranger,
         ),
+        // #195 (F1): each multi-principal arm signs with its own distinct fixture
+        // identity, so reverting one arm in the handler turns only that arm's twin
+        // RED.
+        Signer::Author => signed_request(
+            client,
+            probe.method.clone(),
+            base_url,
+            &probe.path,
+            probe.body.clone(),
+            &fixture.author,
+        ),
+        Signer::Creator => signed_request(
+            client,
+            probe.method.clone(),
+            base_url,
+            &probe.path,
+            probe.body.clone(),
+            &fixture.creator,
+        ),
+        Signer::Claimant => signed_request(
+            client,
+            probe.method.clone(),
+            base_url,
+            &probe.path,
+            probe.body.clone(),
+            &fixture.claimant,
+        ),
     };
     let rb = if probe.json {
         rb.header("content-type", "application/json")
@@ -737,7 +764,7 @@ mod completeness {
     use std::collections::HashSet;
 
     use super::deny_bearing_routes;
-    use crate::support::routes::GateClass;
+    use crate::support::routes::{GateClass, Principal};
 
     /// Every `.route("<path>", <method>(<handler>)…)` mount in `src`, as
     /// (METHOD, path). Multiline-aware: most mounts put the path on the line after
@@ -994,9 +1021,17 @@ mod completeness {
         // owner gate; the signer-self / author forms (register_replica's
         // did_matches(replica_did, …), close_pr's did_matches(&auth.0, &author_did))
         // are deliberately NOT matched, so they don't false-orphan.
+        // A handler satisfies the owner marker if it is a plain OwnerGate row OR a
+        // MultiPrincipalGate row that declares the Owner arm (#195, F1: close_pr /
+        // close_issue owner-gate via require_repo_owner but are owner-OR-author, so
+        // they register as MultiPrincipalGate — their owner arm is still driven).
         let registry_owner_handlers: HashSet<&str> = deny_bearing_routes()
             .iter()
-            .filter(|r| r.gate == GateClass::OwnerGate)
+            .filter(|r| {
+                r.gate == GateClass::OwnerGate
+                    || (r.gate == GateClass::MultiPrincipalGate
+                        && r.principals.contains(&Principal::Owner))
+            })
             .map(|r| short_handler(r.handler))
             .collect();
 

--- a/crates/gitlawb-node/tests/deny_harness.rs
+++ b/crates/gitlawb-node/tests/deny_harness.rs
@@ -404,7 +404,8 @@ fn build_branch_push_body(server_main_tip: &str, branch: &str, files: &[(&str, &
         );
         String::from_utf8_lossy(&out.stdout).trim().to_string()
     };
-    run(&["init", "-q", "-b", "main"]);
+    // Pin sha1 to match the served fixture repo; init.defaultObjectFormat=sha256 breaks the ref update.
+    run(&["init", "-q", "-b", "main", "--object-format=sha1"]);
     run(&["config", "user.email", "t@t"]);
     run(&["config", "user.name", "t"]);
     std::fs::write(work.join("base.txt"), "prdiff base").unwrap();
@@ -829,11 +830,13 @@ async fn deny_bearing_registry_denies_hostile_and_admits_authorized(pool: sqlx::
         }
     }
 
-    // One anon hostile per row, plus one signed-stranger hostile per read-gate row.
+    // One hostile per row (a signed stranger for the 403 gates, including the
+    // #195 N2 status-gated bounty rows; anon for the signature and read-gate
+    // rows), plus the EXTRA signed-stranger 404 each read-gate row drives.
     assert_eq!(
         hostile_driven,
         rows.len() + readgate_rows,
-        "expected one anon hostile per row ({} rows) plus one signed-stranger hostile per read-gate row ({readgate_rows}), drove {hostile_driven}",
+        "expected one hostile per row ({} rows) plus one signed-stranger hostile per read-gate row ({readgate_rows}), drove {hostile_driven}",
         rows.len()
     );
     // #195 (F1): every read-gate row must be probed by a signed non-reader — a

--- a/crates/gitlawb-node/tests/deny_harness.rs
+++ b/crates/gitlawb-node/tests/deny_harness.rs
@@ -514,19 +514,19 @@ async fn deny_bearing_registry_denies_hostile_and_admits_authorized(pool: sqlx::
                         "owner-reachability twin must reach the handler (not 403): {ctx}"
                     );
                 }
-                Expect::Ok2xx(token) => {
+                Expect::Ok2xx => {
                     twins_driven += 1;
                     assert!(
                         status.is_success(),
                         "read-reachability twin must be 2xx, got {status}: {ctx}"
                     );
-                    if let Some(tok) = token {
-                        let body = resp.text().await.unwrap_or_default();
-                        assert!(
-                            body.contains(tok),
-                            "read twin 2xx body missing expected token {tok:?}: {ctx}"
-                        );
-                    }
+                    // A 2xx with an empty body is a denial rendered as success:
+                    // the authorized read must actually return the resource.
+                    let body = resp.bytes().await.unwrap_or_default();
+                    assert!(
+                        !body.is_empty(),
+                        "read-reachability twin returned an empty 2xx body (denial-as-success?): {ctx}"
+                    );
                 }
             }
         }
@@ -795,6 +795,15 @@ mod completeness {
         // are helpers, not mounted handlers, so drop them.
         owner_marked.remove("require_owner");
         owner_marked.remove("require_repo_owner");
+
+        // Non-vacuous floor: if the marker scan silently found nothing (a parser
+        // regression), the orphan loop below would pass by checking zero handlers.
+        // The tree has 10 owner-marker handlers today; 6 trips only on a real break.
+        assert!(
+            owner_marked.len() >= 6,
+            "owner-gate marker scan found only {} handlers — the scan likely broke",
+            owner_marked.len()
+        );
 
         for h in &owner_marked {
             assert!(

--- a/crates/gitlawb-node/tests/deny_harness.rs
+++ b/crates/gitlawb-node/tests/deny_harness.rs
@@ -624,3 +624,184 @@ async fn additional_owner_gates_reject_non_owner(pool: sqlx::PgPool) {
         );
     }
 }
+
+// ── U4: completeness cross-check (no DB) — the registry cannot silently drift ──
+//
+// The runtime sweep (U3) only proves the routes it is HANDED. This guard, a pure
+// source scrape, keeps that hand-off honest against `server.rs`: no registry row
+// points at a route that no longer mounts (stale row), and no owner-gated mount
+// escapes the registry (orphan). It complements — does not duplicate — the
+// in-crate `authz_guard` egress guard (`src/api/mod.rs`), which proves every
+// repo-scoped API handler is *gated*; this proves the deny-bearing ones are
+// *driven*, and it reaches the non-API git mounts `authz_guard` never sees.
+mod completeness {
+    use std::collections::HashSet;
+
+    use super::deny_bearing_routes;
+    use crate::support::routes::GateClass;
+
+    /// Every `.route("<path>", <method>(<handler>)…)` mount in `src`, as
+    /// (METHOD, path). Multiline-aware: most mounts put the path on the line after
+    /// `.route(`, so a per-line scan false-greens. Walks balanced parens from each
+    /// `.route(` so chained and multi-method (`put().delete().get()`) mounts are
+    /// all captured.
+    fn scrape_mounts(src: &str) -> Vec<(String, String)> {
+        let bytes = src.as_bytes();
+        let mut out = Vec::new();
+        let mut i = 0;
+        while let Some(rel) = src[i..].find(".route(") {
+            let open = i + rel + ".route(".len();
+            let mut depth = 1i32;
+            let mut j = open;
+            while j < src.len() && depth > 0 {
+                match bytes[j] {
+                    b'(' => depth += 1,
+                    b')' => depth -= 1,
+                    _ => {}
+                }
+                j += 1;
+            }
+            let call = &src[open..j.saturating_sub(1)];
+            i = j;
+            // The path is the first string literal in the call.
+            let Some(qs) = call.find('"') else { continue };
+            let Some(qe) = call[qs + 1..].find('"') else {
+                continue;
+            };
+            let path = &call[qs + 1..qs + 1 + qe];
+            for m in ["get", "post", "put", "delete", "patch"] {
+                let needle = format!("{m}(");
+                let mut k = 0;
+                while let Some(mrel) = call[k..].find(&needle) {
+                    let at = k + mrel;
+                    // Reject a match that is the tail of a longer ident (e.g. the
+                    // `get(` inside `budget(`): the char before must be a boundary.
+                    let boundary = call[..at]
+                        .chars()
+                        .last()
+                        .map(|c| !(c.is_alphanumeric() || c == '_'))
+                        .unwrap_or(true);
+                    if boundary {
+                        out.push((m.to_uppercase(), path.to_string()));
+                    }
+                    k = at + needle.len();
+                }
+            }
+        }
+        out
+    }
+
+    /// Names of `fn`s in `src` whose body contains any `marker`. The body is the
+    /// slice from a fn's `(` to the next top-level fn declaration — the same
+    /// boundary set `authz_guard::fn_body` uses — so a marker can't leak across
+    /// into the next handler.
+    fn handlers_with_marker(src: &str, markers: &[&str]) -> HashSet<String> {
+        let decls = [
+            "\npub async fn ",
+            "\npub(crate) async fn ",
+            "\nasync fn ",
+            "\npub(crate) fn ",
+            "\npub fn ",
+            "\nfn ",
+        ];
+        // Ordered start offsets of every fn declaration.
+        let mut starts: Vec<usize> = Vec::new();
+        for d in decls {
+            let mut k = 0;
+            while let Some(r) = src[k..].find(d) {
+                starts.push(k + r + 1); // +1: skip the leading '\n'
+                k = k + r + d.len();
+            }
+        }
+        starts.sort_unstable();
+        let mut out = HashSet::new();
+        for (idx, &s) in starts.iter().enumerate() {
+            let end = starts.get(idx + 1).copied().unwrap_or(src.len());
+            let seg = &src[s..end];
+            // The name is the ident after this decl's `fn ` (handles `pub(crate)`,
+            // whose own `(` would otherwise be mistaken for the arg list).
+            let Some(fnpos) = seg.find("fn ") else {
+                continue;
+            };
+            let name: String = seg[fnpos + 3..]
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            if name.is_empty() {
+                continue;
+            }
+            if markers.iter().any(|m| seg.contains(m)) {
+                out.insert(name);
+            }
+        }
+        out
+    }
+
+    fn short_handler(h: &str) -> &str {
+        h.rsplit("::").next().unwrap_or(h)
+    }
+
+    #[test]
+    fn deny_registry_is_not_stale_and_owner_gates_are_all_driven() {
+        let server = include_str!("../src/server.rs");
+        let mounts: HashSet<(String, String)> = scrape_mounts(server).into_iter().collect();
+
+        // Scraper-integrity floor: if the parser silently stopped finding mounts,
+        // the anti-stale check below would pass vacuously. The tree has ~95 mounts.
+        assert!(
+            mounts.len() >= 90,
+            "mount scrape found only {} routes — the parser likely broke (floor 90)",
+            mounts.len()
+        );
+
+        // ANTI-STALE: every deny-bearing row must still point at a live mount, so a
+        // renamed/removed route can't leave a row that the sweep drives against a
+        // 404 and calls a passing deny.
+        for row in deny_bearing_routes() {
+            assert!(
+                mounts.contains(&(row.method.to_string(), row.path.to_string())),
+                "stale registry row: {} {} is not mounted in server.rs (renamed or removed?)",
+                row.method,
+                row.path
+            );
+        }
+
+        // ORPHAN GUARD: every handler carrying an unambiguous owner-gate marker
+        // (`require_repo_owner` / `require_owner`) must be a registry owner-gate
+        // row, so a newly added owner-gated mutation cannot escape the runtime
+        // sweep. The api dir is read at test time (like authz_guard's completeness
+        // scan) so a brand-new module is covered too. `did_matches` is deliberately
+        // NOT a marker here: it is shared with the signer-self bucket and would
+        // misclassify; close_pr/close_issue/protect are already covered as rows.
+        let registry_owner_handlers: HashSet<&str> = deny_bearing_routes()
+            .iter()
+            .filter(|r| r.gate == GateClass::OwnerGate)
+            .map(|r| short_handler(r.handler))
+            .collect();
+
+        let api_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src/api");
+        let mut owner_marked: HashSet<String> = HashSet::new();
+        for entry in std::fs::read_dir(api_dir).expect("read api dir") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().is_some_and(|e| e == "rs") {
+                let src = std::fs::read_to_string(&path).expect("read api file");
+                owner_marked.extend(handlers_with_marker(
+                    &src,
+                    &["require_repo_owner(", "require_owner("],
+                ));
+            }
+        }
+        // The gate helpers' own definition lines contain the marker string; they
+        // are helpers, not mounted handlers, so drop them.
+        owner_marked.remove("require_owner");
+        owner_marked.remove("require_repo_owner");
+
+        for h in &owner_marked {
+            assert!(
+                registry_owner_handlers.contains(h.as_str()),
+                "handler `{h}` carries an owner-gate marker but is not an owner-gate \
+                 row in deny_bearing_routes() — add it so the runtime sweep drives its 403"
+            );
+        }
+    }
+}

--- a/crates/gitlawb-node/tests/deny_harness.rs
+++ b/crates/gitlawb-node/tests/deny_harness.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 
 use support::assert::assert_denied;
 use support::probe::{probes_for, Expect, Fixture, Probe, Signer};
-use support::routes::deny_bearing_routes;
+use support::routes::{deny_bearing_routes, GateClass};
 use support::signing::signed_request;
 
 use gitlawb_core::cid::Cid;
@@ -111,6 +111,79 @@ async fn unsigned_receive_pack_is_denied(pool: sqlx::PgPool) {
     // No repo was seeded, so there are no OIDs to leak; the assertion still
     // enforces the 4xx-and-not-empty-200 INV-8 shape.
     assert_denied(resp, 401, &[]).await;
+}
+
+/// Build a minimal git-receive-pack request body: one ref-update pkt-line for
+/// `refs/heads/<branch>` (dummy 40-hex old/new SHAs — the branch-protection gate
+/// only reads the ref NAME) plus a flush. Enough to reach the ref-update parse
+/// and the protection gate, not a real pack.
+fn receive_pack_update_body(branch: &str) -> Vec<u8> {
+    let old = "0".repeat(40);
+    let new = "1".repeat(40);
+    let line = format!("{old} {new} refs/heads/{branch}\0report-status\n");
+    let pkt = format!("{:04x}{line}", line.len() + 4);
+    let mut body = pkt.into_bytes();
+    body.extend_from_slice(b"0000");
+    body
+}
+
+/// #195 (F3): a signed NON-OWNER pushing to a PROTECTED branch is forbidden (403)
+/// by the branch-protection gate (`repos.rs`), and the owner pushing to the same
+/// branch is NOT blocked (control). git_receive_pack's registry row only drives the
+/// unsigned-401 signature path, so without this probe inverting the 403 leaves the
+/// sweep AND the completeness scan green. Drives the 403 so the gate can't rot.
+#[sqlx::test]
+async fn signed_stranger_protected_branch_push_is_forbidden(pool: sqlx::PgPool) {
+    let node = spawn_node(pool).await;
+    let client = reqwest::Client::new();
+    let owner = Keypair::generate();
+    let owner_did = owner.did().to_string();
+    let stranger = Keypair::generate();
+
+    let repo_id = node.seed_repo(&owner_did, "protrepo", true).await;
+    node.seed_protected_branch(&repo_id, "main", &owner_did)
+        .await;
+
+    let path = format!("/{owner_did}/protrepo/git-receive-pack");
+    let body = receive_pack_update_body("main");
+
+    // Signed non-owner -> 403 branch protection; the denial leaks no repo internals.
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &path,
+        body.clone(),
+        &stranger,
+    )
+    .send()
+    .await
+    .expect("request sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        403,
+        "a signed non-owner push to a protected branch must be forbidden (403)"
+    );
+    assert_denied(resp, 403, &[repo_id.as_str()]).await;
+
+    // Owner control: the owner is NOT blocked by branch protection (it may fail
+    // later on the dummy pack, but must not be the 403 the stranger got).
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &path,
+        body,
+        &owner,
+    )
+    .send()
+    .await
+    .expect("request sends");
+    assert_ne!(
+        resp.status().as_u16(),
+        403,
+        "the owner must not be blocked by their own branch protection (control)"
+    );
 }
 
 // ── U5(b): INV-8/INV-2 — anonymous /ipfs/{cid} of a withheld blob is denied ──
@@ -479,7 +552,16 @@ async fn deny_bearing_registry_denies_hostile_and_admits_authorized(pool: sqlx::
         "deny-bearing route registry is empty — nothing to sweep"
     );
 
+    // #195 (F1): every read-gate row is now probed by a signed non-reader too, so a
+    // dropped stranger probe must fail loudly rather than being absorbed into the
+    // total. Count the read-gate rows and the stranger hostiles separately.
+    let readgate_rows = rows
+        .iter()
+        .filter(|r| matches!(r.gate, GateClass::ReadGate))
+        .count();
+
     let mut hostile_driven = 0usize;
+    let mut readgate_stranger_driven = 0usize;
     let mut twins_driven = 0usize;
 
     for row in rows {
@@ -497,6 +579,11 @@ async fn deny_bearing_registry_denies_hostile_and_admits_authorized(pool: sqlx::
             match &probe.expect {
                 Expect::Deny(code) => {
                     hostile_driven += 1;
+                    // A signed-stranger 404 is the read-gate signed-non-reader probe
+                    // (owner-gate strangers are 403, signature hostiles are anon 401).
+                    if probe.signer == Signer::Stranger && *code == 404 {
+                        readgate_stranger_driven += 1;
+                    }
                     assert_eq!(
                         status.as_u16(),
                         *code,
@@ -537,11 +624,18 @@ async fn deny_bearing_registry_denies_hostile_and_admits_authorized(pool: sqlx::
         }
     }
 
+    // One anon hostile per row, plus one signed-stranger hostile per read-gate row.
     assert_eq!(
         hostile_driven,
-        rows.len(),
-        "expected exactly one hostile probe per deny-bearing row ({} rows), drove {hostile_driven}",
+        rows.len() + readgate_rows,
+        "expected one anon hostile per row ({} rows) plus one signed-stranger hostile per read-gate row ({readgate_rows}), drove {hostile_driven}",
         rows.len()
+    );
+    // #195 (F1): every read-gate row must be probed by a signed non-reader — a
+    // dropped stranger probe fails HERE rather than silently reducing coverage.
+    assert_eq!(
+        readgate_stranger_driven, readgate_rows,
+        "every read-gate row must drive a signed-non-reader 404 probe ({readgate_rows} rows), drove {readgate_stranger_driven}"
     );
     assert!(
         twins_driven >= 1,
@@ -928,10 +1022,13 @@ mod completeness {
         owner_marked.remove("require_repo_owner");
         // git_receive_pack also carries the inline did_matches-owner idiom, but for
         // a SECONDARY gate: its branch-protection push check (repos.rs), not a
-        // whole-handler owner gate. It IS already a registry row — driven for its
-        // 401 signature deny (SignatureRequired class), not a 403 — so it is not an
-        // owner-gate orphan. Drop it so the owner-orphan assert (which only knows
-        // the OwnerGate rows) does not misflag a route that is already swept.
+        // whole-handler owner gate. Its 403 is DRIVEN by the dedicated
+        // `signed_stranger_protected_branch_push_is_forbidden` test (#195, F3) — a
+        // signed non-owner push to a protected branch, with an owner control — so
+        // inverting the gate goes RED there. It is therefore not an owner-gate
+        // orphan (the OwnerGate registry rows can't carry the protected-branch
+        // substrate); drop it so the owner-orphan assert does not misflag a route
+        // whose owner gate is already driven.
         owner_marked.remove("git_receive_pack");
         // Non-vacuous floor: if the marker scan silently found nothing (a parser
         // regression), the orphan loop below would pass by checking zero handlers.
@@ -1078,22 +1175,6 @@ mod completeness {
             (
                 "list_all_bounties",
                 "global list-filter: 200 with unreadable rows removed, never 404",
-            ),
-            // Repo-root GET reads that gate on "/" but are not yet driven as rows.
-            // They COULD be driven (no sub-entity needed); left out for now with an
-            // explicit reason rather than a silent omission — the whole point of the
-            // guard is that this decision is forced and reviewable.
-            (
-                "get_star_status",
-                "repo-root read: not yet driven as a ReadGate row",
-            ),
-            (
-                "get_icaptcha_proof",
-                "repo-root read: not yet driven as a ReadGate row",
-            ),
-            (
-                "replicate_encrypted_blobs",
-                "repo-root read: not yet driven as a ReadGate row",
             ),
         ];
 

--- a/crates/gitlawb-node/tests/deny_harness.rs
+++ b/crates/gitlawb-node/tests/deny_harness.rs
@@ -135,7 +135,9 @@ fn receive_pack_update_body(branch: &str) -> Vec<u8> {
 #[sqlx::test]
 async fn signed_stranger_protected_branch_push_is_forbidden(pool: sqlx::PgPool) {
     let node = spawn_node(pool).await;
-    let client = reqwest::Client::new();
+    // #195 (F1): a bounded timeout so a wedged git-receive-pack fails the suite
+    // rather than hanging it until CI kills the job.
+    let client = support::bounded_client();
     let owner = Keypair::generate();
     let owner_did = owner.did().to_string();
     let stranger = Keypair::generate();
@@ -379,8 +381,14 @@ async fn withheld_path_blob_read_is_denied(pool: sqlx::PgPool) {
 /// Build a git v0 receive-pack body creating `refs/heads/<branch>` at a fresh
 /// commit that adds `files` on top of the existing `main`, force-updating main to
 /// a deterministic base so `<branch>` shares history with main. Returns the body
-/// bytes plus the new feature tip. Shells out to the local `git`.
-fn build_branch_push_body(server_main_tip: &str, branch: &str, files: &[(&str, &str)]) -> Vec<u8> {
+/// bytes plus a map of each pushed file's blob OID (full sha1), so the caller can
+/// withhold the OID of a pushed secret path (#195, F2). Shells out to the local
+/// `git`.
+fn build_branch_push_body(
+    server_main_tip: &str,
+    branch: &str,
+    files: &[(&str, &str)],
+) -> (Vec<u8>, std::collections::HashMap<String, String>) {
     use std::io::Write;
     use std::process::{Command, Stdio};
 
@@ -424,7 +432,15 @@ fn build_branch_push_body(server_main_tip: &str, branch: &str, files: &[(&str, &
     run(&["commit", "-q", "-m", "feature"]);
     let feature_tip = run(&["rev-parse", "HEAD"]);
 
-    let mut child = Command::new("git")
+    // #195 (F2): capture each pushed file's blob OID (full sha1). seed_bare_repo
+    // never seeds these pushed paths, so this is the only place their OID is known;
+    // the PR-diff denial withholds the secret path's OID (full + [..12] short form).
+    let mut pushed_oids = std::collections::HashMap::new();
+    for (p, _) in files {
+        pushed_oids.insert((*p).to_string(), run(&["rev-parse", &format!("HEAD:{p}")]));
+    }
+
+    let child = Command::new("git")
         .args(["pack-objects", "--stdout", "--revs"])
         .current_dir(&work)
         .stdin(Stdio::piped())
@@ -448,7 +464,7 @@ fn build_branch_push_body(server_main_tip: &str, branch: &str, files: &[(&str, &
     body.extend_from_slice(b"0000");
     body.extend_from_slice(&pack);
     let _ = std::fs::remove_dir_all(&work);
-    body
+    (body, pushed_oids)
 }
 
 /// get_pr_diff has a SECOND, path-scoped gate after the repo-root read: it
@@ -462,7 +478,9 @@ fn build_branch_push_body(server_main_tip: &str, branch: &str, files: &[(&str, &
 #[sqlx::test]
 async fn get_pr_diff_withheld_path_is_denied(pool: sqlx::PgPool) {
     let node = spawn_node(pool).await;
-    let client = reqwest::Client::new();
+    // #195 (F1): a bounded timeout so a wedged git subprocess push fails the suite
+    // rather than hanging it until CI kills the job.
+    let client = support::bounded_client();
     let owner = Keypair::generate();
     let owner_did = owner.did().to_string();
 
@@ -477,7 +495,7 @@ async fn get_pr_diff_withheld_path_is_denied(pool: sqlx::PgPool) {
         .await;
 
     // Push a `feature` branch whose diff vs main touches the withheld secret path.
-    let body = build_branch_push_body(
+    let (body, pushed_oids) = build_branch_push_body(
         &oids["HEAD"],
         "feature",
         &[("secret/x.txt", "TOPSECRET-PRDIFF-PATH")],
@@ -515,7 +533,11 @@ async fn get_pr_diff_withheld_path_is_denied(pool: sqlx::PgPool) {
 
     // Anon PASSES the public repo-root gate, then the per-path gate DENIES the diff
     // (it touches the withheld secret path): 404, leaking no content or OID.
-    let secret_oid = oids.get("secret/x.txt").cloned().unwrap_or_default(); // seed_bare_repo didn't seed it; the pushed one is unknown here.
+    // #195 (F2): withhold the pushed secret blob's OID in both forms (the full
+    // sha1 and `oid[..12]`), matching the private_blob_oid_short convention
+    // (probe.rs:200), NOT `git rev-parse --short` (variable-length).
+    let secret_oid_full = pushed_oids["secret/x.txt"].clone();
+    let secret_oid_short = secret_oid_full[..12].to_string();
     let resp = client
         .get(format!(
             "{}/api/v1/repos/{owner_did}/prdiff-repo/pulls/{number}/diff",
@@ -524,10 +546,11 @@ async fn get_pr_diff_withheld_path_is_denied(pool: sqlx::PgPool) {
         .send()
         .await
         .expect("anon diff read sends");
-    let mut withheld = vec!["TOPSECRET-PRDIFF-PATH"];
-    if !secret_oid.is_empty() {
-        withheld.push(secret_oid.as_str());
-    }
+    let withheld = vec![
+        "TOPSECRET-PRDIFF-PATH",
+        secret_oid_full.as_str(),
+        secret_oid_short.as_str(),
+    ];
     assert_denied(resp, 404, &withheld).await;
 
     // Owner sees the full diff (the per-path gate admits the reader).
@@ -717,6 +740,17 @@ async fn send_probe(
             &probe.path,
             probe.body.clone(),
             &fixture.claimant,
+        ),
+        // #195 (F3): the assignee actor arm of complete_task / fail_task signs with
+        // the fixture's assignee identity (the one that claimed the seeded task), so
+        // reverting the assignee gate turns that arm's Not403 twin RED.
+        Signer::Assignee => signed_request(
+            client,
+            probe.method.clone(),
+            base_url,
+            &probe.path,
+            probe.body.clone(),
+            &fixture.assignee,
         ),
     };
     let rb = if probe.json {
@@ -1239,6 +1273,58 @@ mod completeness {
         false
     }
 
+    /// The CLOSED set of caller-self REST gates deliberately NOT driven as a
+    /// registry row. INTENTIONALLY EMPTY (#195, F3/R4): every caller-self
+    /// `did_matches(caller, X)` gate in `src/api` is driven by a real-node
+    /// hostile+control probe (a `SignerSelfGate` field-binding row or a
+    /// `MultiPrincipalGate` assignee-arm row), so no caller-self REST gate is
+    /// un-drivable. A new classifier-marked handler that is not a driven row must
+    /// fail `signer_self_gates_are_all_driven`; it is not parked here.
+    const SIGNER_SELF_NOT_DRIVEN: &[&str] = &[];
+
+    /// True when `body` contains a CALLER-SELF `did_matches` call: one whose FIRST
+    /// arg is the caller (`caller` / `&caller` / `&auth.0`) AND whose SECOND arg is
+    /// NOT `&record.owner_did`. Sibling to [`has_owner_did_matches`] (the owner form
+    /// is guarded there); this is the field-binding / actor idiom the task and
+    /// register handlers use: create_task (`&body.delegator_did`), claim_task
+    /// (`&body.assignee_did`), complete_task / fail_task (the stored `assignee_did`,
+    /// spelled across lines), register (`agent_did.as_str()`). The arg1 set matches
+    /// its owner sibling's (NOT just `&auth.0`), so a `let caller = &auth.0;
+    /// did_matches(caller, X)` gate cannot escape. The paren-walk is multi-line-robust
+    /// because complete_task / fail_task spell the call across lines.
+    fn has_signer_self_did_matches(body: &str) -> bool {
+        let bytes = body.as_bytes();
+        let mut i = 0;
+        while let Some(rel) = body[i..].find("did_matches(") {
+            let open = i + rel + "did_matches(".len();
+            let mut depth = 1i32;
+            let mut comma: Option<usize> = None;
+            let mut j = open;
+            while j < body.len() && depth > 0 {
+                match bytes[j] {
+                    b'(' => depth += 1,
+                    b')' => depth -= 1,
+                    b',' if depth == 1 && comma.is_none() => comma = Some(j),
+                    _ => {}
+                }
+                j += 1;
+            }
+            i = j;
+            let close = j.saturating_sub(1);
+            let Some(comma) = comma else { continue };
+            let arg1 = body[open..comma].split_whitespace().collect::<String>();
+            let arg2 = body[comma + 1..close]
+                .split_whitespace()
+                .collect::<String>();
+            let caller_first = arg1 == "caller" || arg1 == "&caller" || arg1 == "&auth.0";
+            let owner_second = arg2 == "&record.owner_did";
+            if caller_first && !owner_second {
+                return true;
+            }
+        }
+        false
+    }
+
     #[test]
     fn deny_registry_is_not_stale_and_owner_gates_are_all_driven() {
         let server = include_str!("../src/server.rs");
@@ -1334,6 +1420,78 @@ mod completeness {
                 registry_owner_handlers.contains(h.as_str()),
                 "handler `{h}` carries an owner-gate marker but is not an owner-gate \
                  row in deny_bearing_routes() — add it so the runtime sweep drives its 403"
+            );
+        }
+    }
+
+    /// CALLER-SELF ORPHAN GUARD (#195, F3/R4, INV-21b). Sibling to the owner-gate
+    /// and read-gate orphan guards above: every handler carrying a caller-self
+    /// `did_matches(caller, X)` gate (X != `&record.owner_did`) must be a DRIVEN
+    /// registry row (ANY gate class: a `SignerSelfGate` field-binding row or a
+    /// `MultiPrincipalGate` assignee-arm row) OR listed in the (empty)
+    /// `SIGNER_SELF_NOT_DRIVEN`. Derived from a SOURCE scan of the `src/api` `.rs`
+    /// files at test time (KTD-2): a caller-self gate spelled with the inline
+    /// `did_matches(caller|&caller|&auth.0, X)` idiom in an existing OR new api file
+    /// is caught and forced to be a driven row. It does NOT catch two shapes (the
+    /// same limits the owner/read sibling guards have): a check hidden behind a
+    /// helper (the owner side tracks `require_owner` / `require_repo_owner` as markers
+    /// for exactly this reason -- add a marker if a caller-self helper is introduced),
+    /// and a gate in a new SUBDIRECTORY module (the scan is flat, not recursive). The
+    /// parallel GraphQL mutation gates (`src/graphql/mutation.rs`) are out of this
+    /// scan's scope, fenced separately (#219).
+    #[test]
+    fn signer_self_gates_are_all_driven() {
+        // A caller-self gate may be driven as a SignerSelfGate row (body-field bind)
+        // OR a MultiPrincipalGate row (the complete/fail assignee actor gate), so the
+        // required set is EVERY registry handler regardless of class.
+        let registry_handlers: HashSet<&str> = deny_bearing_routes()
+            .iter()
+            .map(|r| short_handler(r.handler))
+            .collect();
+
+        let api_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src/api");
+        let mut signer_self_marked: HashSet<String> = HashSet::new();
+        for entry in std::fs::read_dir(api_dir).expect("read api dir") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().is_some_and(|e| e == "rs") {
+                let src = std::fs::read_to_string(&path).expect("read api file");
+                signer_self_marked.extend(handlers_matching(&src, has_signer_self_did_matches));
+            }
+        }
+        // Drop the gate helpers' own definitions (mirror of the owner scan dropping
+        // require_owner / require_repo_owner): none of these is a mounted handler.
+        signer_self_marked.remove("did_matches");
+        signer_self_marked.remove("require_owner");
+        signer_self_marked.remove("require_repo_owner");
+
+        // Non-vacuous floor PINNED to the exact caller-self handler count (close_pr,
+        // close_issue, dispute/submit/approve/cancel_bounty, create/claim/complete/
+        // fail_task, register = 11). Pinned, not loose, so a PARTIAL classifier
+        // regression (dropping even one) trips here rather than being absorbed by the
+        // runtime sweep; bump it when the caller-self surface legitimately changes.
+        assert!(
+            signer_self_marked.len() >= 11,
+            "caller-self marker scan found only {} handlers (expected 11); the scan broke or the caller-self surface changed without bumping this floor",
+            signer_self_marked.len()
+        );
+
+        for h in &signer_self_marked {
+            assert!(
+                registry_handlers.contains(h.as_str())
+                    || SIGNER_SELF_NOT_DRIVEN.contains(&h.as_str()),
+                "handler `{h}` carries a caller-self did_matches gate but is neither a \
+                 driven registry row nor in SIGNER_SELF_NOT_DRIVEN; drive its 403"
+            );
+        }
+
+        // Staleness: every SIGNER_SELF_NOT_DRIVEN entry must still be a real
+        // caller-self handler. Vacuous while the list is empty, but it keeps a future
+        // exemption honest (the mirror of the owner/read staleness checks).
+        for name in SIGNER_SELF_NOT_DRIVEN {
+            assert!(
+                signer_self_marked.contains(*name),
+                "SIGNER_SELF_NOT_DRIVEN lists `{name}`, which no longer carries a \
+                 caller-self did_matches gate; update the list"
             );
         }
     }
@@ -1709,5 +1867,35 @@ mod completeness {
                 "self/author did_matches form must NOT be treated as an owner gate: {body}"
             );
         }
+    }
+
+    // ── F3 unit tests: the caller-self did_matches discriminator ─────────────────
+
+    #[test]
+    fn has_signer_self_did_matches_fires_on_caller_self_and_ignores_owner_form() {
+        // Fires: caller-spelled first arg (bound via `let caller = &auth.0;`), a
+        // non-owner second arg, the field-binding form the task handlers use. Proves
+        // the arg1 set is honored (a `&auth.0`-only classifier would miss this).
+        let self_form = "let caller = &auth.0;\n\
+                         if !crate::api::did_matches(caller, &x.foo_did) {\n\
+                             return Err(forbidden(\"...\"));\n\
+                         }";
+        assert!(
+            has_signer_self_did_matches(self_form),
+            "the caller-self field-binding did_matches must be recognized"
+        );
+        // The `&auth.0` spelling with a non-owner second arg fires too.
+        let auth0_form = "if !crate::api::did_matches(&auth.0, &body.assignee_did) {";
+        assert!(
+            has_signer_self_did_matches(auth0_form),
+            "the &auth.0 caller-self form must be recognized"
+        );
+        // Does NOT fire on the owner form (that is has_owner_did_matches' job), so a
+        // caller-self classifier that matched it would double-count.
+        let owner_form = "if !crate::api::did_matches(caller, &record.owner_did) {";
+        assert!(
+            !has_signer_self_did_matches(owner_form),
+            "the owner form must NOT be treated as a caller-self gate (no double-count)"
+        );
     }
 }

--- a/crates/gitlawb-node/tests/support/mod.rs
+++ b/crates/gitlawb-node/tests/support/mod.rs
@@ -3,6 +3,9 @@
 //! node spawner (U3).
 
 pub mod assert;
+// U2 fixture state matrix + per-gate-class probe generators; driven by U3.
+#[allow(dead_code)]
+pub mod probe;
 // U1 deny-bearing route registry; fields consumed by U2/U3 as they land.
 #[allow(dead_code)]
 pub mod routes;

--- a/crates/gitlawb-node/tests/support/mod.rs
+++ b/crates/gitlawb-node/tests/support/mod.rs
@@ -10,3 +10,15 @@ pub mod probe;
 #[allow(dead_code)]
 pub mod routes;
 pub mod signing;
+
+/// A reqwest client with a bounded request timeout, so a wedged git subprocess or
+/// route fails the suite rather than hanging it until CI kills the job (#195, F1).
+/// The two real-node probes that drive git subprocesses use this; the inline
+/// twins at the upload-pack and registry-sweep sites use the same pattern.
+#[allow(dead_code)]
+pub fn bounded_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap()
+}

--- a/crates/gitlawb-node/tests/support/mod.rs
+++ b/crates/gitlawb-node/tests/support/mod.rs
@@ -3,4 +3,7 @@
 //! node spawner (U3).
 
 pub mod assert;
+// U1 deny-bearing route registry; fields consumed by U2/U3 as they land.
+#[allow(dead_code)]
+pub mod routes;
 pub mod signing;

--- a/crates/gitlawb-node/tests/support/probe.rs
+++ b/crates/gitlawb-node/tests/support/probe.rs
@@ -187,12 +187,7 @@ impl Fixture {
         let priv_bounty_id =
             seed_private_bounty(node, &owner, &owner_did, priv_repo, &bounty_marker).await;
 
-        let priv_markers = vec![
-            issue_marker,
-            pr_marker,
-            pr_diff_marker,
-            bounty_marker,
-        ];
+        let priv_markers = vec![issue_marker, pr_marker, pr_diff_marker, bounty_marker];
 
         Fixture {
             owner,
@@ -352,11 +347,18 @@ async fn seed_private_issue(
     let client = reqwest::Client::new();
     let path = format!("/api/v1/repos/{owner_did}/{repo}/issues");
     let body = format!(r#"{{"title":"{marker}"}}"#).into_bytes();
-    let resp = signed_request(&client, reqwest::Method::POST, &node.base_url, &path, body, owner)
-        .header("content-type", "application/json")
-        .send()
-        .await
-        .expect("create private issue sends");
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &path,
+        body,
+        owner,
+    )
+    .header("content-type", "application/json")
+    .send()
+    .await
+    .expect("create private issue sends");
     assert_eq!(
         resp.status().as_u16(),
         201,
@@ -384,15 +386,21 @@ async fn seed_private_pr(
 
     let client = reqwest::Client::new();
     let path = format!("/api/v1/repos/{owner_did}/{repo}/pulls");
-    let body = format!(
-        r#"{{"title":"{marker}","source_branch":"feature","target_branch":"main"}}"#
+    let body =
+        format!(r#"{{"title":"{marker}","source_branch":"feature","target_branch":"main"}}"#)
+            .into_bytes();
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &path,
+        body,
+        owner,
     )
-    .into_bytes();
-    let resp = signed_request(&client, reqwest::Method::POST, &node.base_url, &path, body, owner)
-        .header("content-type", "application/json")
-        .send()
-        .await
-        .expect("create private PR sends");
+    .header("content-type", "application/json")
+    .send()
+    .await
+    .expect("create private PR sends");
     assert_eq!(
         resp.status().as_u16(),
         201,
@@ -422,11 +430,18 @@ async fn seed_private_bounty(
     let client = reqwest::Client::new();
     let path = format!("/api/v1/repos/{owner_did}/{repo}/bounties");
     let body = format!(r#"{{"title":"{marker}","amount":1}}"#).into_bytes();
-    let resp = signed_request(&client, reqwest::Method::POST, &node.base_url, &path, body, owner)
-        .header("content-type", "application/json")
-        .send()
-        .await
-        .expect("create private bounty sends");
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &path,
+        body,
+        owner,
+    )
+    .header("content-type", "application/json")
+    .send()
+    .await
+    .expect("create private bounty sends");
     assert_eq!(
         resp.status().as_u16(),
         201,

--- a/crates/gitlawb-node/tests/support/probe.rs
+++ b/crates/gitlawb-node/tests/support/probe.rs
@@ -1,0 +1,264 @@
+//! U2: fixture state matrix + per-gate-class probe generators.
+//!
+//! The fixture is a STATE MATRIX, not one repo: owner-gate rows need a repo the
+//! signed stranger can REACH (so the request hits the owner gate, not an
+//! existence-hiding 404), and read-gate rows need a repo the caller CANNOT see.
+//! A single repo cannot be both, so we seed a public repo (owner-gate substrate)
+//! and a private repo with content (read-gate substrate).
+//!
+//! Each deny-bearing row expands to probes: the hostile request (asserting the
+//! exact deny) plus a positive twin (owner-reachability for owner-gate,
+//! reader/sibling-public read for read-gate) so a 403/404 for the wrong reason
+//! cannot false-pass.
+
+use gitlawb_core::identity::Keypair;
+use gitlawb_node::test_harness::TestNode;
+
+use super::routes::{GateClass, Reach, Row};
+
+/// A seeded two-repo state matrix plus the owner and stranger identities.
+pub struct Fixture {
+    pub owner: Keypair,
+    pub stranger: Keypair,
+    pub owner_did: String,
+    /// Public repo: owner-gate rows run against this so the stranger reaches the
+    /// owner gate rather than a hidden-repo 404.
+    pub public_repo: String,
+    /// Private repo (is_public=false) with seeded content: read-gate rows run
+    /// against this so an anon caller gets the existence-hiding 404 and the owner
+    /// twin gets 2xx.
+    pub private_repo: String,
+    /// A seeded blob path present in both repos, for `{*path}` reads.
+    pub content_path: String,
+}
+
+impl Fixture {
+    pub async fn seed(node: &TestNode) -> Fixture {
+        let owner = Keypair::generate();
+        let owner_did = owner.did().to_string();
+        let stranger = Keypair::generate();
+        let content_path = "public/a.txt".to_string();
+
+        let pub_repo = "prober-pub";
+        node.seed_repo(&owner_did, pub_repo, true).await;
+        node.seed_bare_repo(&owner_did, pub_repo, &[("public/a.txt", "pub content")], "sha1");
+
+        let priv_repo = "prober-priv";
+        node.seed_repo(&owner_did, priv_repo, false).await;
+        node.seed_bare_repo(&owner_did, priv_repo, &[("public/a.txt", "priv content")], "sha1");
+
+        Fixture {
+            owner,
+            stranger,
+            owner_did,
+            public_repo: pub_repo.to_string(),
+            private_repo: priv_repo.to_string(),
+            content_path,
+        }
+    }
+}
+
+/// Who signs a probe request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Signer {
+    Anon,
+    Owner,
+    Stranger,
+}
+
+/// What a probe expects.
+#[derive(Debug, Clone)]
+pub enum Expect {
+    /// Hostile request: the exact deny status, body leaking none of `withheld`.
+    Deny(u16),
+    /// Owner-gate twin: the owner reaches the handler, so NOT 403.
+    Not403,
+    /// Read-gate twin: an authorized read returns 2xx (optionally containing a token).
+    Ok2xx(Option<String>),
+}
+
+/// A single request to drive against the node.
+#[derive(Debug, Clone)]
+pub struct Probe {
+    pub label: String,
+    pub method: reqwest::Method,
+    /// Path used both for the URL and for RFC-9421 `@path` signing.
+    pub path: String,
+    pub body: Vec<u8>,
+    pub signer: Signer,
+    pub json: bool,
+    pub expect: Expect,
+}
+
+/// Substitute path-template placeholders from the fixture. `repo` is the public
+/// repo for owner-gate rows and the private repo for read-gate rows.
+fn fill(path: &str, fixture: &Fixture, repo: &str) -> String {
+    path.replace("{owner}", &fixture.owner_did)
+        .replace("{repo}", repo)
+        .replace("{number}", "1")
+        .replace("{id}", "1")
+        .replace("{label}", "bug")
+        .replace("{branch}", "main")
+        .replace("{*path}", &fixture.content_path)
+        .replace("{path}", &fixture.content_path)
+}
+
+/// Expand one deny-bearing row into its hostile probe plus positive twin.
+pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
+    let method: reqwest::Method = row.method.parse().expect("valid method");
+    let body = row.body.map(|b| b.as_bytes().to_vec()).unwrap_or_default();
+    let json = row.body.is_some();
+
+    match row.gate {
+        GateClass::OwnerGate => {
+            let path = fill(row.path, fixture, &fixture.public_repo);
+            vec![
+                Probe {
+                    label: format!("{} owner-gate hostile", row.handler),
+                    method: method.clone(),
+                    path: path.clone(),
+                    body: body.clone(),
+                    signer: Signer::Stranger,
+                    json,
+                    expect: Expect::Deny(403),
+                },
+                Probe {
+                    label: format!("{} owner-reachability twin", row.handler),
+                    method,
+                    path,
+                    body,
+                    signer: Signer::Owner,
+                    json,
+                    expect: Expect::Not403,
+                },
+            ]
+        }
+        GateClass::ReadGate => {
+            let path = fill(row.path, fixture, &fixture.private_repo);
+            let mut v = vec![Probe {
+                label: format!("{} read-gate hostile", row.handler),
+                method: method.clone(),
+                path: path.clone(),
+                body: body.clone(),
+                signer: Signer::Anon,
+                json,
+                expect: Expect::Deny(404),
+            }];
+            // Positive twin: prove the 404 is the gate, not an absent entity.
+            let twin = match row.reach {
+                Reach::ReaderReads => Probe {
+                    label: format!("{} read-reachability twin (owner)", row.handler),
+                    method,
+                    path,
+                    body,
+                    signer: Signer::Owner,
+                    json,
+                    expect: Expect::Ok2xx(None),
+                },
+                Reach::SiblingPublic(sibling) => Probe {
+                    label: format!("{} read-reachability twin (sibling public)", row.handler),
+                    method,
+                    path: fill(sibling, fixture, &fixture.private_repo),
+                    body,
+                    signer: Signer::Anon,
+                    json,
+                    expect: Expect::Ok2xx(None),
+                },
+                Reach::None => panic!(
+                    "read-gate row {} {} has no Reach twin (U1 consistency should have caught this)",
+                    row.method, row.path
+                ),
+            };
+            v.push(twin);
+            v
+        }
+        GateClass::SignatureRequired => {
+            let path = fill(row.path, fixture, &fixture.public_repo);
+            vec![Probe {
+                label: format!("{} signature-required hostile", row.handler),
+                method,
+                path,
+                body,
+                signer: Signer::Anon,
+                json,
+                expect: Expect::Deny(401),
+            }]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::support::routes::{GateClass, Reach, Row};
+
+    fn fx() -> Fixture {
+        Fixture {
+            owner: Keypair::generate(),
+            stranger: Keypair::generate(),
+            owner_did: "did:key:zOWNER".to_string(),
+            public_repo: "prober-pub".to_string(),
+            private_repo: "prober-priv".to_string(),
+            content_path: "public/a.txt".to_string(),
+        }
+    }
+
+    #[test]
+    fn owner_gate_row_yields_stranger_403_and_owner_twin() {
+        let row = Row {
+            method: "PUT",
+            path: "/api/v1/repos/{owner}/{repo}/visibility",
+            gate: GateClass::OwnerGate,
+            handler: "visibility::set_visibility",
+            body: Some(r#"{"path_glob":"/"}"#),
+            needs: &[],
+            reach: Reach::None,
+        };
+        let ps = probes_for(&row, &fx());
+        assert_eq!(ps.len(), 2);
+        assert_eq!(ps[0].signer, Signer::Stranger);
+        assert!(ps[0].json);
+        assert!(matches!(ps[0].expect, Expect::Deny(403)));
+        assert!(ps[0].path.contains("prober-pub"), "owner-gate uses the public repo");
+        assert_eq!(ps[1].signer, Signer::Owner);
+        assert!(matches!(ps[1].expect, Expect::Not403));
+    }
+
+    #[test]
+    fn read_gate_row_yields_anon_404_and_positive_twin() {
+        let row = Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/blob/{*path}",
+            gate: GateClass::ReadGate,
+            handler: "repos::get_blob",
+            body: None,
+            needs: &[],
+            reach: Reach::ReaderReads,
+        };
+        let ps = probes_for(&row, &fx());
+        assert_eq!(ps.len(), 2);
+        assert_eq!(ps[0].signer, Signer::Anon);
+        assert!(matches!(ps[0].expect, Expect::Deny(404)));
+        assert!(ps[0].path.contains("prober-priv"), "read-gate uses the private repo");
+        assert!(ps[0].path.contains("public/a.txt"), "{{*path}} substituted");
+        assert_eq!(ps[1].signer, Signer::Owner);
+        assert!(matches!(ps[1].expect, Expect::Ok2xx(_)));
+    }
+
+    #[test]
+    fn signature_row_yields_unsigned_401_no_twin() {
+        let row = Row {
+            method: "POST",
+            path: "/{owner}/{repo}/git-receive-pack",
+            gate: GateClass::SignatureRequired,
+            handler: "repos::git_receive_pack",
+            body: None,
+            needs: &[],
+            reach: Reach::None,
+        };
+        let ps = probes_for(&row, &fx());
+        assert_eq!(ps.len(), 1);
+        assert_eq!(ps[0].signer, Signer::Anon);
+        assert!(matches!(ps[0].expect, Expect::Deny(401)));
+    }
+}

--- a/crates/gitlawb-node/tests/support/probe.rs
+++ b/crates/gitlawb-node/tests/support/probe.rs
@@ -24,6 +24,8 @@ pub struct Fixture {
     /// Public repo: owner-gate rows run against this so the stranger reaches the
     /// owner gate rather than a hidden-repo 404.
     pub public_repo: String,
+    /// The public repo's id, needed to seed the PR the close-gate rows require.
+    pub public_repo_id: String,
     /// Private repo (is_public=false) with seeded content: read-gate rows run
     /// against this so an anon caller gets the existence-hiding 404 and the owner
     /// twin gets 2xx.
@@ -40,18 +42,34 @@ impl Fixture {
         let content_path = "public/a.txt".to_string();
 
         let pub_repo = "prober-pub";
-        node.seed_repo(&owner_did, pub_repo, true).await;
-        node.seed_bare_repo(&owner_did, pub_repo, &[("public/a.txt", "pub content")], "sha1");
+        let public_repo_id = node.seed_repo(&owner_did, pub_repo, true).await;
+        node.seed_bare_repo(
+            &owner_did,
+            pub_repo,
+            &[("public/a.txt", "pub content")],
+            "sha1",
+        );
+        // The author-or-owner close gates load the PR/issue before they run, so
+        // the `.../pulls/1/close` and `.../issues/1/close` rows need entity #1 to
+        // exist (owner-authored) or a stranger 404s (absent) instead of 403.
+        node.seed_pr(&public_repo_id, 1, &owner_did).await;
+        node.seed_issue(&owner_did, pub_repo, "1", &owner_did);
 
         let priv_repo = "prober-priv";
         node.seed_repo(&owner_did, priv_repo, false).await;
-        node.seed_bare_repo(&owner_did, priv_repo, &[("public/a.txt", "priv content")], "sha1");
+        node.seed_bare_repo(
+            &owner_did,
+            priv_repo,
+            &[("public/a.txt", "priv content")],
+            "sha1",
+        );
 
         Fixture {
             owner,
             stranger,
             owner_did,
             public_repo: pub_repo.to_string(),
+            public_repo_id,
             private_repo: priv_repo.to_string(),
             content_path,
         }
@@ -198,6 +216,7 @@ mod tests {
             stranger: Keypair::generate(),
             owner_did: "did:key:zOWNER".to_string(),
             public_repo: "prober-pub".to_string(),
+            public_repo_id: "pub-id".to_string(),
             private_repo: "prober-priv".to_string(),
             content_path: "public/a.txt".to_string(),
         }
@@ -219,7 +238,10 @@ mod tests {
         assert_eq!(ps[0].signer, Signer::Stranger);
         assert!(ps[0].json);
         assert!(matches!(ps[0].expect, Expect::Deny(403)));
-        assert!(ps[0].path.contains("prober-pub"), "owner-gate uses the public repo");
+        assert!(
+            ps[0].path.contains("prober-pub"),
+            "owner-gate uses the public repo"
+        );
         assert_eq!(ps[1].signer, Signer::Owner);
         assert!(matches!(ps[1].expect, Expect::Not403));
     }
@@ -239,7 +261,10 @@ mod tests {
         assert_eq!(ps.len(), 2);
         assert_eq!(ps[0].signer, Signer::Anon);
         assert!(matches!(ps[0].expect, Expect::Deny(404)));
-        assert!(ps[0].path.contains("prober-priv"), "read-gate uses the private repo");
+        assert!(
+            ps[0].path.contains("prober-priv"),
+            "read-gate uses the private repo"
+        );
         assert!(ps[0].path.contains("public/a.txt"), "{{*path}} substituted");
         assert_eq!(ps[1].signer, Signer::Owner);
         assert!(matches!(ps[1].expect, Expect::Ok2xx(_)));

--- a/crates/gitlawb-node/tests/support/probe.rs
+++ b/crates/gitlawb-node/tests/support/probe.rs
@@ -49,7 +49,7 @@ pub struct Fixture {
     /// private repo, filled into the get_cert read-gate row (IdSource::CertId).
     pub cert_id: String,
     /// Per-read secret markers seeded into the private sub-entities (issue title,
-    /// PR title, cert signature, bounty title). Each read's own marker is added to
+    /// PR title, PR diff, bounty title). Each read's own marker is added to
     /// that read's withheld set so a 404 leaking THAT read's private content fails
     /// (#195, R3/KTD-4). A union is used so every seeded marker is withheld from
     /// every read-gate hostile — a per-read withheld token, never a status-only

--- a/crates/gitlawb-node/tests/support/probe.rs
+++ b/crates/gitlawb-node/tests/support/probe.rs
@@ -38,6 +38,23 @@ pub struct Fixture {
     /// The id (UUID) of the seeded issue (authored by `author`), filled into the
     /// `close_issue` row's `{id}` placeholder (IdSource::IssueId).
     pub issue_id: String,
+    /// The id (UUID) of an issue seeded in the PRIVATE repo (marker in its title),
+    /// filled into the get_issue / list_issue_comments read-gate rows
+    /// (IdSource::PrivIssueId). Distinct from `issue_id` (the public close issue).
+    pub priv_issue_id: String,
+    /// The id (UUID) of a bounty seeded against the PRIVATE repo (marker in its
+    /// title), filled into the get_bounty read-gate row (IdSource::PrivBountyId).
+    pub priv_bounty_id: String,
+    /// The id (UUID) of a ref-certificate issued by a real owner push to the
+    /// private repo, filled into the get_cert read-gate row (IdSource::CertId).
+    pub cert_id: String,
+    /// Per-read secret markers seeded into the private sub-entities (issue title,
+    /// PR title, cert signature, bounty title). Each read's own marker is added to
+    /// that read's withheld set so a 404 leaking THAT read's private content fails
+    /// (#195, R3/KTD-4). A union is used so every seeded marker is withheld from
+    /// every read-gate hostile — a per-read withheld token, never a status-only
+    /// 404 check.
+    pub priv_markers: Vec<String>,
     /// Public repo: owner-gate rows run against this so the stranger reaches the
     /// owner gate rather than a hidden-repo 404.
     pub public_repo: String,
@@ -132,6 +149,50 @@ impl Fixture {
         );
         let private_blob_oid = priv_oids["public/a.txt"].clone();
         let private_blob_oid_short = private_blob_oid[..12].to_string();
+        // The private repo's current `main` commit tip, needed as the `old` oid of
+        // the ref-update that force-points main at the deterministic push below.
+        let private_main_tip = priv_oids["HEAD"].clone();
+
+        // #195 (F2/U3): seed the private sub-entities the deferred reads return, each
+        // carrying its OWN distinctive marker so the per-read leak assertion is
+        // load-bearing. All are seeded as the OWNER (the only reader of the private
+        // repo), so anon/stranger get the existence-hiding 404 and the owner twin
+        // gets a 2xx that actually returns the entity.
+        //
+        // A real owner push to the private repo advances a `feature` branch with a
+        // marker file (so get_pr_diff's branch_diff_names(main, feature) is
+        // NON-EMPTY) AND issues a ref-certificate (get_cert). Do it first so the PR's
+        // source branch exists before create_pr and the cert id is captured.
+        let pr_diff_marker = "TOPSECRET-PRDIFF-U3".to_string();
+        let cert_id = seed_private_push_and_cert(
+            node,
+            &owner,
+            &owner_did,
+            priv_repo,
+            &private_main_tip,
+            &private_secret,
+            &private_blob_oid,
+            &pr_diff_marker,
+        )
+        .await;
+
+        let issue_marker = "TOPSECRET-ISSUE-U3".to_string();
+        let priv_issue_id =
+            seed_private_issue(node, &owner, &owner_did, priv_repo, &issue_marker).await;
+
+        let pr_marker = "TOPSECRET-PRTITLE-U3".to_string();
+        seed_private_pr(node, &owner, &owner_did, priv_repo, &pr_marker).await;
+
+        let bounty_marker = "TOPSECRET-BOUNTY-U3".to_string();
+        let priv_bounty_id =
+            seed_private_bounty(node, &owner, &owner_did, priv_repo, &bounty_marker).await;
+
+        let priv_markers = vec![
+            issue_marker,
+            pr_marker,
+            pr_diff_marker,
+            bounty_marker,
+        ];
 
         Fixture {
             owner,
@@ -145,6 +206,10 @@ impl Fixture {
             claimant_did,
             bounty_id,
             issue_id,
+            priv_issue_id,
+            priv_bounty_id,
+            cert_id,
+            priv_markers,
             public_repo: pub_repo.to_string(),
             public_repo_id,
             private_repo: priv_repo.to_string(),
@@ -271,6 +336,263 @@ async fn seed_disputable_bounty(
     bounty_id
 }
 
+/// Seed an issue in the PRIVATE repo (as the owner, the only reader) whose title
+/// carries `marker`, and return its id. get_issue returns the whole IssueRecord,
+/// so a 404 that echoes the title has leaked private content; the marker is added
+/// to the withheld set.
+async fn seed_private_issue(
+    node: &TestNode,
+    owner: &Keypair,
+    owner_did: &str,
+    repo: &str,
+    marker: &str,
+) -> String {
+    use super::signing::signed_request;
+
+    let client = reqwest::Client::new();
+    let path = format!("/api/v1/repos/{owner_did}/{repo}/issues");
+    let body = format!(r#"{{"title":"{marker}"}}"#).into_bytes();
+    let resp = signed_request(&client, reqwest::Method::POST, &node.base_url, &path, body, owner)
+        .header("content-type", "application/json")
+        .send()
+        .await
+        .expect("create private issue sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        201,
+        "seeding: private issue create must return 201 (owner reads its own private repo)"
+    );
+    let created: serde_json::Value = resp.json().await.expect("issue create returns JSON");
+    created["id"]
+        .as_str()
+        .expect("created private issue carries an id")
+        .to_string()
+}
+
+/// Seed a PR in the PRIVATE repo (as the owner) with `marker` in its title and
+/// `feature` as its source branch (which the prior push created). get_pr returns
+/// the whole PullRequest and get_pr_diff a real non-empty diff, so both the title
+/// marker and the diff marker are withheld. Lands at PR number 1 (first PR).
+async fn seed_private_pr(
+    node: &TestNode,
+    owner: &Keypair,
+    owner_did: &str,
+    repo: &str,
+    marker: &str,
+) {
+    use super::signing::signed_request;
+
+    let client = reqwest::Client::new();
+    let path = format!("/api/v1/repos/{owner_did}/{repo}/pulls");
+    let body = format!(
+        r#"{{"title":"{marker}","source_branch":"feature","target_branch":"main"}}"#
+    )
+    .into_bytes();
+    let resp = signed_request(&client, reqwest::Method::POST, &node.base_url, &path, body, owner)
+        .header("content-type", "application/json")
+        .send()
+        .await
+        .expect("create private PR sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        201,
+        "seeding: private PR create must return 201 (owner reads its own private repo)"
+    );
+    let created: serde_json::Value = resp.json().await.expect("PR create returns JSON");
+    assert_eq!(
+        created["number"].as_i64(),
+        Some(1),
+        "seeded private PR must be number 1 (the read-gate rows fill {{number}} = 1)"
+    );
+}
+
+/// Seed a bounty against the PRIVATE repo (as the owner) with `marker` in its
+/// title, and return its id. get_bounty read-gates the bounty's own repo, so
+/// anon/stranger get a 404 while the owner gets the bounty JSON (title marker
+/// withheld from the 404).
+async fn seed_private_bounty(
+    node: &TestNode,
+    owner: &Keypair,
+    owner_did: &str,
+    repo: &str,
+    marker: &str,
+) -> String {
+    use super::signing::signed_request;
+
+    let client = reqwest::Client::new();
+    let path = format!("/api/v1/repos/{owner_did}/{repo}/bounties");
+    let body = format!(r#"{{"title":"{marker}","amount":1}}"#).into_bytes();
+    let resp = signed_request(&client, reqwest::Method::POST, &node.base_url, &path, body, owner)
+        .header("content-type", "application/json")
+        .send()
+        .await
+        .expect("create private bounty sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        201,
+        "seeding: private bounty create must return 201 (owner reads its own private repo)"
+    );
+    let created: serde_json::Value = resp.json().await.expect("bounty create returns JSON");
+    created["id"]
+        .as_str()
+        .expect("created private bounty carries an id")
+        .to_string()
+}
+
+/// Point the PRIVATE repo's `main` at a deterministic commit and add a `feature`
+/// branch (a marker file on top of it) via a real owner git-receive-pack push,
+/// which also makes the node issue a ref-certificate. Returns the issued cert's
+/// id, read back from the owner's list_certs.
+///
+/// seed_bare_repo's `main` tip is non-deterministic (its commit dates are ambient),
+/// so we cannot build a `feature` that descends from it without the parent objects.
+/// Instead we push a full (non-thin) history: a fresh `main` commit and `feature`
+/// on top, force-updating the served `main` (the ref-update carries the server's
+/// current tip as its `old` oid; receive.denyNonFastForwards is off by default, so
+/// the non-fast-forward update applies). After the push, `feature` descends from
+/// the new `main`, so get_pr_diff's `git diff main...feature` has a merge base and
+/// returns the marker file. The push is signed as the owner (require_signature) and,
+/// on a non-protected branch of an owner-owned repo, lands cleanly and issues a cert.
+#[allow(clippy::too_many_arguments)]
+async fn seed_private_push_and_cert(
+    node: &TestNode,
+    owner: &Keypair,
+    owner_did: &str,
+    repo: &str,
+    server_main_tip: &str,
+    blob_contents: &str,
+    expected_blob_oid: &str,
+    marker_file_contents: &str,
+) -> String {
+    use super::signing::signed_request;
+    use std::process::Command;
+
+    let work = std::env::temp_dir().join(format!(
+        "gl-u3-certpush-{}-{}",
+        std::process::id(),
+        server_main_tip
+    ));
+    let _ = std::fs::remove_dir_all(&work);
+    std::fs::create_dir_all(&work).expect("create cert-push workdir");
+    let run = |args: &[&str], cwd: &std::path::Path| -> String {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("git runs");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+
+    run(&["init", "-q", "-b", "main"], &work);
+    run(&["config", "user.email", "t@t"], &work);
+    run(&["config", "user.name", "t"], &work);
+    // Keep `public/a.txt` (the seeded blob) on the new main so the get_blob /
+    // get_tree owner twins still resolve it — the blob OID depends only on content,
+    // so preserving the bytes preserves `private_blob_oid`.
+    std::fs::create_dir_all(work.join("public")).expect("mk public dir");
+    std::fs::write(work.join("public/a.txt"), blob_contents).expect("seed blob file");
+    run(&["add", "public/a.txt"], &work);
+    run(&["commit", "-q", "-m", "u3 main"], &work);
+    let new_main = run(&["rev-parse", "HEAD"], &work);
+    let new_blob = run(&["rev-parse", "HEAD:public/a.txt"], &work);
+    assert_eq!(
+        new_blob, expected_blob_oid,
+        "the pushed public/a.txt blob OID must equal the fixture's private_blob_oid"
+    );
+
+    // feature = new main + a marker file.
+    run(&["checkout", "-q", "-b", "feature"], &work);
+    std::fs::write(work.join("feature.txt"), marker_file_contents).expect("seed marker file");
+    run(&["add", "feature.txt"], &work);
+    run(&["commit", "-q", "-m", "feature commit"], &work);
+    let feature_tip = run(&["rev-parse", "HEAD"], &work);
+
+    // Full (non-thin) pack of both branches' objects — the server keeps its old
+    // main objects but needs all of the new ones since feature does not descend
+    // from the server's current main.
+    let pack = {
+        let out = Command::new("git")
+            .args(["pack-objects", "--stdout", "--revs"])
+            .current_dir(&work)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn pack-objects");
+        use std::io::Write;
+        out.stdin
+            .as_ref()
+            .expect("pack-objects stdin")
+            .write_all(format!("{new_main}\n{feature_tip}\n").as_bytes())
+            .expect("write revs");
+        let done = out.wait_with_output().expect("pack-objects completes");
+        assert!(done.status.success(), "pack-objects must succeed");
+        done.stdout
+    };
+
+    // git v0 receive-pack body: two ref-update pkt-lines — force-update main
+    // (old = the server's current tip) and create feature — the first carrying the
+    // capabilities after a NUL, a flush, then the packfile.
+    let zero = "0".repeat(server_main_tip.len());
+    let l1 = format!("{server_main_tip} {new_main} refs/heads/main\0report-status\n");
+    let l2 = format!("{zero} {feature_tip} refs/heads/feature\n");
+    let mut body: Vec<u8> = Vec::new();
+    body.extend(format!("{:04x}{l1}", l1.len() + 4).into_bytes());
+    body.extend(format!("{:04x}{l2}", l2.len() + 4).into_bytes());
+    body.extend_from_slice(b"0000");
+    body.extend_from_slice(&pack);
+
+    let client = reqwest::Client::new();
+    let push_path = format!("/{owner_did}/{repo}/git-receive-pack");
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &push_path,
+        body,
+        owner,
+    )
+    .header("content-type", "application/x-git-receive-pack-request")
+    .send()
+    .await
+    .expect("receive-pack push sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "seeding: owner push to a non-protected feature branch must return 200 so a cert issues"
+    );
+
+    let _ = std::fs::remove_dir_all(&work);
+
+    // Read the issued cert id back from the owner's list_certs on the private repo.
+    let certs_path = format!("/api/v1/repos/{owner_did}/{repo}/certs");
+    let resp = signed_request(
+        &client,
+        reqwest::Method::GET,
+        &node.base_url,
+        &certs_path,
+        Vec::new(),
+        owner,
+    )
+    .send()
+    .await
+    .expect("list_certs sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "seeding: owner list_certs must return 200"
+    );
+    let listed: serde_json::Value = resp.json().await.expect("list_certs returns JSON");
+    listed["certificates"][0]["id"]
+        .as_str()
+        .expect("a ref-certificate must have been issued by the push")
+        .to_string()
+}
+
 /// Who signs a probe request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Signer {
@@ -341,6 +663,9 @@ fn fill(path: &str, fixture: &Fixture, repo: &str, id_source: IdSource) -> Strin
         IdSource::Fixed => "1",
         IdSource::BountyId => fixture.bounty_id.as_str(),
         IdSource::IssueId => fixture.issue_id.as_str(),
+        IdSource::PrivIssueId => fixture.priv_issue_id.as_str(),
+        IdSource::PrivBountyId => fixture.priv_bounty_id.as_str(),
+        IdSource::CertId => fixture.cert_id.as_str(),
     };
     path.replace("{owner}", &fixture.owner_did)
         .replace("{repo}", repo)
@@ -426,12 +751,19 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
             // (full or short) nor the private repo's internal id (#195, F4). An empty
             // withheld list would let a 404 that spilled the private content pass as
             // a clean denial.
-            let withheld = vec![
+            // #195 (R3/KTD-4): the fixed blob-scoped withheld set PLUS every seeded
+            // sub-entity marker. The new reads (get_issue/get_pr/get_pr_diff/get_cert
+            // /get_bounty and the list rows off them) return their OWN private
+            // content, whose markers are NOT in the blob set — a 404 that leaks an
+            // issue title or PR diff must fail, so the per-read markers are withheld
+            // from every read-gate hostile. A status-only 404 check would be vacuous.
+            let mut withheld = vec![
                 fixture.private_secret.clone(),
                 fixture.private_blob_oid.clone(),
                 fixture.private_blob_oid_short.clone(),
                 fixture.private_repo_id.clone(),
             ];
+            withheld.extend(fixture.priv_markers.iter().cloned());
             let mut v = vec![
                 Probe {
                     label: format!("{} read-gate hostile (anon)", row.handler),
@@ -530,6 +862,15 @@ pub mod tests_support {
             claimant,
             bounty_id: "bounty-uuid-1234".to_string(),
             issue_id: "issue-uuid-1234".to_string(),
+            priv_issue_id: "priv-issue-uuid-1234".to_string(),
+            priv_bounty_id: "priv-bounty-uuid-1234".to_string(),
+            cert_id: "cert-uuid-1234".to_string(),
+            priv_markers: vec![
+                "TOPSECRET-ISSUE-U3".to_string(),
+                "TOPSECRET-PRTITLE-U3".to_string(),
+                "TOPSECRET-PRDIFF-U3".to_string(),
+                "TOPSECRET-BOUNTY-U3".to_string(),
+            ],
             owner: Keypair::generate(),
             stranger: Keypair::generate(),
             owner_did: "did:key:zOWNER".to_string(),

--- a/crates/gitlawb-node/tests/support/probe.rs
+++ b/crates/gitlawb-node/tests/support/probe.rs
@@ -32,6 +32,15 @@ pub struct Fixture {
     pub private_repo: String,
     /// A seeded blob path present in both repos, for `{*path}` reads.
     pub content_path: String,
+    /// The DISTINCTIVE secret bytes seeded into the private repo's blob. A
+    /// read-gate denial body must never echo this (INV-8: the sweep claims the
+    /// denial "leaks nothing", so it must actually check for the private content).
+    pub private_secret: String,
+    /// The private blob's full sha1 object id, and its short prefix. Neither may
+    /// appear in a read-gate denial body — a 404 that names the withheld object's
+    /// OID has leaked its existence.
+    pub private_blob_oid: String,
+    pub private_blob_oid_short: String,
 }
 
 impl Fixture {
@@ -56,13 +65,21 @@ impl Fixture {
         node.seed_issue(&owner_did, pub_repo, "1", &owner_did);
 
         let priv_repo = "prober-priv";
+        // Seed the private blob with an UNMISTAKABLE marker (not "priv content"),
+        // so a read-gate denial body that echoes the content is caught as a leak
+        // rather than blending into generic prose. The OID is captured so the OID
+        // (full + short) is withheld too — a 404 naming the object's id has leaked
+        // its existence just as much as its bytes.
+        let private_secret = "TOPSECRET-PRIVREAD-U3".to_string();
         node.seed_repo(&owner_did, priv_repo, false).await;
-        node.seed_bare_repo(
+        let priv_oids = node.seed_bare_repo(
             &owner_did,
             priv_repo,
-            &[("public/a.txt", "priv content")],
+            &[("public/a.txt", &private_secret)],
             "sha1",
         );
+        let private_blob_oid = priv_oids["public/a.txt"].clone();
+        let private_blob_oid_short = private_blob_oid[..12].to_string();
 
         Fixture {
             owner,
@@ -72,6 +89,9 @@ impl Fixture {
             public_repo_id,
             private_repo: priv_repo.to_string(),
             content_path,
+            private_secret,
+            private_blob_oid,
+            private_blob_oid_short,
         }
     }
 }
@@ -107,6 +127,12 @@ pub struct Probe {
     pub signer: Signer,
     pub json: bool,
     pub expect: Expect,
+    /// Private tokens (secret content, blob OID) that the DENY body must not echo.
+    /// Non-empty only for read-gate hostile probes, where a private repo/blob is
+    /// actually seeded; the owner-gate (403) and signature (401) hostile probes
+    /// fire on NO_ENTITY repos before any entity lookup, so there is genuinely
+    /// nothing seeded to leak and an empty list is the honest assertion there.
+    pub withheld: Vec<String>,
 }
 
 /// Substitute path-template placeholders from the fixture. `repo` is the public
@@ -140,6 +166,9 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
                     signer: Signer::Stranger,
                     json,
                     expect: Expect::Deny(403),
+                    // No entity is seeded on the public owner-gate substrate before
+                    // the 403 fires, so there is nothing private to leak here.
+                    withheld: Vec::new(),
                 },
                 Probe {
                     label: format!("{} owner-reachability twin", row.handler),
@@ -149,6 +178,7 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
                     signer: Signer::Owner,
                     json,
                     expect: Expect::Not403,
+                    withheld: Vec::new(),
                 },
             ]
         }
@@ -162,6 +192,15 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
                 signer: Signer::Anon,
                 json,
                 expect: Expect::Deny(404),
+                // INV-8: the private repo's blob and its OID are actually seeded
+                // here, so the 404 body must echo neither the secret content nor the
+                // blob OID (full or short). An empty withheld list would let a 404
+                // that spilled the private content pass as a clean denial.
+                withheld: vec![
+                    fixture.private_secret.clone(),
+                    fixture.private_blob_oid.clone(),
+                    fixture.private_blob_oid_short.clone(),
+                ],
             }];
             // Positive twin: prove the 404 is the gate, not an absent entity.
             let twin = match row.reach {
@@ -173,6 +212,9 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
                     signer: Signer::Owner,
                     json,
                     expect: Expect::Ok2xx,
+                    // The twin is a GRANTED read; it is expected to return the
+                    // content, so nothing is withheld from it.
+                    withheld: Vec::new(),
                 },
                 Reach::SiblingPublic(sibling) => Probe {
                     label: format!("{} read-reachability twin (sibling public)", row.handler),
@@ -182,6 +224,7 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
                     signer: Signer::Anon,
                     json,
                     expect: Expect::Ok2xx,
+                    withheld: Vec::new(),
                 },
                 Reach::None => panic!(
                     "read-gate row {} {} has no Reach twin (U1 consistency should have caught this)",
@@ -201,6 +244,9 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
                 signer: Signer::Anon,
                 json,
                 expect: Expect::Deny(401),
+                // The 401 fires at the signature layer before any repo/entity is
+                // looked up (NO_ENTITY substrate), so nothing private is in scope.
+                withheld: Vec::new(),
             }]
         }
     }
@@ -220,6 +266,9 @@ mod tests {
             public_repo_id: "pub-id".to_string(),
             private_repo: "prober-priv".to_string(),
             content_path: "public/a.txt".to_string(),
+            private_secret: "TOPSECRET-PRIVREAD-U3".to_string(),
+            private_blob_oid: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
+            private_blob_oid_short: "deadbeefdead".to_string(),
         }
     }
 
@@ -245,6 +294,12 @@ mod tests {
         );
         assert_eq!(ps[1].signer, Signer::Owner);
         assert!(matches!(ps[1].expect, Expect::Not403));
+        // Owner-gate hostile fires on a NO_ENTITY public repo before any lookup, so
+        // there is nothing private seeded to leak: an empty withheld list is honest.
+        assert!(
+            ps[0].withheld.is_empty(),
+            "owner-gate hostile probe seeds no private entity, so withholds nothing"
+        );
     }
 
     #[test]
@@ -258,7 +313,8 @@ mod tests {
             needs: &[],
             reach: Reach::ReaderReads,
         };
-        let ps = probes_for(&row, &fx());
+        let f = fx();
+        let ps = probes_for(&row, &f);
         assert_eq!(ps.len(), 2);
         assert_eq!(ps[0].signer, Signer::Anon);
         assert!(matches!(ps[0].expect, Expect::Deny(404)));
@@ -267,8 +323,32 @@ mod tests {
             "read-gate uses the private repo"
         );
         assert!(ps[0].path.contains("public/a.txt"), "{{*path}} substituted");
+        // F2 belt-and-suspenders: the read-gate hostile probe MUST carry the private
+        // tokens, so a future refactor that drops them (reverting F2 to a vacuous
+        // empty-withheld 404 check) fails loudly here.
+        assert!(
+            !ps[0].withheld.is_empty(),
+            "read-gate hostile probe must carry withheld private tokens"
+        );
+        assert!(
+            ps[0].withheld.contains(&f.private_secret),
+            "the seeded secret content must be a withheld token"
+        );
+        assert!(
+            ps[0].withheld.contains(&f.private_blob_oid),
+            "the private blob OID must be a withheld token"
+        );
+        assert!(
+            ps[0].withheld.contains(&f.private_blob_oid_short),
+            "the short blob OID prefix must be a withheld token"
+        );
         assert_eq!(ps[1].signer, Signer::Owner);
         assert!(matches!(ps[1].expect, Expect::Ok2xx));
+        // The granted twin returns the content, so it withholds nothing.
+        assert!(
+            ps[1].withheld.is_empty(),
+            "the granted read twin must not carry withheld tokens"
+        );
     }
 
     #[test]
@@ -286,6 +366,11 @@ mod tests {
         assert_eq!(ps.len(), 1);
         assert_eq!(ps[0].signer, Signer::Anon);
         assert!(matches!(ps[0].expect, Expect::Deny(401)));
+        // The 401 fires before any entity lookup, so nothing private is in scope.
+        assert!(
+            ps[0].withheld.is_empty(),
+            "signature-required hostile probe withholds nothing (fires pre-lookup)"
+        );
     }
 
     #[test]
@@ -312,6 +397,56 @@ mod tests {
         assert!(
             ps[1].path.contains("public/a.txt"),
             "sibling template's {{*path}} is filled from the fixture content path"
+        );
+    }
+
+    // F2 RED proof at the check_denied level (no DB): feed a synthetic denial body
+    // that DOES contain the private secret through the SAME withheld tokens the
+    // read-gate probe carries. If the tokens are truly threaded and non-empty, the
+    // deny check must reject it as a leak. This is the fail case a real node's
+    // clean 404 avoids; it proves the sweep would actually catch a leaking 404.
+    #[test]
+    fn read_gate_withheld_tokens_reject_a_leaking_denial_body() {
+        use crate::support::assert::check_denied;
+
+        let row = Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}",
+            gate: GateClass::ReadGate,
+            handler: "repos::get_repo",
+            body: None,
+            needs: &[],
+            reach: Reach::ReaderReads,
+        };
+        let f = fx();
+        let ps = probes_for(&row, &f);
+        let tokens: Vec<&str> = ps[0].withheld.iter().map(String::as_str).collect();
+        assert!(
+            !tokens.is_empty(),
+            "precondition: read-gate probe carries tokens"
+        );
+
+        // A hostile 404 that spilled the secret content: must be rejected as a leak.
+        let leaking = format!(
+            r#"{{"error":"blob {} at {}"}}"#,
+            f.private_secret, f.private_blob_oid
+        );
+        let r = check_denied(404, &leaking, 404, &tokens);
+        assert!(
+            r.is_err(),
+            "a 404 body echoing the secret must be flagged: {r:?}"
+        );
+        assert!(
+            r.unwrap_err().contains(&f.private_secret),
+            "the failure must name the leaked secret token"
+        );
+
+        // A clean 404 (no private tokens) with the same tokens passes: the tokens do
+        // not spuriously trip on an honest denial.
+        let clean = check_denied(404, r#"{"error":"repository not found"}"#, 404, &tokens);
+        assert!(
+            clean.is_ok(),
+            "a clean 404 must pass the withheld check: {clean:?}"
         );
     }
 

--- a/crates/gitlawb-node/tests/support/probe.rs
+++ b/crates/gitlawb-node/tests/support/probe.rs
@@ -91,8 +91,9 @@ pub enum Expect {
     Deny(u16),
     /// Owner-gate twin: the owner reaches the handler, so NOT 403.
     Not403,
-    /// Read-gate twin: an authorized read returns 2xx (optionally containing a token).
-    Ok2xx(Option<String>),
+    /// Read-gate twin: an authorized read returns a non-empty 2xx (an empty 2xx
+    /// would be a denial rendered as success).
+    Ok2xx,
 }
 
 /// A single request to drive against the node.
@@ -171,7 +172,7 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
                     body,
                     signer: Signer::Owner,
                     json,
-                    expect: Expect::Ok2xx(None),
+                    expect: Expect::Ok2xx,
                 },
                 Reach::SiblingPublic(sibling) => Probe {
                     label: format!("{} read-reachability twin (sibling public)", row.handler),
@@ -180,7 +181,7 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
                     body,
                     signer: Signer::Anon,
                     json,
-                    expect: Expect::Ok2xx(None),
+                    expect: Expect::Ok2xx,
                 },
                 Reach::None => panic!(
                     "read-gate row {} {} has no Reach twin (U1 consistency should have caught this)",
@@ -267,7 +268,7 @@ mod tests {
         );
         assert!(ps[0].path.contains("public/a.txt"), "{{*path}} substituted");
         assert_eq!(ps[1].signer, Signer::Owner);
-        assert!(matches!(ps[1].expect, Expect::Ok2xx(_)));
+        assert!(matches!(ps[1].expect, Expect::Ok2xx));
     }
 
     #[test]
@@ -285,5 +286,50 @@ mod tests {
         assert_eq!(ps.len(), 1);
         assert_eq!(ps[0].signer, Signer::Anon);
         assert!(matches!(ps[0].expect, Expect::Deny(401)));
+    }
+
+    #[test]
+    fn read_gate_sibling_public_twin_reads_the_sibling_path_anon() {
+        let row = Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/blob/secret/x.txt",
+            gate: GateClass::ReadGate,
+            handler: "repos::get_blob",
+            body: None,
+            needs: &[],
+            reach: Reach::SiblingPublic("/api/v1/repos/{owner}/{repo}/blob/{*path}"),
+        };
+        let ps = probes_for(&row, &fx());
+        assert_eq!(ps.len(), 2);
+        // Hostile: anon on the withheld path -> 404.
+        assert_eq!(ps[0].signer, Signer::Anon);
+        assert!(matches!(ps[0].expect, Expect::Deny(404)));
+        assert!(ps[0].path.ends_with("/blob/secret/x.txt"));
+        // Twin: anon on the sibling PUBLIC path -> non-empty 2xx (proves the 404
+        // is path-scoped withholding, not a blanket refusal).
+        assert_eq!(ps[1].signer, Signer::Anon);
+        assert!(matches!(ps[1].expect, Expect::Ok2xx));
+        assert!(
+            ps[1].path.contains("public/a.txt"),
+            "sibling template's {{*path}} is filled from the fixture content path"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "has no Reach twin")]
+    fn read_gate_row_without_a_reach_twin_panics() {
+        // A read-gate row with Reach::None is a registry bug the U1 consistency
+        // test rejects; if one slips through, the probe generator must fail loud
+        // rather than silently emit a hostile probe with no positive twin.
+        let row = Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/issues",
+            gate: GateClass::ReadGate,
+            handler: "issues::list_issues",
+            body: None,
+            needs: &[],
+            reach: Reach::None,
+        };
+        let _ = probes_for(&row, &fx());
     }
 }

--- a/crates/gitlawb-node/tests/support/probe.rs
+++ b/crates/gitlawb-node/tests/support/probe.rs
@@ -14,13 +14,30 @@
 use gitlawb_core::identity::Keypair;
 use gitlawb_node::test_harness::TestNode;
 
-use super::routes::{GateClass, Reach, Row};
+use super::routes::{GateClass, IdSource, Principal, Reach, Row};
 
 /// A seeded two-repo state matrix plus the owner and stranger identities.
 pub struct Fixture {
     pub owner: Keypair,
     pub stranger: Keypair,
+    /// The PR/issue author — distinct from owner and stranger — so the
+    /// owner-OR-author close gates (#195, F1) drive their author arm with an
+    /// identity that is NOT the owner (the original bug seeded author == owner).
+    pub author: Keypair,
+    /// The bounty creator, distinct from every other identity.
+    pub creator: Keypair,
+    /// The bounty claimant, distinct from every other identity.
+    pub claimant: Keypair,
     pub owner_did: String,
+    pub author_did: String,
+    pub creator_did: String,
+    pub claimant_did: String,
+    /// The id (UUID) of the seeded disputable bounty, filled into the
+    /// `dispute_bounty` row's `{id}` placeholder (IdSource::BountyId).
+    pub bounty_id: String,
+    /// The id (UUID) of the seeded issue (authored by `author`), filled into the
+    /// `close_issue` row's `{id}` placeholder (IdSource::IssueId).
+    pub issue_id: String,
     /// Public repo: owner-gate rows run against this so the stranger reaches the
     /// owner gate rather than a hidden-repo 404.
     pub public_repo: String,
@@ -52,6 +69,16 @@ impl Fixture {
         let owner = Keypair::generate();
         let owner_did = owner.did().to_string();
         let stranger = Keypair::generate();
+        // #195 (F1): distinct identities for each authorizing arm of the
+        // multi-principal gates. All four must differ from owner and stranger and
+        // from each other, or an arm silently collapses onto another and reverting
+        // it stays invisible (the original author == owner bug).
+        let author = Keypair::generate();
+        let author_did = author.did().to_string();
+        let creator = Keypair::generate();
+        let creator_did = creator.did().to_string();
+        let claimant = Keypair::generate();
+        let claimant_did = claimant.did().to_string();
         let content_path = "public/a.txt".to_string();
 
         let pub_repo = "prober-pub";
@@ -63,10 +90,31 @@ impl Fixture {
             "sha1",
         );
         // The author-or-owner close gates load the PR/issue before they run, so
-        // the `.../pulls/1/close` and `.../issues/1/close` rows need entity #1 to
-        // exist (owner-authored) or a stranger 404s (absent) instead of 403.
-        node.seed_pr(&public_repo_id, 1, &owner_did).await;
-        node.seed_issue(&owner_did, pub_repo, "1", &owner_did);
+        // the close rows need the entity to exist. Seed both authored by `author`
+        // (NOT the owner) so the author arm is granted by a non-owner identity and
+        // reverting either arm is observable. The PR seeds via the DB (author_did
+        // is a real column). The issue is seeded over HTTP as `author` (below):
+        // close_issue deserializes the WHOLE git-JSON IssueRecord before reading
+        // its author, so a bare `{"author":..}` DB-seed fails to deserialize and
+        // the author falls back to None — the author arm would then 403.
+        node.seed_pr(&public_repo_id, 1, &author_did).await;
+        let issue_id = seed_authored_issue(node, &owner_did, pub_repo, &author).await;
+
+        // Seed a DISPUTABLE bounty (status "claimed", creator + claimant set) so the
+        // dispute_bounty creator/claimant arms reach their auth check. dispute_bounty
+        // gates on creator/claimant, NOT the repo, so the bounty is created on the
+        // public repo (both signers can read it). Seeded over HTTP through the real
+        // handlers — create (creator) then claim (claimant) — because the DB seam is
+        // private to TestNode and a test-only seed method would be a src/ change.
+        let bounty_id = seed_disputable_bounty(
+            node,
+            &owner_did,
+            pub_repo,
+            &creator,
+            &creator_did,
+            &claimant,
+        )
+        .await;
 
         let priv_repo = "prober-priv";
         // Seed the private blob with an UNMISTAKABLE marker (not "priv content"),
@@ -88,7 +136,15 @@ impl Fixture {
         Fixture {
             owner,
             stranger,
+            author,
+            creator,
+            claimant,
             owner_did,
+            author_did,
+            creator_did,
+            claimant_did,
+            bounty_id,
+            issue_id,
             public_repo: pub_repo.to_string(),
             public_repo_id,
             private_repo: priv_repo.to_string(),
@@ -101,12 +157,144 @@ impl Fixture {
     }
 }
 
+/// Seed an issue authored by `author` through the real `create_issue` handler
+/// and return its minted UUID id. Written as a full git-JSON `IssueRecord` (the
+/// handler serializes the whole record), so `close_issue`'s deserialize-then-read
+/// author path finds the author — which a bare-field DB seed cannot satisfy.
+async fn seed_authored_issue(
+    node: &TestNode,
+    owner_did: &str,
+    repo: &str,
+    author: &Keypair,
+) -> String {
+    use super::signing::signed_request;
+
+    let client = reqwest::Client::new();
+    let path = format!("/api/v1/repos/{owner_did}/{repo}/issues");
+    let body = br#"{"title":"prober close issue"}"#.to_vec();
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &path,
+        body,
+        author,
+    )
+    .header("content-type", "application/json")
+    .send()
+    .await
+    .expect("create issue sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        201,
+        "seeding: issue create must return 201 (author can read the public repo)"
+    );
+    let created: serde_json::Value = resp.json().await.expect("issue create returns JSON");
+    created["id"]
+        .as_str()
+        .expect("created issue carries an id")
+        .to_string()
+}
+
+/// Seed a bounty in the `claimed` state (creator + claimant set) so the
+/// dispute_bounty creator/claimant arms reach their auth check, and return its id.
+///
+/// Driven through the real HTTP handlers rather than the DB: `create_bounty` mints
+/// a UUID id we read back from the response, and `claim_bounty` sets the claimant.
+/// Both read-gate the (public) repo, which the creator/claimant can read. The
+/// bounty lands `status = "claimed"`; because its deadline has not been exceeded,
+/// a creator/claimant dispute returns 400 (not 403) after passing auth — which is
+/// still a Not403 twin — while a stranger is denied 403 at the auth check first.
+async fn seed_disputable_bounty(
+    node: &TestNode,
+    owner_did: &str,
+    repo: &str,
+    creator: &Keypair,
+    creator_did: &str,
+    claimant: &Keypair,
+) -> String {
+    use super::signing::signed_request;
+
+    let client = reqwest::Client::new();
+
+    // create_bounty (creator) -> 201 with the minted BountyRecord (carries the id).
+    let create_path = format!("/api/v1/repos/{owner_did}/{repo}/bounties");
+    let body = br#"{"title":"prober dispute bounty","amount":1}"#.to_vec();
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &create_path,
+        body,
+        creator,
+    )
+    .header("content-type", "application/json")
+    .send()
+    .await
+    .expect("create bounty sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        201,
+        "seeding: bounty create must return 201 (creator can read the public repo)"
+    );
+    let created: serde_json::Value = resp.json().await.expect("bounty create returns JSON");
+    let bounty_id = created["id"]
+        .as_str()
+        .expect("created bounty carries an id")
+        .to_string();
+    assert_eq!(
+        created["creator_did"].as_str(),
+        Some(creator_did),
+        "seeded bounty creator must be the fixture creator"
+    );
+
+    // claim_bounty (claimant) -> 200, status becomes "claimed", claimant recorded.
+    let claim_path = format!("/api/v1/bounties/{bounty_id}/claim");
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &claim_path,
+        br#"{}"#.to_vec(),
+        claimant,
+    )
+    .header("content-type", "application/json")
+    .send()
+    .await
+    .expect("claim bounty sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "seeding: bounty claim must return 200 (claimant can read the public repo)"
+    );
+
+    bounty_id
+}
+
 /// Who signs a probe request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Signer {
     Anon,
     Owner,
     Stranger,
+    /// The PR/issue author arm of a multi-principal close gate.
+    Author,
+    /// The bounty creator arm of dispute_bounty.
+    Creator,
+    /// The bounty claimant arm of dispute_bounty.
+    Claimant,
+}
+
+/// The signer identity that grants a given multi-principal arm. The runtime sweep
+/// resolves each to its fixture keypair; the structural consistency test uses it
+/// to confirm every declared arm has a twin signed by ITS identity.
+pub fn signer_for_principal(p: Principal) -> Signer {
+    match p {
+        Principal::Owner => Signer::Owner,
+        Principal::Author => Signer::Author,
+        Principal::Creator => Signer::Creator,
+        Principal::Claimant => Signer::Claimant,
+    }
 }
 
 /// What a probe expects.
@@ -142,11 +330,22 @@ pub struct Probe {
 
 /// Substitute path-template placeholders from the fixture. `repo` is the public
 /// repo for owner-gate rows and the private repo for read-gate rows.
-fn fill(path: &str, fixture: &Fixture, repo: &str) -> String {
+///
+/// `id_source` selects what `{id}` resolves to: `Fixed` uses the static seed id
+/// `"1"` (entities seeded at #1), while a per-row source such as `BountyId`
+/// injects a UUID minted at seed time. This is the general id-threading hook U3
+/// reuses for the other id-keyed reads (a cert id, etc.): add an `IdSource`
+/// variant + fixture field and map it here.
+fn fill(path: &str, fixture: &Fixture, repo: &str, id_source: IdSource) -> String {
+    let id = match id_source {
+        IdSource::Fixed => "1",
+        IdSource::BountyId => fixture.bounty_id.as_str(),
+        IdSource::IssueId => fixture.issue_id.as_str(),
+    };
     path.replace("{owner}", &fixture.owner_did)
         .replace("{repo}", repo)
         .replace("{number}", "1")
-        .replace("{id}", "1")
+        .replace("{id}", id)
         .replace("{label}", "bug")
         .replace("{branch}", "main")
         .replace("{*path}", &fixture.content_path)
@@ -161,7 +360,7 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
 
     match row.gate {
         GateClass::OwnerGate => {
-            let path = fill(row.path, fixture, &fixture.public_repo);
+            let path = fill(row.path, fixture, &fixture.public_repo, row.id_source);
             vec![
                 Probe {
                     label: format!("{} owner-gate hostile", row.handler),
@@ -187,8 +386,41 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
                 },
             ]
         }
+        GateClass::MultiPrincipalGate => {
+            // #195 (F1): a single stranger-403 hostile plus one Not403 twin PER
+            // declared arm. Each arm is signed by ITS distinct fixture identity, so
+            // reverting any single arm in the handler turns that arm's twin RED
+            // while the others (and the stranger 403) stay green.
+            let path = fill(row.path, fixture, &fixture.public_repo, row.id_source);
+            let mut v = vec![Probe {
+                label: format!("{} multi-principal hostile (stranger)", row.handler),
+                method: method.clone(),
+                path: path.clone(),
+                body: body.clone(),
+                signer: Signer::Stranger,
+                json,
+                expect: Expect::Deny(403),
+                // The gate fires before returning any entity; nothing private is
+                // seeded to leak on this substrate.
+                withheld: Vec::new(),
+            }];
+            for arm in row.principals {
+                let signer = signer_for_principal(*arm);
+                v.push(Probe {
+                    label: format!("{} arm twin ({:?})", row.handler, arm),
+                    method: method.clone(),
+                    path: path.clone(),
+                    body: body.clone(),
+                    signer,
+                    json,
+                    expect: Expect::Not403,
+                    withheld: Vec::new(),
+                });
+            }
+            v
+        }
         GateClass::ReadGate => {
-            let path = fill(row.path, fixture, &fixture.private_repo);
+            let path = fill(row.path, fixture, &fixture.private_repo, row.id_source);
             // INV-8: the private repo's blob and its OID are actually seeded here, so
             // the 404 body must echo neither the secret content nor the blob OID
             // (full or short) nor the private repo's internal id (#195, F4). An empty
@@ -243,7 +475,7 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
                 Reach::SiblingPublic(sibling) => Probe {
                     label: format!("{} read-reachability twin (sibling public)", row.handler),
                     method,
-                    path: fill(sibling, fixture, &fixture.private_repo),
+                    path: fill(sibling, fixture, &fixture.private_repo, row.id_source),
                     body,
                     signer: Signer::Anon,
                     json,
@@ -259,7 +491,7 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
             v
         }
         GateClass::SignatureRequired => {
-            let path = fill(row.path, fixture, &fixture.public_repo);
+            let path = fill(row.path, fixture, &fixture.public_repo, row.id_source);
             vec![Probe {
                 label: format!("{} signature-required hostile", row.handler),
                 method,
@@ -276,13 +508,28 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
     }
 }
 
+/// A DB-less `Fixture` for the pure-generator unit tests (here and the structural
+/// consistency test in `routes.rs`). No node is seeded, so the identities are
+/// generated keypairs with placeholder repo/secret metadata; only the arm DIDs
+/// and the injected `{id}` matter to `probes_for`. Shared so both test modules
+/// build the same shape.
 #[cfg(test)]
-mod tests {
+pub mod tests_support {
     use super::*;
-    use crate::support::routes::{GateClass, Reach, Row};
 
-    fn fx() -> Fixture {
+    pub fn fx() -> Fixture {
+        let author = Keypair::generate();
+        let creator = Keypair::generate();
+        let claimant = Keypair::generate();
         Fixture {
+            author_did: author.did().to_string(),
+            creator_did: creator.did().to_string(),
+            claimant_did: claimant.did().to_string(),
+            author,
+            creator,
+            claimant,
+            bounty_id: "bounty-uuid-1234".to_string(),
+            issue_id: "issue-uuid-1234".to_string(),
             owner: Keypair::generate(),
             stranger: Keypair::generate(),
             owner_did: "did:key:zOWNER".to_string(),
@@ -296,6 +543,14 @@ mod tests {
             private_blob_oid_short: "deadbeefdead".to_string(),
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::support::routes::{GateClass, Reach, Row};
+
+    use super::tests_support::fx;
 
     #[test]
     fn owner_gate_row_yields_stranger_403_and_owner_twin() {
@@ -307,6 +562,8 @@ mod tests {
             body: Some(r#"{"path_glob":"/"}"#),
             needs: &[],
             reach: Reach::None,
+            principals: &[],
+            id_source: crate::support::routes::IdSource::Fixed,
         };
         let ps = probes_for(&row, &fx());
         assert_eq!(ps.len(), 2);
@@ -337,6 +594,8 @@ mod tests {
             body: None,
             needs: &[],
             reach: Reach::ReaderReads,
+            principals: &[],
+            id_source: crate::support::routes::IdSource::Fixed,
         };
         let f = fx();
         let ps = probes_for(&row, &f);
@@ -394,6 +653,8 @@ mod tests {
             body: None,
             needs: &[],
             reach: Reach::None,
+            principals: &[],
+            id_source: crate::support::routes::IdSource::Fixed,
         };
         let ps = probes_for(&row, &fx());
         assert_eq!(ps.len(), 1);
@@ -416,6 +677,8 @@ mod tests {
             body: None,
             needs: &[],
             reach: Reach::SiblingPublic("/api/v1/repos/{owner}/{repo}/blob/{*path}"),
+            principals: &[],
+            id_source: crate::support::routes::IdSource::Fixed,
         };
         let ps = probes_for(&row, &fx());
         // anon hostile, signed-stranger hostile (#195 F1), sibling-public twin.
@@ -455,6 +718,8 @@ mod tests {
             body: None,
             needs: &[],
             reach: Reach::ReaderReads,
+            principals: &[],
+            id_source: crate::support::routes::IdSource::Fixed,
         };
         let f = fx();
         let ps = probes_for(&row, &f);
@@ -516,6 +781,8 @@ mod tests {
             body: None,
             needs: &[],
             reach: Reach::None,
+            principals: &[],
+            id_source: crate::support::routes::IdSource::Fixed,
         };
         let _ = probes_for(&row, &fx());
     }

--- a/crates/gitlawb-node/tests/support/probe.rs
+++ b/crates/gitlawb-node/tests/support/probe.rs
@@ -28,10 +28,16 @@ pub struct Fixture {
     pub creator: Keypair,
     /// The bounty claimant, distinct from every other identity.
     pub claimant: Keypair,
+    /// The task assignee, distinct from every other identity (#195, F3). The
+    /// complete/fail actor gates drive their Assignee arm as this identity, so it
+    /// must differ from owner and stranger or the arm cannot false-pass on an
+    /// owner fallback.
+    pub assignee: Keypair,
     pub owner_did: String,
     pub author_did: String,
     pub creator_did: String,
     pub claimant_did: String,
+    pub assignee_did: String,
     /// The id (UUID) of the seeded disputable bounty, filled into the
     /// `dispute_bounty` row's `{id}` placeholder (IdSource::BountyId).
     pub bounty_id: String,
@@ -47,6 +53,15 @@ pub struct Fixture {
     pub submitted_bounty_id: String,
     /// Left "open" (create only) for the cancel_bounty row (IdSource::OpenBountyId).
     pub open_bounty_id: String,
+    /// #195 (F3): a task seeded "pending" (delegated by the owner) for the
+    /// claim_task caller-self row (IdSource::ClaimableTaskId).
+    pub claimable_task_id: String,
+    /// A task seeded "claimed" by the assignee for the complete_task actor row
+    /// (IdSource::CompletableTaskId).
+    pub completable_task_id: String,
+    /// A second assignee-claimed task for the fail_task actor row
+    /// (IdSource::FailableTaskId).
+    pub failable_task_id: String,
     /// The id (UUID) of the seeded issue (authored by `author`), filled into the
     /// `close_issue` row's `{id}` placeholder (IdSource::IssueId).
     pub issue_id: String,
@@ -108,6 +123,11 @@ impl Fixture {
         let creator_did = creator.did().to_string();
         let claimant = Keypair::generate();
         let claimant_did = claimant.did().to_string();
+        // #195 (F3): a distinct assignee identity (!= owner, != stranger) for the
+        // complete/fail actor gates, so their Assignee arm cannot false-pass on an
+        // owner fallback.
+        let assignee = Keypair::generate();
+        let assignee_did = assignee.did().to_string();
         let content_path = "public/a.txt".to_string();
 
         let pub_repo = "prober-pub";
@@ -238,20 +258,35 @@ impl Fixture {
 
         let priv_markers = vec![issue_marker, pr_marker, pr_diff_marker, bounty_marker];
 
+        // #195 (F3): seed the caller-self task entities through the real task write
+        // routes (behind add_auth_layers only, no icaptcha). The claimable task
+        // stays "pending" so its claim control (the owner) can claim it; the
+        // completable and failable tasks are claimed by the assignee, so
+        // complete_task / fail_task reach their assignee actor gate against a
+        // "claimed" task.
+        let claimable_task_id = seed_pending_task(node, &owner).await;
+        let completable_task_id = seed_claimed_task(node, &owner, &assignee).await;
+        let failable_task_id = seed_claimed_task(node, &owner, &assignee).await;
+
         Fixture {
             owner,
             stranger,
             author,
             creator,
             claimant,
+            assignee,
             owner_did,
             author_did,
             creator_did,
             claimant_did,
+            assignee_did,
             bounty_id,
             claimed_bounty_id,
             submitted_bounty_id,
             open_bounty_id,
+            claimable_task_id,
+            completable_task_id,
+            failable_task_id,
             issue_id,
             priv_issue_id,
             priv_bounty_id,
@@ -306,6 +341,74 @@ async fn seed_authored_issue(
         .as_str()
         .expect("created issue carries an id")
         .to_string()
+}
+
+/// Create a "pending" task delegated by `delegator` through the real `create_task`
+/// handler and return its minted id. `create_task` binds `delegator_did` to the
+/// signer, so the body names the signer's DID. Task write routes sit behind
+/// `add_auth_layers` only (no icaptcha), so a signed create reaches the handler.
+async fn seed_pending_task(node: &TestNode, delegator: &Keypair) -> String {
+    use super::signing::signed_request;
+
+    let client = reqwest::Client::new();
+    let delegator_did = delegator.did().to_string();
+    let body =
+        format!(r#"{{"kind":"review","capability":"read","delegator_did":"{delegator_did}"}}"#)
+            .into_bytes();
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        "/api/v1/tasks",
+        body,
+        delegator,
+    )
+    .header("content-type", "application/json")
+    .send()
+    .await
+    .expect("create task sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        201,
+        "seeding: task create must return 201 (delegator_did binds to the signer)"
+    );
+    let created: serde_json::Value = resp.json().await.expect("task create returns JSON");
+    created["id"]
+        .as_str()
+        .expect("created task carries an id")
+        .to_string()
+}
+
+/// Create a "pending" task (delegated by `owner`), then claim it as `assignee`
+/// (`claim_task` binds `assignee_did` to the signer), leaving it "claimed" so
+/// `complete_task` / `fail_task` reach their assignee actor gate. Returns the id.
+async fn seed_claimed_task(node: &TestNode, owner: &Keypair, assignee: &Keypair) -> String {
+    use super::signing::signed_request;
+
+    let id = seed_pending_task(node, owner).await;
+
+    let client = reqwest::Client::new();
+    let assignee_did = assignee.did().to_string();
+    let claim_path = format!("/api/v1/tasks/{id}/claim");
+    let body = format!(r#"{{"assignee_did":"{assignee_did}"}}"#).into_bytes();
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &claim_path,
+        body,
+        assignee,
+    )
+    .header("content-type", "application/json")
+    .send()
+    .await
+    .expect("claim task sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "seeding: task claim must return 200 (assignee_did binds to the signer)"
+    );
+    id
 }
 
 /// How far along its lifecycle a seeded bounty is driven, expressed as the real
@@ -717,6 +820,8 @@ pub enum Signer {
     Creator,
     /// The bounty claimant arm of dispute_bounty.
     Claimant,
+    /// The task assignee arm of complete_task / fail_task (#195, F3).
+    Assignee,
 }
 
 /// The signer identity that grants a given multi-principal arm. The runtime sweep
@@ -728,6 +833,7 @@ pub fn signer_for_principal(p: Principal) -> Signer {
         Principal::Author => Signer::Author,
         Principal::Creator => Signer::Creator,
         Principal::Claimant => Signer::Claimant,
+        Principal::Assignee => Signer::Assignee,
     }
 }
 
@@ -783,6 +889,11 @@ fn fill(path: &str, fixture: &Fixture, repo: &str, id_source: IdSource) -> Strin
         IdSource::ClaimedBountyId => fixture.claimed_bounty_id.as_str(),
         IdSource::SubmittedBountyId => fixture.submitted_bounty_id.as_str(),
         IdSource::OpenBountyId => fixture.open_bounty_id.as_str(),
+        // #195 (F3): the caller-self task rows, each keyed to a seeded task in the
+        // state its gate needs (pending for claim, claimed for complete/fail).
+        IdSource::ClaimableTaskId => fixture.claimable_task_id.as_str(),
+        IdSource::CompletableTaskId => fixture.completable_task_id.as_str(),
+        IdSource::FailableTaskId => fixture.failable_task_id.as_str(),
     };
     path.replace("{owner}", &fixture.owner_did)
         .replace("{repo}", repo)
@@ -954,6 +1065,45 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
                 withheld: Vec::new(),
             }]
         }
+        GateClass::SignerSelfGate => {
+            // #195 (F3, KTD-1): a body-field caller-self gate. The shared body runs
+            // through `fill()` so `{owner}` resolves to the real owner DID; hostile
+            // and control differ ONLY in signer. Hostile: a Stranger signs but the
+            // body names the owner -> `did_matches(stranger, owner) == false` -> 403.
+            // Control: the Owner signs and the body names the owner -> match ->
+            // Not403. (The repo arg to `fill` is inert here: task/register paths
+            // carry no `{repo}` placeholder, but the signature requires it.)
+            let path = fill(row.path, fixture, &fixture.public_repo, row.id_source);
+            let filled_body = row
+                .body
+                .map(|b| fill(b, fixture, &fixture.public_repo, row.id_source).into_bytes())
+                .unwrap_or_default();
+            vec![
+                Probe {
+                    label: format!("{} signer-self hostile (stranger)", row.handler),
+                    method: method.clone(),
+                    path: path.clone(),
+                    body: filled_body.clone(),
+                    signer: Signer::Stranger,
+                    json,
+                    expect: Expect::Deny(403),
+                    // Each gate returns a fixed forbidden() message before serializing
+                    // any entity, and nothing private is seeded on this substrate, so
+                    // an empty withheld list is the honest assertion (KTD-4).
+                    withheld: Vec::new(),
+                },
+                Probe {
+                    label: format!("{} signer-self control (owner)", row.handler),
+                    method,
+                    path,
+                    body: filled_body,
+                    signer: Signer::Owner,
+                    json,
+                    expect: Expect::Not403,
+                    withheld: Vec::new(),
+                },
+            ]
+        }
     }
 }
 
@@ -970,17 +1120,23 @@ pub mod tests_support {
         let author = Keypair::generate();
         let creator = Keypair::generate();
         let claimant = Keypair::generate();
+        let assignee = Keypair::generate();
         Fixture {
             author_did: author.did().to_string(),
             creator_did: creator.did().to_string(),
             claimant_did: claimant.did().to_string(),
+            assignee_did: assignee.did().to_string(),
             author,
             creator,
             claimant,
+            assignee,
             bounty_id: "bounty-uuid-1234".to_string(),
             claimed_bounty_id: "claimed-bounty-uuid-1234".to_string(),
             submitted_bounty_id: "submitted-bounty-uuid-1234".to_string(),
             open_bounty_id: "open-bounty-uuid-1234".to_string(),
+            claimable_task_id: "claimable-task-uuid-1234".to_string(),
+            completable_task_id: "completable-task-uuid-1234".to_string(),
+            failable_task_id: "failable-task-uuid-1234".to_string(),
             issue_id: "issue-uuid-1234".to_string(),
             priv_issue_id: "priv-issue-uuid-1234".to_string(),
             priv_bounty_id: "priv-bounty-uuid-1234".to_string(),

--- a/crates/gitlawb-node/tests/support/probe.rs
+++ b/crates/gitlawb-node/tests/support/probe.rs
@@ -35,6 +35,18 @@ pub struct Fixture {
     /// The id (UUID) of the seeded disputable bounty, filled into the
     /// `dispute_bounty` row's `{id}` placeholder (IdSource::BountyId).
     pub bounty_id: String,
+    /// #195 (N2): one bounty per status-gated bounty mutation row. submit/approve/
+    /// cancel check the bounty's STATUS before their 403 auth gate, so the stranger
+    /// hostile only exercises the gate against a bounty in the gate-reaching
+    /// status, and each row's authorized twin CONSUMES that status; the rows
+    /// cannot share a bounty. This one stays "claimed" (create + claim) for the
+    /// submit_bounty row (IdSource::ClaimedBountyId).
+    pub claimed_bounty_id: String,
+    /// Driven to "submitted" (create + claim + submit) for the approve_bounty row
+    /// (IdSource::SubmittedBountyId).
+    pub submitted_bounty_id: String,
+    /// Left "open" (create only) for the cancel_bounty row (IdSource::OpenBountyId).
+    pub open_bounty_id: String,
     /// The id (UUID) of the seeded issue (authored by `author`), filled into the
     /// `close_issue` row's `{id}` placeholder (IdSource::IssueId).
     pub issue_id: String,
@@ -123,13 +135,50 @@ impl Fixture {
         // public repo (both signers can read it). Seeded over HTTP through the real
         // handlers — create (creator) then claim (claimant) — because the DB seam is
         // private to TestNode and a test-only seed method would be a src/ change.
-        let bounty_id = seed_disputable_bounty(
+        let bounty_id = seed_bounty_at_stage(
             node,
             &owner_did,
             pub_repo,
             &creator,
-            &creator_did,
             &claimant,
+            "prober dispute bounty",
+            BountyStage::Claimed,
+        )
+        .await;
+
+        // #195 (N2): submit/approve/cancel check the bounty's STATUS before their
+        // 403 auth gate, so each row gets its OWN bounty in the gate-reaching
+        // status (claimed / submitted / open); the authorized twins consume that
+        // status, so the rows cannot share a bounty with each other or with the
+        // disputable one above.
+        let claimed_bounty_id = seed_bounty_at_stage(
+            node,
+            &owner_did,
+            pub_repo,
+            &creator,
+            &claimant,
+            "prober submit bounty",
+            BountyStage::Claimed,
+        )
+        .await;
+        let submitted_bounty_id = seed_bounty_at_stage(
+            node,
+            &owner_did,
+            pub_repo,
+            &creator,
+            &claimant,
+            "prober approve bounty",
+            BountyStage::Submitted,
+        )
+        .await;
+        let open_bounty_id = seed_bounty_at_stage(
+            node,
+            &owner_did,
+            pub_repo,
+            &creator,
+            &claimant,
+            "prober cancel bounty",
+            BountyStage::Open,
         )
         .await;
 
@@ -200,6 +249,9 @@ impl Fixture {
             creator_did,
             claimant_did,
             bounty_id,
+            claimed_bounty_id,
+            submitted_bounty_id,
+            open_bounty_id,
             issue_id,
             priv_issue_id,
             priv_bounty_id,
@@ -256,22 +308,38 @@ async fn seed_authored_issue(
         .to_string()
 }
 
-/// Seed a bounty in the `claimed` state (creator + claimant set) so the
-/// dispute_bounty creator/claimant arms reach their auth check, and return its id.
+/// How far along its lifecycle a seeded bounty is driven, expressed as the real
+/// API transitions that get it there. Each status-gated bounty row needs the
+/// status its handler's pre-auth check demands (#195, N2): cancel needs "open",
+/// submit (and dispute) need "claimed", approve needs "submitted".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BountyStage {
+    /// `create_bounty` only: status "open".
+    Open,
+    /// create + claim: status "claimed" (creator + claimant set).
+    Claimed,
+    /// create + claim + submit: status "submitted".
+    Submitted,
+}
+
+/// Seed a bounty on the (public) repo, drive it to `stage`, and return its id.
 ///
-/// Driven through the real HTTP handlers rather than the DB: `create_bounty` mints
-/// a UUID id we read back from the response, and `claim_bounty` sets the claimant.
-/// Both read-gate the (public) repo, which the creator/claimant can read. The
-/// bounty lands `status = "claimed"`; because its deadline has not been exceeded,
-/// a creator/claimant dispute returns 400 (not 403) after passing auth — which is
-/// still a Not403 twin — while a stranger is denied 403 at the auth check first.
-async fn seed_disputable_bounty(
+/// Driven through the real HTTP handlers rather than the DB: `create_bounty`
+/// (creator) mints a UUID id we read back from the response, `claim_bounty`
+/// (claimant) sets the claimant, `submit_bounty` (claimant) records a PR id.
+/// All read-gate the (public) repo, which the creator/claimant can read, and the
+/// claim/submit transitions pass their own auth gates as the claimant. A Claimed
+/// bounty's deadline has not been exceeded, so a creator/claimant dispute returns
+/// 400 (not 403) after passing auth, which is still a Not403 twin, while a
+/// stranger is denied 403 at the auth check first.
+async fn seed_bounty_at_stage(
     node: &TestNode,
     owner_did: &str,
     repo: &str,
     creator: &Keypair,
-    creator_did: &str,
     claimant: &Keypair,
+    title: &str,
+    stage: BountyStage,
 ) -> String {
     use super::signing::signed_request;
 
@@ -279,7 +347,7 @@ async fn seed_disputable_bounty(
 
     // create_bounty (creator) -> 201 with the minted BountyRecord (carries the id).
     let create_path = format!("/api/v1/repos/{owner_did}/{repo}/bounties");
-    let body = br#"{"title":"prober dispute bounty","amount":1}"#.to_vec();
+    let body = format!(r#"{{"title":"{title}","amount":1}}"#).into_bytes();
     let resp = signed_request(
         &client,
         reqwest::Method::POST,
@@ -302,11 +370,15 @@ async fn seed_disputable_bounty(
         .as_str()
         .expect("created bounty carries an id")
         .to_string();
+    let creator_did = creator.did().to_string();
     assert_eq!(
         created["creator_did"].as_str(),
-        Some(creator_did),
+        Some(creator_did.as_str()),
         "seeded bounty creator must be the fixture creator"
     );
+    if stage == BountyStage::Open {
+        return bounty_id;
+    }
 
     // claim_bounty (claimant) -> 200, status becomes "claimed", claimant recorded.
     let claim_path = format!("/api/v1/bounties/{bounty_id}/claim");
@@ -326,6 +398,30 @@ async fn seed_disputable_bounty(
         resp.status().as_u16(),
         200,
         "seeding: bounty claim must return 200 (claimant can read the public repo)"
+    );
+    if stage == BountyStage::Claimed {
+        return bounty_id;
+    }
+
+    // submit_bounty (claimant) -> 200, status becomes "submitted". pr_id is a
+    // free-text column; the seed value only needs to clear serde.
+    let submit_path = format!("/api/v1/bounties/{bounty_id}/submit");
+    let resp = signed_request(
+        &client,
+        reqwest::Method::POST,
+        &node.base_url,
+        &submit_path,
+        br#"{"pr_id":"1"}"#.to_vec(),
+        claimant,
+    )
+    .header("content-type", "application/json")
+    .send()
+    .await
+    .expect("submit bounty sends");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "seeding: bounty submit must return 200 (the claimant passes the submit gate)"
     );
 
     bounty_id
@@ -503,7 +599,8 @@ async fn seed_private_push_and_cert(
         String::from_utf8_lossy(&out.stdout).trim().to_string()
     };
 
-    run(&["init", "-q", "-b", "main"], &work);
+    // Pin sha1 to match the served fixture repo; init.defaultObjectFormat=sha256 skews the OIDs.
+    run(&["init", "-q", "-b", "main", "--object-format=sha1"], &work);
     run(&["config", "user.email", "t@t"], &work);
     run(&["config", "user.name", "t"], &work);
     // Keep `public/a.txt` (the seeded blob) on the new main so the get_blob /
@@ -681,6 +778,11 @@ fn fill(path: &str, fixture: &Fixture, repo: &str, id_source: IdSource) -> Strin
         IdSource::PrivIssueId => fixture.priv_issue_id.as_str(),
         IdSource::PrivBountyId => fixture.priv_bounty_id.as_str(),
         IdSource::CertId => fixture.cert_id.as_str(),
+        // #195 (N2): the status-gated bounty mutations, each keyed to the bounty
+        // seeded in its gate-reaching status.
+        IdSource::ClaimedBountyId => fixture.claimed_bounty_id.as_str(),
+        IdSource::SubmittedBountyId => fixture.submitted_bounty_id.as_str(),
+        IdSource::OpenBountyId => fixture.open_bounty_id.as_str(),
     };
     path.replace("{owner}", &fixture.owner_did)
         .replace("{repo}", repo)
@@ -876,6 +978,9 @@ pub mod tests_support {
             creator,
             claimant,
             bounty_id: "bounty-uuid-1234".to_string(),
+            claimed_bounty_id: "claimed-bounty-uuid-1234".to_string(),
+            submitted_bounty_id: "submitted-bounty-uuid-1234".to_string(),
+            open_bounty_id: "open-bounty-uuid-1234".to_string(),
             issue_id: "issue-uuid-1234".to_string(),
             priv_issue_id: "priv-issue-uuid-1234".to_string(),
             priv_bounty_id: "priv-bounty-uuid-1234".to_string(),

--- a/crates/gitlawb-node/tests/support/probe.rs
+++ b/crates/gitlawb-node/tests/support/probe.rs
@@ -30,6 +30,10 @@ pub struct Fixture {
     /// against this so an anon caller gets the existence-hiding 404 and the owner
     /// twin gets 2xx.
     pub private_repo: String,
+    /// The private repo's internal id (UUID). A read-gate denial body must never
+    /// echo it: a 404 that serializes the private record's internal id has leaked
+    /// repository metadata just as much as the blob content (#195, F4).
+    pub private_repo_id: String,
     /// A seeded blob path present in both repos, for `{*path}` reads.
     pub content_path: String,
     /// The DISTINCTIVE secret bytes seeded into the private repo's blob. A
@@ -71,7 +75,7 @@ impl Fixture {
         // (full + short) is withheld too — a 404 naming the object's id has leaked
         // its existence just as much as its bytes.
         let private_secret = "TOPSECRET-PRIVREAD-U3".to_string();
-        node.seed_repo(&owner_did, priv_repo, false).await;
+        let private_repo_id = node.seed_repo(&owner_did, priv_repo, false).await;
         let priv_oids = node.seed_bare_repo(
             &owner_did,
             priv_repo,
@@ -88,6 +92,7 @@ impl Fixture {
             public_repo: pub_repo.to_string(),
             public_repo_id,
             private_repo: priv_repo.to_string(),
+            private_repo_id,
             content_path,
             private_secret,
             private_blob_oid,
@@ -184,24 +189,43 @@ pub fn probes_for(row: &Row, fixture: &Fixture) -> Vec<Probe> {
         }
         GateClass::ReadGate => {
             let path = fill(row.path, fixture, &fixture.private_repo);
-            let mut v = vec![Probe {
-                label: format!("{} read-gate hostile", row.handler),
-                method: method.clone(),
-                path: path.clone(),
-                body: body.clone(),
-                signer: Signer::Anon,
-                json,
-                expect: Expect::Deny(404),
-                // INV-8: the private repo's blob and its OID are actually seeded
-                // here, so the 404 body must echo neither the secret content nor the
-                // blob OID (full or short). An empty withheld list would let a 404
-                // that spilled the private content pass as a clean denial.
-                withheld: vec![
-                    fixture.private_secret.clone(),
-                    fixture.private_blob_oid.clone(),
-                    fixture.private_blob_oid_short.clone(),
-                ],
-            }];
+            // INV-8: the private repo's blob and its OID are actually seeded here, so
+            // the 404 body must echo neither the secret content nor the blob OID
+            // (full or short) nor the private repo's internal id (#195, F4). An empty
+            // withheld list would let a 404 that spilled the private content pass as
+            // a clean denial.
+            let withheld = vec![
+                fixture.private_secret.clone(),
+                fixture.private_blob_oid.clone(),
+                fixture.private_blob_oid_short.clone(),
+                fixture.private_repo_id.clone(),
+            ];
+            let mut v = vec![
+                Probe {
+                    label: format!("{} read-gate hostile (anon)", row.handler),
+                    method: method.clone(),
+                    path: path.clone(),
+                    body: body.clone(),
+                    signer: Signer::Anon,
+                    json,
+                    expect: Expect::Deny(404),
+                    withheld: withheld.clone(),
+                },
+                // #195 (F1): a signed NON-READER must also get the existence-hiding
+                // 404 — a signature is not access (INV-12). Without this probe, a
+                // regression that treats any valid signature as authorized would leak
+                // the private repo while the anon probe stayed green.
+                Probe {
+                    label: format!("{} read-gate hostile (signed non-reader)", row.handler),
+                    method: method.clone(),
+                    path: path.clone(),
+                    body: body.clone(),
+                    signer: Signer::Stranger,
+                    json,
+                    expect: Expect::Deny(404),
+                    withheld: withheld.clone(),
+                },
+            ];
             // Positive twin: prove the 404 is the gate, not an absent entity.
             let twin = match row.reach {
                 Reach::ReaderReads => Probe {
@@ -265,6 +289,7 @@ mod tests {
             public_repo: "prober-pub".to_string(),
             public_repo_id: "pub-id".to_string(),
             private_repo: "prober-priv".to_string(),
+            private_repo_id: "priv-repo-uuid-0BADF00D".to_string(),
             content_path: "public/a.txt".to_string(),
             private_secret: "TOPSECRET-PRIVREAD-U3".to_string(),
             private_blob_oid: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
@@ -303,7 +328,7 @@ mod tests {
     }
 
     #[test]
-    fn read_gate_row_yields_anon_404_and_positive_twin() {
+    fn read_gate_row_yields_anon_and_stranger_404_and_positive_twin() {
         let row = Row {
             method: "GET",
             path: "/api/v1/repos/{owner}/{repo}/blob/{*path}",
@@ -315,9 +340,17 @@ mod tests {
         };
         let f = fx();
         let ps = probes_for(&row, &f);
-        assert_eq!(ps.len(), 2);
+        // anon hostile, signed-stranger hostile (#195 F1), owner twin.
+        assert_eq!(ps.len(), 3);
         assert_eq!(ps[0].signer, Signer::Anon);
         assert!(matches!(ps[0].expect, Expect::Deny(404)));
+        // #195 (F1): the signed non-reader hostile must also expect a 404 no-leak.
+        assert_eq!(ps[1].signer, Signer::Stranger);
+        assert!(matches!(ps[1].expect, Expect::Deny(404)));
+        assert!(
+            !ps[1].withheld.is_empty(),
+            "the signed-stranger hostile must carry the same withheld tokens"
+        );
         assert!(
             ps[0].path.contains("prober-priv"),
             "read-gate uses the private repo"
@@ -342,11 +375,11 @@ mod tests {
             ps[0].withheld.contains(&f.private_blob_oid_short),
             "the short blob OID prefix must be a withheld token"
         );
-        assert_eq!(ps[1].signer, Signer::Owner);
-        assert!(matches!(ps[1].expect, Expect::Ok2xx));
+        assert_eq!(ps[2].signer, Signer::Owner);
+        assert!(matches!(ps[2].expect, Expect::Ok2xx));
         // The granted twin returns the content, so it withholds nothing.
         assert!(
-            ps[1].withheld.is_empty(),
+            ps[2].withheld.is_empty(),
             "the granted read twin must not carry withheld tokens"
         );
     }
@@ -385,17 +418,22 @@ mod tests {
             reach: Reach::SiblingPublic("/api/v1/repos/{owner}/{repo}/blob/{*path}"),
         };
         let ps = probes_for(&row, &fx());
-        assert_eq!(ps.len(), 2);
+        // anon hostile, signed-stranger hostile (#195 F1), sibling-public twin.
+        assert_eq!(ps.len(), 3);
         // Hostile: anon on the withheld path -> 404.
         assert_eq!(ps[0].signer, Signer::Anon);
         assert!(matches!(ps[0].expect, Expect::Deny(404)));
         assert!(ps[0].path.ends_with("/blob/secret/x.txt"));
+        // Signed non-reader on the withheld path -> 404 too.
+        assert_eq!(ps[1].signer, Signer::Stranger);
+        assert!(matches!(ps[1].expect, Expect::Deny(404)));
+        assert!(ps[1].path.ends_with("/blob/secret/x.txt"));
         // Twin: anon on the sibling PUBLIC path -> non-empty 2xx (proves the 404
         // is path-scoped withholding, not a blanket refusal).
-        assert_eq!(ps[1].signer, Signer::Anon);
-        assert!(matches!(ps[1].expect, Expect::Ok2xx));
+        assert_eq!(ps[2].signer, Signer::Anon);
+        assert!(matches!(ps[2].expect, Expect::Ok2xx));
         assert!(
-            ps[1].path.contains("public/a.txt"),
+            ps[2].path.contains("public/a.txt"),
             "sibling template's {{*path}} is filled from the fixture content path"
         );
     }
@@ -439,6 +477,20 @@ mod tests {
         assert!(
             r.unwrap_err().contains(&f.private_secret),
             "the failure must name the leaked secret token"
+        );
+
+        // #195 (F4): a 404 that serialized the private repo's internal id (UUID) is
+        // a repository-metadata leak and must be flagged too — proving the UUID is a
+        // load-bearing withheld token, not just the blob content.
+        let leaking_meta = format!(r#"{{"error":"repo {} not found"}}"#, f.private_repo_id);
+        let rm = check_denied(404, &leaking_meta, 404, &tokens);
+        assert!(
+            rm.is_err(),
+            "a 404 body echoing the private repo id must be flagged: {rm:?}"
+        );
+        assert!(
+            rm.unwrap_err().contains(&f.private_repo_id),
+            "the failure must name the leaked private repo id token"
         );
 
         // A clean 404 (no private tokens) with the same tokens passes: the tokens do

--- a/crates/gitlawb-node/tests/support/routes.rs
+++ b/crates/gitlawb-node/tests/support/routes.rs
@@ -22,6 +22,13 @@ pub enum GateClass {
     /// `require_repo_owner` / `require_owner` / inline `did_matches(caller, owner)`
     /// -> `AppError::Forbidden` == 403. Probed with a validly-signed non-owner.
     OwnerGate,
+    /// A 403 gate with MORE THAN ONE authorizing principal (owner-OR-author,
+    /// creator-OR-claimant, …). Probed with a validly-signed stranger (403) plus
+    /// one Not403 twin per declared arm (`Row.principals`), so reverting ANY
+    /// single arm turns that arm's twin RED. A single-arm `OwnerGate` cannot
+    /// express this: it tests one identity, so the untested arm is invisible
+    /// (#195, F1).
+    MultiPrincipalGate,
     /// `authorize_repo_read` / `visibility_check` -> `RepoNotFound` == 404
     /// (existence-hiding). Probed with a non-reader against a private/withheld
     /// target. A 404 alone is ambiguous (a missing entity also 404s), so every
@@ -34,11 +41,26 @@ pub enum GateClass {
 impl GateClass {
     pub fn expected_status(self) -> u16 {
         match self {
-            GateClass::OwnerGate => 403,
+            GateClass::OwnerGate | GateClass::MultiPrincipalGate => 403,
             GateClass::ReadGate => 404,
             GateClass::SignatureRequired => 401,
         }
     }
+}
+
+/// An authorizing principal (arm) of a multi-principal 403 gate. Each maps to a
+/// distinct fixture identity in `probe.rs` so reverting one arm cannot silently
+/// re-collapse onto another (the original bug seeded `author == owner`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Principal {
+    /// The repo owner (`require_repo_owner` / `did_matches(caller, owner)`).
+    Owner,
+    /// The PR/issue author (`did_matches(caller, author_did)`).
+    Author,
+    /// The bounty creator (`did_matches(caller, creator_did)`).
+    Creator,
+    /// The bounty claimant (`did_matches(caller, claimant_did)`).
+    Claimant,
 }
 
 /// How a read-gate row's positive twin proves the 404 is the gate and not a
@@ -55,6 +77,23 @@ pub enum Reach {
     /// the 404 is path-scoped withholding, not a blanket/absent 404. Mirrors the
     /// existing U7/U8/anon_ipfs cases in `tests/deny_harness.rs`.
     SiblingPublic(&'static str),
+}
+
+/// How a row's `{id}` placeholder is filled. Most id-keyed paths use a fixed
+/// seed id (`"1"`), but some entities are keyed by a UUID minted at seed time
+/// (a bounty, a cert), so the fixture must inject the captured id per row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdSource {
+    /// `{id}` -> the fixed seed id `"1"` (static-template entities seeded at #1).
+    Fixed,
+    /// `{id}` -> the fixture's seeded disputable bounty id (UUID).
+    BountyId,
+    /// `{id}` -> the fixture's seeded issue id (UUID). The issue is stored as a
+    /// full git-JSON `IssueRecord` (authored by the fixture author), which a
+    /// bare `{"author":..}` seed cannot satisfy — close_issue deserializes the
+    /// whole record before reading its author, so the author arm needs the
+    /// complete record.
+    IssueId,
 }
 
 /// One deny-bearing route. `path` is a template with `{owner}`/`{repo}`/`{id}`
@@ -75,9 +114,16 @@ pub struct Row {
     pub needs: &'static [&'static str],
     /// Positive-twin strategy for read-gate rows.
     pub reach: Reach,
+    /// For `MultiPrincipalGate` rows, the authorizing arms this gate must drive
+    /// (one Not403 twin each). Empty for every other class — only meaningful for
+    /// `MultiPrincipalGate`, and the consistency test enforces that pairing.
+    pub principals: &'static [Principal],
+    /// How the `{id}` placeholder is filled for this row (see [`IdSource`]).
+    pub id_source: IdSource,
 }
 
 const NO_ENTITY: &[&str] = &[];
+const NO_PRINCIPAL: &[Principal] = &[];
 
 /// The deny-bearing route set. Owner-gate and signature-required tranches are
 /// fully verified against their handlers this session; the read-gate tranche is
@@ -94,24 +140,47 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: &["pr_number"],
             reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
+        // #195 (F1): close_pr / close_issue are owner-OR-author gates (pulls.rs:276,
+        // issues.rs:255). A plain OwnerGate tests only the owner arm, so reverting
+        // the author arm is invisible. MultiPrincipalGate drives BOTH arms.
         Row {
             method: "POST",
             path: "/api/v1/repos/{owner}/{repo}/pulls/{number}/close",
-            gate: GateClass::OwnerGate,
+            gate: GateClass::MultiPrincipalGate,
             handler: "pulls::close_pr",
             body: None,
             needs: &["pr_number"],
             reach: Reach::None,
+            principals: &[Principal::Owner, Principal::Author],
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "POST",
             path: "/api/v1/repos/{owner}/{repo}/issues/{id}/close",
-            gate: GateClass::OwnerGate,
+            gate: GateClass::MultiPrincipalGate,
             handler: "issues::close_issue",
             body: None,
             needs: &["issue_id"],
             reach: Reach::None,
+            principals: &[Principal::Owner, Principal::Author],
+            id_source: IdSource::IssueId,
+        },
+        // #195 (F1): dispute_bounty is creator-OR-claimant (bounties.rs:425). Not
+        // repo-scoped: it gates on the bounty's creator/claimant, so the row is
+        // id-keyed by the seeded disputable bounty's UUID (IdSource::BountyId).
+        Row {
+            method: "POST",
+            path: "/api/v1/bounties/{id}/dispute",
+            gate: GateClass::MultiPrincipalGate,
+            handler: "bounties::dispute_bounty",
+            body: None,
+            needs: &["bounty_id"],
+            reach: Reach::None,
+            principals: &[Principal::Creator, Principal::Claimant],
+            id_source: IdSource::BountyId,
         },
         Row {
             method: "POST",
@@ -121,6 +190,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: Some(r#"{"url":"https://e.example/h","events":["*"]}"#),
             needs: NO_ENTITY,
             reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "DELETE",
@@ -130,6 +201,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "POST",
@@ -139,6 +212,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: Some(r#"{"label":"bug"}"#),
             needs: NO_ENTITY,
             reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "DELETE",
@@ -148,6 +223,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "POST",
@@ -157,6 +234,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "DELETE",
@@ -166,6 +245,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "PUT",
@@ -175,6 +256,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: Some(r#"{"path_glob":"/","reader_dids":[]}"#),
             needs: NO_ENTITY,
             reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "DELETE",
@@ -184,6 +267,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: Some(r#"{"path_glob":"/"}"#),
             needs: NO_ENTITY,
             reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         // list_visibility is a 403 owner-gate despite being a GET (calls
         // require_owner); the /visibility mount chains put+delete+get, all gated.
@@ -195,6 +280,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         // ── Signature-required (401) — verified: git write route wrapped by the
         //    require_signature layer (add_auth_layers in server.rs). ─────────────
@@ -206,6 +293,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         // ── Read-gate (404) — verified: each handler calls
         //    authorize_repo_read / visibility_check on "/" which returns
@@ -225,6 +314,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         // #195 (F2): repo-root reads that gate on "/" — driven as real ReadGate rows
         // rather than source-only exemptions, so a runtime bypass that keeps the
@@ -237,6 +328,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -246,6 +339,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -255,6 +350,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -264,6 +361,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -273,6 +372,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         // Path-scoped read: get_blob gates on "/{path}" (repos.rs:390). The
         // fully-private fixture repo denies any path to anon (404); the owner
@@ -287,6 +388,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -296,6 +399,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -305,6 +410,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -314,6 +421,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -323,6 +432,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -332,6 +443,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -341,6 +454,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -350,6 +465,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -359,6 +476,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -368,6 +487,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         Row {
             method: "GET",
@@ -377,6 +498,8 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
         },
         // The read-gate handlers NOT driven here (deferred GET reads, read-gating
         // mutations, git smart-HTTP reads, the content-addressed read, and the
@@ -437,6 +560,86 @@ mod tests {
                     r.path
                 ),
             }
+
+            // `principals` is meaningful ONLY on MultiPrincipalGate rows: it must
+            // be non-empty there (a gate with no declared arm drives nothing) and
+            // empty everywhere else (a stray arm set on a non-multi row is a bug).
+            match r.gate {
+                GateClass::MultiPrincipalGate => assert!(
+                    !r.principals.is_empty(),
+                    "multi-principal row {} {} declares no authorizing arms",
+                    r.method,
+                    r.path
+                ),
+                _ => assert!(
+                    r.principals.is_empty(),
+                    "non-multi-principal row {} {} must not declare arms",
+                    r.method,
+                    r.path
+                ),
+            }
         }
+    }
+
+    /// STRUCTURAL enforcement (#195, F1): every `MultiPrincipalGate` row's
+    /// generator output must carry exactly one Not403 twin PER declared arm plus
+    /// the single stranger hostile, so a row that registered an arm but never
+    /// emits its twin (the vacuous-guard failure) fails HERE rather than in a
+    /// runtime sweep nobody re-runs. Invokes `probes_for` directly — the same
+    /// generator the real sweep drives — so the two cannot drift.
+    #[test]
+    fn multi_principal_rows_emit_one_twin_per_arm() {
+        use crate::support::probe::{probes_for, tests_support::fx, Expect, Signer};
+
+        let fixture = fx();
+        let mut checked = 0usize;
+        for r in deny_bearing_routes() {
+            if r.gate != GateClass::MultiPrincipalGate {
+                continue;
+            }
+            checked += 1;
+            let ps = probes_for(r, &fixture);
+
+            let hostile = ps
+                .iter()
+                .filter(|p| p.signer == Signer::Stranger && matches!(p.expect, Expect::Deny(403)))
+                .count();
+            assert_eq!(
+                hostile, 1,
+                "multi-principal row {} {} must drive exactly one stranger-403 hostile, drove {hostile}",
+                r.method, r.path
+            );
+
+            let twins = ps
+                .iter()
+                .filter(|p| matches!(p.expect, Expect::Not403))
+                .count();
+            assert_eq!(
+                twins,
+                r.principals.len(),
+                "multi-principal row {} {} declares {} arms but emits {twins} Not403 twins",
+                r.method,
+                r.path,
+                r.principals.len(),
+            );
+
+            // Each declared arm maps to a distinct signer, and every twin's signer
+            // is one of the declared arms (no phantom / wrong-arm twin).
+            for arm in r.principals {
+                let want = crate::support::probe::signer_for_principal(*arm);
+                let present = ps
+                    .iter()
+                    .any(|p| p.signer == want && matches!(p.expect, Expect::Not403));
+                assert!(
+                    present,
+                    "multi-principal row {} {} declares arm {:?} but emits no Not403 twin for it",
+                    r.method, r.path, arm
+                );
+            }
+        }
+        assert!(
+            checked >= 3,
+            "expected at least the three known multi-principal rows, checked {checked}"
+        );
     }
 }

--- a/crates/gitlawb-node/tests/support/routes.rs
+++ b/crates/gitlawb-node/tests/support/routes.rs
@@ -1,0 +1,269 @@
+//! U1: the deny-bearing route set for the invariant deny-prober.
+//!
+//! ONLY the routes that carry a runtime deny to assert live here: owner-gate
+//! (403), read-gate (404), and signature-required (401). Everything else on the
+//! surface (positive-only / public / signer-self) is NOT listed here; U4's
+//! completeness cross-check discharges those against the existing `authz_guard`
+//! classification in `crates/gitlawb-node/src/api/mod.rs`.
+//!
+//! Each row is classified by READING its handler, never inferred from the route
+//! name, and records the handler fn name so a reviewer can spot-check. Guessing
+//! is how a false test enters the sweep (the register_replica lesson: it looks
+//! like an owner-gate, it is signer-self; and list_visibility is a 403
+//! owner-gate despite being a GET).
+//!
+//! Rows are declarative (gate class + entities + reachability), not prebuilt
+//! requests, so Flavor B (the cross-surface differential prober) can reuse them
+//! (R9).
+
+/// The gate class of a deny-bearing route and the exact status its deny emits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateClass {
+    /// `require_repo_owner` / `require_owner` / inline `did_matches(caller, owner)`
+    /// -> `AppError::Forbidden` == 403. Probed with a validly-signed non-owner.
+    OwnerGate,
+    /// `authorize_repo_read` / `visibility_check` -> `RepoNotFound` == 404
+    /// (existence-hiding). Probed with a non-reader against a private/withheld
+    /// target. A 404 alone is ambiguous (a missing entity also 404s), so every
+    /// read-gate row carries a `Reach` positive twin.
+    ReadGate,
+    /// `require_signature` layer -> 401 on the git write routes. Probed unsigned.
+    SignatureRequired,
+}
+
+impl GateClass {
+    pub fn expected_status(self) -> u16 {
+        match self {
+            GateClass::OwnerGate => 403,
+            GateClass::ReadGate => 404,
+            GateClass::SignatureRequired => 401,
+        }
+    }
+}
+
+/// How a read-gate row's positive twin proves the 404 is the gate and not a
+/// merely-absent entity/repo. Owner-gate and signature rows use `None`
+/// (the owner-gate twin is the same request re-signed as the owner, handled by
+/// the probe generator from the class, not a path).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reach {
+    /// Not a read-gate row; no read-twin.
+    None,
+    /// The authorized reader/owner issues the same request and gets 2xx.
+    ReaderReads,
+    /// A sibling PUBLIC path on the same repo returns 2xx-with-content, proving
+    /// the 404 is path-scoped withholding, not a blanket/absent 404. Mirrors the
+    /// existing U7/U8/anon_ipfs cases in `tests/deny_harness.rs`.
+    SiblingPublic(&'static str),
+}
+
+/// One deny-bearing route. `path` is a template with `{owner}`/`{repo}`/`{id}`
+/// /`{number}`/`{*path}` placeholders the probe generator (U2) fills from the
+/// fixture. `needs` names the seeded sub-entities the path requires (empty for
+/// owner-gate rows: the gate fires before the entity lookup).
+#[derive(Debug, Clone, Copy)]
+pub struct Row {
+    pub method: &'static str,
+    pub path: &'static str,
+    pub gate: GateClass,
+    /// Handler fn name, recorded for review spot-check (per-row verification).
+    pub handler: &'static str,
+    /// Sample request body (JSON) or `None`. JSON bodies drive the
+    /// `Content-Type: application/json` the probe attaches to clear the extractor.
+    pub body: Option<&'static str>,
+    /// Seeded sub-entities the path template consumes.
+    pub needs: &'static [&'static str],
+    /// Positive-twin strategy for read-gate rows.
+    pub reach: Reach,
+}
+
+const NO_ENTITY: &[&str] = &[];
+
+/// The deny-bearing route set. Owner-gate and signature-required tranches are
+/// fully verified against their handlers this session; the read-gate tranche is
+/// populated as each handler's deny path (404-deny vs list-filter) is verified.
+pub fn deny_bearing_routes() -> &'static [Row] {
+    &[
+        // ── Owner-gate (403) — verified: each calls require_repo_owner /
+        //    require_owner / inline did_matches against the repo owner. ──────────
+        Row {
+            method: "POST",
+            path: "/api/v1/repos/{owner}/{repo}/pulls/{number}/merge",
+            gate: GateClass::OwnerGate,
+            handler: "pulls::merge_pr",
+            body: None,
+            needs: &["pr_number"],
+            reach: Reach::None,
+        },
+        Row {
+            method: "POST",
+            path: "/api/v1/repos/{owner}/{repo}/pulls/{number}/close",
+            gate: GateClass::OwnerGate,
+            handler: "pulls::close_pr",
+            body: None,
+            needs: &["pr_number"],
+            reach: Reach::None,
+        },
+        Row {
+            method: "POST",
+            path: "/api/v1/repos/{owner}/{repo}/issues/{id}/close",
+            gate: GateClass::OwnerGate,
+            handler: "issues::close_issue",
+            body: None,
+            needs: &["issue_id"],
+            reach: Reach::None,
+        },
+        Row {
+            method: "POST",
+            path: "/api/v1/repos/{owner}/{repo}/hooks",
+            gate: GateClass::OwnerGate,
+            handler: "webhooks::create_webhook",
+            body: Some(r#"{"url":"https://e.example/h","events":["*"]}"#),
+            needs: NO_ENTITY,
+            reach: Reach::None,
+        },
+        Row {
+            method: "DELETE",
+            path: "/api/v1/repos/{owner}/{repo}/hooks/{id}",
+            gate: GateClass::OwnerGate,
+            handler: "webhooks::delete_webhook",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::None,
+        },
+        Row {
+            method: "POST",
+            path: "/api/v1/repos/{owner}/{repo}/labels",
+            gate: GateClass::OwnerGate,
+            handler: "labels::add_label",
+            body: Some(r#"{"label":"bug"}"#),
+            needs: NO_ENTITY,
+            reach: Reach::None,
+        },
+        Row {
+            method: "DELETE",
+            path: "/api/v1/repos/{owner}/{repo}/labels/{label}",
+            gate: GateClass::OwnerGate,
+            handler: "labels::remove_label",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::None,
+        },
+        Row {
+            method: "POST",
+            path: "/api/v1/repos/{owner}/{repo}/branches/{branch}/protect",
+            gate: GateClass::OwnerGate,
+            handler: "protect::protect_branch",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::None,
+        },
+        Row {
+            method: "DELETE",
+            path: "/api/v1/repos/{owner}/{repo}/branches/{branch}/protect",
+            gate: GateClass::OwnerGate,
+            handler: "protect::unprotect_branch",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::None,
+        },
+        Row {
+            method: "PUT",
+            path: "/api/v1/repos/{owner}/{repo}/visibility",
+            gate: GateClass::OwnerGate,
+            handler: "visibility::set_visibility",
+            body: Some(r#"{"path_glob":"/","reader_dids":[]}"#),
+            needs: NO_ENTITY,
+            reach: Reach::None,
+        },
+        Row {
+            method: "DELETE",
+            path: "/api/v1/repos/{owner}/{repo}/visibility",
+            gate: GateClass::OwnerGate,
+            handler: "visibility::remove_visibility",
+            body: Some(r#"{"path_glob":"/"}"#),
+            needs: NO_ENTITY,
+            reach: Reach::None,
+        },
+        // list_visibility is a 403 owner-gate despite being a GET (calls
+        // require_owner); the /visibility mount chains put+delete+get, all gated.
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/visibility",
+            gate: GateClass::OwnerGate,
+            handler: "visibility::list_visibility",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::None,
+        },
+        // ── Signature-required (401) — verified: git write route wrapped by the
+        //    require_signature layer (add_auth_layers in server.rs). ─────────────
+        Row {
+            method: "POST",
+            path: "/{owner}/{repo}/git-receive-pack",
+            gate: GateClass::SignatureRequired,
+            handler: "repos::git_receive_pack",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::None,
+        },
+        // ── Read-gate (404) — TODO(U1 continuation): populate per-handler-verified
+        //    rows for the repo-scoped 404-reads (get_repo, get_blob, get_tree,
+        //    get_by_cid, git_info_refs, git_upload_pack, get_cert, get_issue,
+        //    get_pr, list_certs, list_issues, ...), each with a Reach twin, and
+        //    keep the global list-filter surfaces (list_repos, list_all_bounties)
+        //    OUT (they filter, they do not 404 — a different class, Flavor B).
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_internal_consistency() {
+        let rows = deny_bearing_routes();
+
+        // No duplicate method+path.
+        let mut seen = std::collections::HashSet::new();
+        for r in rows {
+            assert!(
+                seen.insert((r.method, r.path)),
+                "duplicate deny-bearing row: {} {}",
+                r.method,
+                r.path
+            );
+        }
+
+        for r in rows {
+            // Every row records its handler fn (review spot-check anchor).
+            assert!(
+                !r.handler.is_empty(),
+                "row {} {} has no handler",
+                r.method,
+                r.path
+            );
+
+            match r.gate {
+                // Every read-gate row must carry a positive twin, or a 404 from a
+                // merely-absent entity is indistinguishable from the gate's 404.
+                GateClass::ReadGate => assert_ne!(
+                    r.reach,
+                    Reach::None,
+                    "read-gate row {} {} needs a Reach positive twin",
+                    r.method,
+                    r.path
+                ),
+                // Owner-gate/signature rows use the class's own twin (owner re-sign)
+                // or none, never a read-path twin.
+                _ => assert_eq!(
+                    r.reach,
+                    Reach::None,
+                    "non-read-gate row {} {} must not carry a read twin",
+                    r.method,
+                    r.path
+                ),
+            }
+        }
+    }
+}

--- a/crates/gitlawb-node/tests/support/routes.rs
+++ b/crates/gitlawb-node/tests/support/routes.rs
@@ -22,12 +22,14 @@ pub enum GateClass {
     /// `require_repo_owner` / `require_owner` / inline `did_matches(caller, owner)`
     /// -> `AppError::Forbidden` == 403. Probed with a validly-signed non-owner.
     OwnerGate,
-    /// A 403 gate with MORE THAN ONE authorizing principal (owner-OR-author,
-    /// creator-OR-claimant, …). Probed with a validly-signed stranger (403) plus
-    /// one Not403 twin per declared arm (`Row.principals`), so reverting ANY
-    /// single arm turns that arm's twin RED. A single-arm `OwnerGate` cannot
-    /// express this: it tests one identity, so the untested arm is invisible
-    /// (#195, F1).
+    /// A 403 gate with ONE OR MORE NAMED authorizing principals (owner-OR-author,
+    /// creator-OR-claimant, claimant-only, …). Probed with a validly-signed
+    /// stranger (403) plus one Not403 twin per declared arm (`Row.principals`),
+    /// so reverting ANY single arm turns that arm's twin RED (#195, F1).
+    /// `OwnerGate` is the owner-arm special case; a single-arm gate whose
+    /// principal is NOT the repo owner (submit_bounty's claimant-only check,
+    /// approve/cancel's creator-only check) belongs here, because the point is
+    /// that the arms are DECLARED and each one gets its own twin (#195, N2).
     MultiPrincipalGate,
     /// `authorize_repo_read` / `visibility_check` -> `RepoNotFound` == 404
     /// (existence-hiding). Probed with a non-reader against a private/withheld
@@ -109,6 +111,22 @@ pub enum IdSource {
     /// then fetches the cert by id, so the owner-2xx twin needs a real cert whose
     /// repo_id is the private repo's (#195, U3).
     CertId,
+    /// `{id}` -> the fixture's bounty seeded in status "claimed" (#195, N2).
+    /// submit_bounty checks status BEFORE auth (bounties.rs:294), so the stranger
+    /// only reaches the claimant 403 gate on a bounty that is already "claimed";
+    /// the claimant twin then consumes that status (claimed -> submitted), so the
+    /// row needs its own bounty.
+    ClaimedBountyId,
+    /// `{id}` -> the fixture's bounty driven to status "submitted" (#195, N2).
+    /// approve_bounty's status check fires before its creator gate
+    /// (bounties.rs:334), so only a "submitted" bounty reaches the 403; the
+    /// creator twin consumes it (submitted -> completed).
+    SubmittedBountyId,
+    /// `{id}` -> the fixture's bounty left in status "open" (#195, N2).
+    /// cancel_bounty's status check fires before its creator gate
+    /// (bounties.rs:381), so only an "open" bounty reaches the 403; the creator
+    /// twin consumes it (open -> cancelled).
+    OpenBountyId,
 }
 
 /// One deny-bearing route. `path` is a template with `{owner}`/`{repo}`/`{id}`
@@ -196,6 +214,52 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             reach: Reach::None,
             principals: &[Principal::Creator, Principal::Claimant],
             id_source: IdSource::BountyId,
+        },
+        // #195 (N2): submit/approve/cancel each 403 a non-claimant/non-creator, but
+        // their STATUS check fires before the auth check, so each row gets its own
+        // bounty seeded in the gate-reaching status (claimed / submitted / open).
+        // The sweep drives probes in emission order (hostile first, probes_for),
+        // so the stranger 403 fires while the bounty still holds that status; the
+        // arm twin then consumes it (submit: claimed -> submitted, approve:
+        // submitted -> completed, cancel: open -> cancelled), which is why the
+        // rows cannot share a bounty with each other or with dispute_bounty.
+        Row {
+            method: "POST",
+            path: "/api/v1/bounties/{id}/submit",
+            gate: GateClass::MultiPrincipalGate,
+            handler: "bounties::submit_bounty",
+            // pr_id is a free-text column (no FK); any string clears serde and
+            // the UPDATE. The gate fires before the value is used.
+            body: Some(r#"{"pr_id":"1"}"#),
+            needs: &["claimed_bounty_id"],
+            reach: Reach::None,
+            principals: &[Principal::Claimant],
+            id_source: IdSource::ClaimedBountyId,
+        },
+        Row {
+            method: "POST",
+            path: "/api/v1/bounties/{id}/approve",
+            gate: GateClass::MultiPrincipalGate,
+            handler: "bounties::approve_bounty",
+            // ApproveBountyRequest's only field (tx_hash) is Option, so an empty
+            // JSON object clears the Json extractor; a missing body would 4xx at
+            // the extractor, before the gate under test.
+            body: Some(r#"{}"#),
+            needs: &["submitted_bounty_id"],
+            reach: Reach::None,
+            principals: &[Principal::Creator],
+            id_source: IdSource::SubmittedBountyId,
+        },
+        Row {
+            method: "POST",
+            path: "/api/v1/bounties/{id}/cancel",
+            gate: GateClass::MultiPrincipalGate,
+            handler: "bounties::cancel_bounty",
+            body: None,
+            needs: &["open_bounty_id"],
+            reach: Reach::None,
+            principals: &[Principal::Creator],
+            id_source: IdSource::OpenBountyId,
         },
         Row {
             method: "POST",
@@ -804,8 +868,9 @@ mod tests {
             );
         }
         assert!(
-            checked >= 3,
-            "expected at least the three known multi-principal rows, checked {checked}"
+            checked >= 6,
+            "expected at least the six known multi-principal rows (close_pr, \
+             close_issue, dispute/submit/approve/cancel bounty), checked {checked}"
         );
     }
 }

--- a/crates/gitlawb-node/tests/support/routes.rs
+++ b/crates/gitlawb-node/tests/support/routes.rs
@@ -1,10 +1,17 @@
 //! U1: the deny-bearing route set for the invariant deny-prober.
 //!
-//! ONLY the routes that carry a runtime deny to assert live here: owner-gate
-//! (403), read-gate (404), and signature-required (401). Everything else on the
-//! surface (positive-only / public / signer-self) is NOT listed here; U4's
-//! completeness cross-check discharges those against the existing `authz_guard`
-//! classification in `crates/gitlawb-node/src/api/mod.rs`.
+//! Every route that carries a runtime deny to assert lives here: owner-gate
+//! (403), multi-principal (403), read-gate (404), signature-required (401), and
+//! caller-self / actor (403): `SignerSelfGate` for the request-body field
+//! bindings (create_task delegator, claim_task assignee, register did) and
+//! `MultiPrincipalGate` with the assignee arm for the complete/fail actor gates.
+//! The completeness cross-check in `deny_harness.rs` derives the caller-self set
+//! from `src/api` and requires each `did_matches(caller, X)` handler to be a
+//! driven row, so a new one cannot silently escape the sweep.
+//!
+//! Scope: this doc claims the REST/api surface only. The parallel GraphQL
+//! mutation caller-self gates (`src/graphql/mutation.rs`) are out of this
+//! harness and fenced separately (#219).
 //!
 //! Each row is classified by READING its handler, never inferred from the route
 //! name, and records the handler fn name so a reviewer can spot-check. Guessing
@@ -38,12 +45,22 @@ pub enum GateClass {
     ReadGate,
     /// `require_signature` layer -> 401 on the git write routes. Probed unsigned.
     SignatureRequired,
+    /// A caller-self 403 gate that binds a DID field in the request BODY to the
+    /// authenticated signer (`did_matches(caller, &body.<field>_did)`): create_task
+    /// (delegator_did), claim_task (assignee_did), register (did). Probed with a
+    /// validly-signed stranger whose body names the OWNER (mismatch -> 403) plus an
+    /// owner control whose body names the owner (match -> Not403). Distinct from
+    /// `OwnerGate`: the bound identity is a body field, not the stored repo owner,
+    /// and the completeness classifier keys on exactly that (#195, F3, KTD-1). The
+    /// actor-vs-stored caller-self gates (complete_task/fail_task) are the
+    /// `MultiPrincipalGate` assignee-arm shape instead, not this class.
+    SignerSelfGate,
 }
 
 impl GateClass {
     pub fn expected_status(self) -> u16 {
         match self {
-            GateClass::OwnerGate | GateClass::MultiPrincipalGate => 403,
+            GateClass::OwnerGate | GateClass::MultiPrincipalGate | GateClass::SignerSelfGate => 403,
             GateClass::ReadGate => 404,
             GateClass::SignatureRequired => 401,
         }
@@ -63,6 +80,11 @@ pub enum Principal {
     Creator,
     /// The bounty claimant (`did_matches(caller, claimant_did)`).
     Claimant,
+    /// The task assignee (`did_matches(caller, stored assignee_did)`): the actor
+    /// arm of complete_task / fail_task (#195, F3). Unlike the field-binding
+    /// `SignerSelfGate`, the identity is the task's STORED assignee, so the arm is
+    /// driven against a seeded claimed task, not a body field.
+    Assignee,
 }
 
 /// How a read-gate row's positive twin proves the 404 is the gate and not a
@@ -127,6 +149,17 @@ pub enum IdSource {
     /// (bounties.rs:381), so only an "open" bounty reaches the 403; the creator
     /// twin consumes it (open -> cancelled).
     OpenBountyId,
+    /// `{id}` -> the fixture's task seeded "pending" (#195, F3). The claim_task
+    /// caller-self gate fires before the DB claim, so the stranger 403 does not
+    /// consume it; the owner control then claims it (pending -> claimed).
+    ClaimableTaskId,
+    /// `{id}` -> the fixture's task seeded "claimed" by the assignee (#195, F3).
+    /// complete_task's assignee actor gate reaches it; the assignee twin then
+    /// finishes it (claimed -> completed).
+    CompletableTaskId,
+    /// `{id}` -> a second assignee-claimed task (#195, F3), so fail_task's twin
+    /// (claimed -> failed) does not race complete_task for one entity.
+    FailableTaskId,
 }
 
 /// One deny-bearing route. `path` is a template with `{owner}`/`{repo}`/`{id}`
@@ -709,6 +742,84 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             principals: NO_PRINCIPAL,
             id_source: IdSource::Fixed,
         },
+        // ── Caller-self / actor (403), #195 (F3). The task/register handlers carry
+        //    genuine caller-self 403 gates a bypass would expose (impersonate a
+        //    delegator/assignee, or forge a trust row for a DID you don't control).
+        //    Before this change they were marker-only (INV-21 vacuous); now each is
+        //    driven hostile-then-authorized. The field-binding shape (a body DID
+        //    field must equal the caller) is `SignerSelfGate`; the actor-vs-stored
+        //    shape (caller must equal the task's stored assignee) is
+        //    `MultiPrincipalGate` with the Assignee arm. Register is DRIVEN, not
+        //    excused: the harness runs icaptcha inert (spawn_node never inits the
+        //    verifier), so a stranger-signed POST /api/register reaches the 403.
+        Row {
+            method: "POST",
+            path: "/api/v1/tasks",
+            gate: GateClass::SignerSelfGate,
+            handler: "tasks::create_task",
+            // delegator_did must equal the signer (tasks.rs:101). Stranger names the
+            // owner -> mismatch -> 403; owner names the owner -> match -> 201.
+            body: Some(r#"{"kind":"review","capability":"read","delegator_did":"{owner}"}"#),
+            needs: NO_ENTITY,
+            reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
+        },
+        Row {
+            method: "POST",
+            path: "/api/v1/tasks/{id}/claim",
+            gate: GateClass::SignerSelfGate,
+            handler: "tasks::claim_task",
+            // assignee_did must equal the signer (tasks.rs:174); the gate fires
+            // before the DB claim, so the stranger 403 leaves the pending task for
+            // the owner control to claim.
+            body: Some(r#"{"assignee_did":"{owner}"}"#),
+            needs: &["claimable_task_id"],
+            reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::ClaimableTaskId,
+        },
+        Row {
+            method: "POST",
+            path: "/api/register",
+            gate: GateClass::SignerSelfGate,
+            handler: "register::register",
+            // did must equal the signer (register.rs:55). The did must parse
+            // (register.rs:50) so the 403 is reached, so `{owner}` is a real DID.
+            // `message` is an unknown field serde ignores.
+            body: Some(r#"{"did":"{owner}","capabilities":[],"message":"probe"}"#),
+            needs: NO_ENTITY,
+            reach: Reach::None,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
+        },
+        Row {
+            method: "POST",
+            path: "/api/v1/tasks/{id}/complete",
+            gate: GateClass::MultiPrincipalGate,
+            handler: "tasks::complete_task",
+            // Caller must equal the task's STORED assignee (tasks.rs:220). Driven
+            // against a claimed task: stranger -> 403, the assignee arm -> 200.
+            body: Some(r#"{"result":"ok"}"#),
+            needs: &["completable_task_id"],
+            reach: Reach::None,
+            principals: &[Principal::Assignee],
+            id_source: IdSource::CompletableTaskId,
+        },
+        Row {
+            method: "POST",
+            path: "/api/v1/tasks/{id}/fail",
+            gate: GateClass::MultiPrincipalGate,
+            handler: "tasks::fail_task",
+            // Caller must equal the task's STORED assignee (tasks.rs:273). Its own
+            // claimed task so the assignee twin (claimed -> failed) does not race
+            // complete_task's.
+            body: Some(r#"{"reason":"x"}"#),
+            needs: &["failable_task_id"],
+            reach: Reach::None,
+            principals: &[Principal::Assignee],
+            id_source: IdSource::FailableTaskId,
+        },
         // The read-gate handlers NOT driven here (deferred GET reads, read-gating
         // mutations, git smart-HTTP reads, the content-addressed read, and the
         // global list-filters) are no longer tracked by free-text prose: they are
@@ -868,9 +979,81 @@ mod tests {
             );
         }
         assert!(
-            checked >= 6,
-            "expected at least the six known multi-principal rows (close_pr, \
-             close_issue, dispute/submit/approve/cancel bounty), checked {checked}"
+            checked >= 8,
+            "expected at least the eight known multi-principal rows (close_pr, \
+             close_issue, dispute/submit/approve/cancel bounty, complete_task, \
+             fail_task), checked {checked}"
+        );
+    }
+
+    /// STRUCTURAL enforcement for `SignerSelfGate` rows (#195, F3): each caller-self
+    /// field-binding row's generator output must be exactly one Stranger/Deny(403)
+    /// hostile plus one Owner/Not403 control, and both bodies must bind the self
+    /// field to the owner DID (so the hostile is a real signer-vs-body mismatch and
+    /// the control a real match). Mirrors `multi_principal_rows_emit_one_twin_per_arm`
+    /// so a SignerSelfGate row that stopped emitting its twin (the vacuous-guard
+    /// failure) fails HERE, not only in a DB sweep nobody re-runs. Invokes
+    /// `probes_for` directly, the same generator the real sweep drives.
+    #[test]
+    fn signer_self_rows_emit_one_hostile_and_one_control() {
+        use crate::support::probe::{probes_for, tests_support::fx, Expect, Signer};
+
+        let fixture = fx();
+        let mut checked = 0usize;
+        for r in deny_bearing_routes() {
+            if r.gate != GateClass::SignerSelfGate {
+                continue;
+            }
+            checked += 1;
+            let ps = probes_for(r, &fixture);
+            assert_eq!(
+                ps.len(),
+                2,
+                "signer-self row {} {} must emit exactly two probes, emitted {}",
+                r.method,
+                r.path,
+                ps.len()
+            );
+
+            let hostile = ps
+                .iter()
+                .filter(|p| p.signer == Signer::Stranger && matches!(p.expect, Expect::Deny(403)))
+                .count();
+            assert_eq!(
+                hostile, 1,
+                "signer-self row {} {} must drive exactly one stranger-403 hostile, drove {hostile}",
+                r.method, r.path
+            );
+
+            let control = ps
+                .iter()
+                .filter(|p| p.signer == Signer::Owner && matches!(p.expect, Expect::Not403))
+                .count();
+            assert_eq!(
+                control, 1,
+                "signer-self row {} {} must drive exactly one owner Not403 control, drove {control}",
+                r.method, r.path
+            );
+
+            // The bound self field (delegator_did / assignee_did / did) must resolve
+            // to the owner DID in BOTH bodies: the hostile is a stranger signing a
+            // body that names the owner (mismatch), the control an owner signing the
+            // same (match). A row whose body did not run through `fill()` would carry
+            // a literal `{owner}` and fail here.
+            for p in &ps {
+                let body = String::from_utf8(p.body.clone()).expect("probe body is UTF-8 JSON");
+                assert!(
+                    body.contains(&fixture.owner_did),
+                    "signer-self row {} {} body must bind the self field to the owner DID, got {body}",
+                    r.method,
+                    r.path
+                );
+            }
+        }
+        assert!(
+            checked >= 3,
+            "expected at least the three SignerSelfGate rows (create_task, claim_task, \
+             register), checked {checked}"
         );
     }
 }

--- a/crates/gitlawb-node/tests/support/routes.rs
+++ b/crates/gitlawb-node/tests/support/routes.rs
@@ -94,6 +94,21 @@ pub enum IdSource {
     /// whole record before reading its author, so the author arm needs the
     /// complete record.
     IssueId,
+    /// `{id}` -> the fixture's seeded PRIVATE-repo issue id (UUID). Distinct from
+    /// `IssueId` (the public-repo close-gate issue): the get_issue /
+    /// list_issue_comments read-gate rows run against the PRIVATE repo, so their
+    /// `{id}` must be an issue that actually exists there (#195, F2/U3).
+    PrivIssueId,
+    /// `{id}` -> the fixture's seeded PRIVATE-repo bounty id (UUID). get_bounty is
+    /// NOT repo-scoped in its path (`/api/v1/bounties/{id}`) but read-gates on the
+    /// bounty's own repo; the bounty is seeded against the private repo so anon /
+    /// stranger get the existence-hiding 404 and the owner gets 2xx (#195, U3).
+    PrivBountyId,
+    /// `{id}` -> the fixture's seeded ref-certificate id (UUID), issued by a real
+    /// owner push to the private repo. get_cert read-gates the private repo on "/"
+    /// then fetches the cert by id, so the owner-2xx twin needs a real cert whose
+    /// repo_id is the private repo's (#195, U3).
+    CertId,
 }
 
 /// One deny-bearing route. `path` is a template with `{owner}`/`{repo}`/`{id}`
@@ -495,6 +510,132 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             path: "/api/v1/repos/{owner}/{repo}/encrypted-blobs",
             gate: GateClass::ReadGate,
             handler: "encrypted::list_encrypted_blobs",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
+        },
+        // #195 (F2, U3): sub-entity reads that gate on "/" (the private repo) but
+        // require the entity to EXIST at the request path for the owner-2xx twin.
+        // Each carries its own distinctive marker (seeded in probe.rs) added to the
+        // per-read withheld set, so a 404 that echoes THAT read's private content
+        // (issue title, PR title, cert signature, bounty title) fails — a status-
+        // only 404 check would be vacuous. These were source-only exemptions in
+        // READ_GATE_NOT_DRIVEN before; they are now driven as real ReadGate rows.
+        // get_issue: id-keyed by the seeded PRIVATE issue (marker in its title).
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/issues/{id}",
+            gate: GateClass::ReadGate,
+            handler: "issues::get_issue",
+            body: None,
+            needs: &["priv_issue_id"],
+            reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::PrivIssueId,
+        },
+        // list_issue_comments: parent issue must exist (private); child list may be
+        // empty — an empty `{"comments":[]}` is a non-empty 2xx body.
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/issues/{id}/comments",
+            gate: GateClass::ReadGate,
+            handler: "issues::list_issue_comments",
+            body: None,
+            needs: &["priv_issue_id"],
+            reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::PrivIssueId,
+        },
+        // get_pr: the seeded PRIVATE PR #1 (marker in its title).
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/pulls/{number}",
+            gate: GateClass::ReadGate,
+            handler: "pulls::get_pr",
+            body: None,
+            needs: &["priv_pr"],
+            reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
+        },
+        // get_pr_diff: the PRIVATE PR #1 has a real `feature` source branch with a
+        // marker file, so branch_diff_names(main, feature) is NON-EMPTY and the
+        // owner twin returns a real diff (a bail!/500 if the source ref were
+        // missing). The per-path visibility_check Deny-return is additionally
+        // driven by the hand-written get_pr_diff_withheld_path_is_denied test.
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/pulls/{number}/diff",
+            gate: GateClass::ReadGate,
+            handler: "pulls::get_pr_diff",
+            body: None,
+            needs: &["priv_pr"],
+            reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
+        },
+        // list_reviews / list_comments: parent PR #1 must exist (private); child
+        // lists may be empty.
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/pulls/{number}/reviews",
+            gate: GateClass::ReadGate,
+            handler: "pulls::list_reviews",
+            body: None,
+            needs: &["priv_pr"],
+            reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/pulls/{number}/comments",
+            gate: GateClass::ReadGate,
+            handler: "pulls::list_comments",
+            body: None,
+            needs: &["priv_pr"],
+            reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::Fixed,
+        },
+        // get_cert: id-keyed by a real ref-certificate issued by an owner push to
+        // the private repo (marker: the cert's own signature/ref content).
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/certs/{id}",
+            gate: GateClass::ReadGate,
+            handler: "certs::get_cert",
+            body: None,
+            needs: &["cert_id"],
+            reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::CertId,
+        },
+        // get_bounty: NOT repo-scoped in its path, read-gates on the bounty's repo.
+        // Seeded against the PRIVATE repo (marker in its title), id-keyed.
+        Row {
+            method: "GET",
+            path: "/api/v1/bounties/{id}",
+            gate: GateClass::ReadGate,
+            handler: "bounties::get_bounty",
+            body: None,
+            needs: &["priv_bounty_id"],
+            reach: Reach::ReaderReads,
+            principals: NO_PRINCIPAL,
+            id_source: IdSource::PrivBountyId,
+        },
+        // get_tree (path-scoped): genuinely ADDITIONAL to get_tree_root (Q1). Root
+        // gates on "/"; get_tree gates on the REQUESTED subtree (N3,
+        // authorize_repo_read(&gate_path)), a distinct path-scoped Deny surface. The
+        // {*path} fills to the private content path, so a non-reader is denied the
+        // subtree listing and the owner gets a non-empty 2xx.
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/tree/{*path}",
+            gate: GateClass::ReadGate,
+            handler: "repos::get_tree",
             body: None,
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,

--- a/crates/gitlawb-node/tests/support/routes.rs
+++ b/crates/gitlawb-node/tests/support/routes.rs
@@ -226,6 +226,36 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
         },
+        // #195 (F2): repo-root reads that gate on "/" — driven as real ReadGate rows
+        // rather than source-only exemptions, so a runtime bypass that keeps the
+        // authorize_repo_read/visibility_check marker but leaks is caught.
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/star",
+            gate: GateClass::ReadGate,
+            handler: "stars::get_star_status",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/icaptcha-proof",
+            gate: GateClass::ReadGate,
+            handler: "repos::get_icaptcha_proof",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/encrypted-blobs/replicate",
+            gate: GateClass::ReadGate,
+            handler: "encrypted::replicate_encrypted_blobs",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
         Row {
             method: "GET",
             path: "/api/v1/repos/{owner}/{repo}/commits",

--- a/crates/gitlawb-node/tests/support/routes.rs
+++ b/crates/gitlawb-node/tests/support/routes.rs
@@ -520,7 +520,7 @@ pub fn deny_bearing_routes() -> &'static [Row] {
         // require the entity to EXIST at the request path for the owner-2xx twin.
         // Each carries its own distinctive marker (seeded in probe.rs) added to the
         // per-read withheld set, so a 404 that echoes THAT read's private content
-        // (issue title, PR title, cert signature, bounty title) fails — a status-
+        // (issue title, PR title, PR diff, bounty title) fails — a status-
         // only 404 check would be vacuous. These were source-only exemptions in
         // READ_GATE_NOT_DRIVEN before; they are now driven as real ReadGate rows.
         // get_issue: id-keyed by the seeded PRIVATE issue (marker in its title).
@@ -601,7 +601,10 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             id_source: IdSource::Fixed,
         },
         // get_cert: id-keyed by a real ref-certificate issued by an owner push to
-        // the private repo (marker: the cert's own signature/ref content).
+        // the private repo. No cert-content marker is seeded: get_cert read-gates
+        // the repo on "/" and 404s a non-reader BEFORE fetching the cert, so cert
+        // fields cannot reach the deny body — the repo-scoped tokens (private_repo_id,
+        // private_secret) plus the status check carry the no-leak assertion here.
         Row {
             method: "GET",
             path: "/api/v1/repos/{owner}/{repo}/certs/{id}",
@@ -777,6 +780,28 @@ mod tests {
                     r.method, r.path, arm
                 );
             }
+
+            // The twins' signers must be DISTINCT and number the declared arms. The
+            // per-arm any() check above is satisfied by a single twin when two arms
+            // map to the same Signer (a signer_for_principal collision), so without
+            // this a wrong mapping would pass with one arm silently untested.
+            let mut twin_signers: Vec<Signer> = ps
+                .iter()
+                .filter(|p| matches!(p.expect, Expect::Not403))
+                .map(|p| p.signer)
+                .collect();
+            twin_signers.sort_by_key(|s| format!("{s:?}"));
+            twin_signers.dedup();
+            assert_eq!(
+                twin_signers.len(),
+                r.principals.len(),
+                "multi-principal row {} {} emits twins with {} DISTINCT signers but declares {} arms \
+                 (Principal->Signer collision?)",
+                r.method,
+                r.path,
+                twin_signers.len(),
+                r.principals.len(),
+            );
         }
         assert!(
             checked >= 3,

--- a/crates/gitlawb-node/tests/support/routes.rs
+++ b/crates/gitlawb-node/tests/support/routes.rs
@@ -207,12 +207,162 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             needs: NO_ENTITY,
             reach: Reach::None,
         },
-        // ── Read-gate (404) — TODO(U1 continuation): populate per-handler-verified
-        //    rows for the repo-scoped 404-reads (get_repo, get_blob, get_tree,
-        //    get_by_cid, git_info_refs, git_upload_pack, get_cert, get_issue,
-        //    get_pr, list_certs, list_issues, ...), each with a Reach twin, and
-        //    keep the global list-filter surfaces (list_repos, list_all_bounties)
-        //    OUT (they filter, they do not 404 — a different class, Flavor B).
+        // ── Read-gate (404) — verified: each handler calls
+        //    authorize_repo_read / visibility_check on "/" which returns
+        //    AppError::RepoNotFound (404) when a non-reader hits a private repo
+        //    (api/mod.rs:44-62). The Reach twin is the owner issuing the same
+        //    request against the private repo and getting 2xx, proving the 404 is
+        //    the gate and not a merely-absent entity/repo. Every row here gates on
+        //    the whole repo ("/"), so ReaderReads (owner re-read) is the twin;
+        //    the fully-private fixture repo needs no per-row sub-entity seeding
+        //    because these reads either return the seeded repo/blob or an empty
+        //    2xx list.
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}",
+            gate: GateClass::ReadGate,
+            handler: "repos::get_repo",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/commits",
+            gate: GateClass::ReadGate,
+            handler: "repos::list_commits",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/tree",
+            gate: GateClass::ReadGate,
+            handler: "repos::get_tree_root",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        // Path-scoped read: get_blob gates on "/{path}" (repos.rs:390). The
+        // fully-private fixture repo denies any path to anon (404); the owner
+        // reads the seeded blob at content_path and gets 2xx bytes. (Path-scoped
+        // subtree WITHHOLDING on a *public* repo — the SiblingPublic twin — is
+        // already covered by the U7/U8 cases in deny_harness.rs.)
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/blob/{*path}",
+            gate: GateClass::ReadGate,
+            handler: "repos::get_blob",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/refs",
+            gate: GateClass::ReadGate,
+            handler: "repos::list_refs",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/issues",
+            gate: GateClass::ReadGate,
+            handler: "issues::list_issues",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/labels",
+            gate: GateClass::ReadGate,
+            handler: "labels::list_labels",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/certs",
+            gate: GateClass::ReadGate,
+            handler: "certs::list_certs",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/events",
+            gate: GateClass::ReadGate,
+            handler: "events::list_repo_events",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/pulls",
+            gate: GateClass::ReadGate,
+            handler: "pulls::list_prs",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/changelog",
+            gate: GateClass::ReadGate,
+            handler: "changelog::get_changelog",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/bounties",
+            gate: GateClass::ReadGate,
+            handler: "bounties::list_repo_bounties",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/withheld-paths",
+            gate: GateClass::ReadGate,
+            handler: "visibility::withheld_paths",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        Row {
+            method: "GET",
+            path: "/api/v1/repos/{owner}/{repo}/encrypted-blobs",
+            gate: GateClass::ReadGate,
+            handler: "encrypted::list_encrypted_blobs",
+            body: None,
+            needs: NO_ENTITY,
+            reach: Reach::ReaderReads,
+        },
+        // DEFERRED read-gate rows (each verified to gate on "/", but the owner
+        // 2xx twin needs a seeded sub-entity the fixture does not yet create, so
+        // they land with the fixture expansion that seeds them):
+        //   get_issue/{id}, get_pr/{number}, get_pr_diff, list_issue_comments,
+        //   list_reviews, list_comments (need a seeded issue/PR),
+        //   get_cert/{id} (cert), get_bounty/{id} (bounty), get_encrypted_blob/
+        //   {oid} (encrypted blob). Path-scoped get_tree/{*path} needs a seeded
+        //   sub-directory. The git smart-HTTP reads (git_info_refs,
+        //   git_upload_pack, ?service= query) and ipfs::get_by_cid are covered by
+        //   the existing U7/U8/anon_ipfs cases in deny_harness.rs.
+        // EXCLUDED (not 404-deny reads): list_repos, list_federated_repos,
+        //   list_all_bounties, list_ref_updates (global list-FILTER: 200 with the
+        //   unreadable rows removed, never a 404); list_webhooks,
+        //   list_protected_branches, list_replicas (KNOWN_UNGATED, api/mod.rs);
+        //   list_visibility (owner-gate 403, already in the owner-gate tranche).
     ]
 }
 

--- a/crates/gitlawb-node/tests/support/routes.rs
+++ b/crates/gitlawb-node/tests/support/routes.rs
@@ -348,21 +348,14 @@ pub fn deny_bearing_routes() -> &'static [Row] {
             needs: NO_ENTITY,
             reach: Reach::ReaderReads,
         },
-        // DEFERRED read-gate rows (each verified to gate on "/", but the owner
-        // 2xx twin needs a seeded sub-entity the fixture does not yet create, so
-        // they land with the fixture expansion that seeds them):
-        //   get_issue/{id}, get_pr/{number}, get_pr_diff, list_issue_comments,
-        //   list_reviews, list_comments (need a seeded issue/PR),
-        //   get_cert/{id} (cert), get_bounty/{id} (bounty), get_encrypted_blob/
-        //   {oid} (encrypted blob). Path-scoped get_tree/{*path} needs a seeded
-        //   sub-directory. The git smart-HTTP reads (git_info_refs,
-        //   git_upload_pack, ?service= query) and ipfs::get_by_cid are covered by
-        //   the existing U7/U8/anon_ipfs cases in deny_harness.rs.
-        // EXCLUDED (not 404-deny reads): list_repos, list_federated_repos,
-        //   list_all_bounties, list_ref_updates (global list-FILTER: 200 with the
-        //   unreadable rows removed, never a 404); list_webhooks,
-        //   list_protected_branches, list_replicas (KNOWN_UNGATED, api/mod.rs);
-        //   list_visibility (owner-gate 403, already in the owner-gate tranche).
+        // The read-gate handlers NOT driven here (deferred GET reads, read-gating
+        // mutations, git smart-HTTP reads, the content-addressed read, and the
+        // global list-filters) are no longer tracked by free-text prose: they are
+        // ENFORCED in deny_harness.rs's `READ_GATE_NOT_DRIVEN` allowlist, which the
+        // `every_read_gate_handler_is_driven_or_explicitly_allowlisted` guard checks
+        // against a live scan of every read-gate marker in src/api. That is the
+        // single source of truth — adding/removing a driven read row here without
+        // updating the allowlist trips the guard.
     ]
 }
 


### PR DESCRIPTION
Stacks on #194 (base `feat/real-node-deny-harness`), reusing its real-node spawn rig and RFC-9421 signing client. Review after #194.

This turns the hand-written deny cases into a driven registry: one declarative table of every route that carries a runtime deny, and a sweep that boots a real node and drives each one hostile-then-authorized.

## What's here

- **Registry** (`tests/support/routes.rs`): every deny-bearing route as a row (owner-gate 403, read-gate 404, signature 401), each classified by reading its handler, not the route name. 12 owner-gate + 1 signature + 14 repo-scoped read rows.
- **Probe generator** (`tests/support/probe.rs`): a two-repo fixture (public owner-gate substrate, private read-gate substrate, plus a seeded PR and issue so the author-or-owner close gates are reached rather than 404'd on an absent entity) and `probes_for`, which expands each row into the hostile request plus a positive twin so a deny for the wrong reason cannot false-pass.
- **Runtime sweep** (`deny_bearing_registry_...`): walks the registry against a real node. Hostile probe must return the exact deny and leak nothing; owner-gate twins must reach the handler (not 403); read twins must return a non-empty 2xx (an empty 2xx is a denial rendered as success). A terminal invariant asserts one hostile probe per row was actually driven, so the sweep can't pass by testing nothing.
- **Completeness cross-check** (`completeness::...`, no DB): a source scrape of `server.rs` (multiline `.route` parser, floor 90) that keeps the registry honest: no row points at a route that no longer mounts, and no handler carrying an owner-gate marker escapes the registry. Complements the in-crate `authz_guard` egress guard (which proves handlers are gated) by proving the deny-bearing ones are actually driven, and reaches the non-API git mounts it never sees.

## Verification

Every deny class was mutation-verified load-bearing, RED-then-GREEN by execution: breaking `did_matches` drove the owner-gate hostile to 500 and, inverted, drove the owner twin to 403; neutering `authorize_repo_read` drove the read hostile to 200 and, as always-deny, the read twin to 404; the signature assertion was isolated at `git-receive-pack`; both completeness floors and both drift guards were tripped and named their target. All reverted. 22 harness tests green.

CI already runs this file on every PR (the `--features test-harness --test deny_harness` step added in #194), so U3 and U4 run there with no config change.
