### PR TITLE
fix(core): honor wildcard capabilities in Ucan::can, matching is_attenuated_by

### DIFF
--- a/crates/gitlawb-core/src/ucan.rs
+++ b/crates/gitlawb-core/src/ucan.rs
@@ -358,6 +358,24 @@ mod tests {
     }
 
     #[test]
+    fn can_honors_action_wildcard() {
+        let issuer = Keypair::generate();
+        let audience = Keypair::generate().did();
+
+        let ucan = Ucan::issue(
+            &issuer,
+            audience,
+            vec![Capability::new("gitlawb://repos/test/repo", "*")],
+            None,
+        )
+        .unwrap();
+
+        assert!(ucan.can("gitlawb://repos/test/repo", caps::GIT_PUSH));
+        assert!(ucan.can("gitlawb://repos/test/repo", caps::PR_MERGE));
+        assert!(!ucan.can("gitlawb://repos/other/repo", caps::GIT_PUSH));
+    }
+
+    #[test]
     fn bootstrap_ucan() {
         let issuer = Keypair::generate();
         let audience = Keypair::generate().did();

--- a/crates/gitlawb-core/src/ucan.rs
+++ b/crates/gitlawb-core/src/ucan.rs
@@ -187,11 +187,17 @@ impl Ucan {
     }
 
     /// Check if this UCAN grants a specific capability on a resource.
+    ///
+    /// Mirrors `Capability::is_attenuated_by`'s wildcard semantics: a stored
+    /// capability of `with: "*"` or `can: "*"` / `"repo/admin"` covers any
+    /// requested resource/action, since a valid delegation chain can produce
+    /// exactly that capability (see `is_attenuated_by`).
     pub fn can(&self, resource: &str, action: &str) -> bool {
-        self.payload
-            .att
-            .iter()
-            .any(|cap| cap.with == resource && cap.can == action)
+        self.payload.att.iter().any(|cap| {
+            let resource_ok = cap.with == resource || cap.with == "*";
+            let action_ok = cap.can == action || cap.can == "*" || cap.can == caps::REPO_ADMIN;
+            resource_ok && action_ok
+        })
     }
 
     /// Encode to a compact JSON string (the wire format).
@@ -310,6 +316,45 @@ mod tests {
         assert_eq!(ucan.payload.aud, audience);
         assert!(ucan.can("gitlawb://repos/test/repo", caps::GIT_PUSH));
         assert!(!ucan.can("gitlawb://repos/test/repo", caps::PR_MERGE));
+    }
+
+    #[test]
+    fn can_honors_resource_wildcard() {
+        let issuer = Keypair::generate();
+        let audience = Keypair::generate().did();
+
+        let ucan = Ucan::issue(
+            &issuer,
+            audience,
+            vec![Capability::new("*", caps::GIT_PUSH)],
+            None,
+        )
+        .unwrap();
+
+        assert!(ucan.can("gitlawb://repos/test/repo", caps::GIT_PUSH));
+        assert!(ucan.can("gitlawb://repos/other/repo", caps::GIT_PUSH));
+        assert!(!ucan.can("gitlawb://repos/test/repo", caps::PR_MERGE));
+    }
+
+    #[test]
+    fn can_honors_repo_admin_action_wildcard() {
+        let issuer = Keypair::generate();
+        let audience = Keypair::generate().did();
+
+        let ucan = Ucan::issue(
+            &issuer,
+            audience,
+            vec![Capability::new(
+                "gitlawb://repos/test/repo",
+                caps::REPO_ADMIN,
+            )],
+            None,
+        )
+        .unwrap();
+
+        assert!(ucan.can("gitlawb://repos/test/repo", caps::GIT_PUSH));
+        assert!(ucan.can("gitlawb://repos/test/repo", caps::PR_MERGE));
+        assert!(!ucan.can("gitlawb://repos/other/repo", caps::GIT_PUSH));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Capability::is_attenuated_by` (`crates/gitlawb-core/src/ucan.rs:52-57`) treats `with: "*"` and `can: "*"` / `"repo/admin"` on a parent capability as wildcards during delegation-chain verification, so a valid UCAN can end with a capability like `{"with": "*", "can": "git/push"}`. But `Ucan::can` did strict equality on both fields, so that same capability could never match a concrete `(resource, action)` request at runtime.

Closes #199

## Why this is a bug fix, not a security fix

The mismatch only produces false negatives: a validly-delegated wildcard capability gets denied, never something unauthorized getting granted. It's also dormant today — `Ucan::can` isn't called from any production authorization path yet (`auth::caller_authorized_to_push` is pure `did_matches(...)`, with UCAN-capability checking noted as future Phase 2 work). This closes the gap before that wiring lands.

## What changed

- `Ucan::can` now mirrors `is_attenuated_by`'s wildcard semantics from the matching side: the stored capability plays the "parent" role, so `with == "*"` matches any resource and `can == "*"` or `"repo/admin"` matches any action.
- Two new tests: one for the resource wildcard, one for the `repo/admin` action wildcard.

## How a reviewer can verify

```
cargo test -p gitlawb-core ucan
cargo test -p gl ucan
cargo fmt --all -- --check
cargo clippy -p gitlawb-core --all-targets -- -D warnings
cargo clippy -p gl --all-targets -- -D warnings
cargo clippy -p gitlawb-node --all-targets -- -D warnings
```

## Kind of change

- [x] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change

## Protocol & signing impact

- [x] Touches DID / `did:key`, Ed25519 / RFC 9421 signatures, UCAN, ref certs, or P2P wire formats

No wire-format or signing change — `can()` is a local, in-process capability check over an already-verified UCAN's payload. Behavior only changes for capabilities that already contain a literal `"*"` or `"repo/admin"`, which `is_attenuated_by` already treats as wildcards during chain verification.