### PR TITLE
test(icaptcha): harden mock-consumed guard with proxy observer and blackhole tripwire

### DIFF
--- a/crates/icaptcha-client/tests/icaptcha_blackhole_tripwire.rs
+++ b/crates/icaptcha-client/tests/icaptcha_blackhole_tripwire.rs
@@ -13,6 +13,9 @@
 //! intercepts the connection and blocks it; without the blackhole the request
 //! would reach the server directly and succeed, turning this test RED.
 //!
+//! A positive control (disarmed blackhole) runs first, proving the fixture is
+//! valid and `127.0.0.2` is reachable.
+//!
 //! Design constraints (see issue #211):
 //!   - An unresolvable host would keep the request failing even when the guard
 //!     is disarmed (DNS failure masquerading as the blackhole), so we must use
@@ -45,10 +48,11 @@ fn serve_icaptcha(listener: TcpListener) {
         for stream in listener.incoming() {
             let Ok(mut stream) = stream else { continue };
             let mut buf = [0; 4096];
-            if stream.read(&mut buf).is_err() {
-                continue;
-            }
-            let request = String::from_utf8_lossy(&buf);
+            let n = match stream.read(&mut buf) {
+                Ok(0) | Err(_) => continue,
+                Ok(n) => n,
+            };
+            let request = String::from_utf8_lossy(&buf[..n]);
             let body = if request.contains("/v1/answer") {
                 r#"{"status":"passed","proof":"PROOF-TRIP"}"#
             } else {
@@ -63,32 +67,48 @@ fn serve_icaptcha(listener: TcpListener) {
     });
 }
 
-#[test]
-fn obtain_proof_fails_when_blackhole_blocks_non_loopback_destination() {
-    // Start a listener on 127.0.0.2, a loopback alias NOT listed in NO_PROXY.
-    let listener = TcpListener::bind("127.0.0.2:0")
-        .expect("bind on 127.0.0.2 (requires OS support for 127/8 loopback)");
-    let port = listener.local_addr().unwrap().port();
-    serve_icaptcha(listener);
-
-    support::arm_blackhole("http://127.0.0.1:1");
-
-    let cfg = IcaptchaCfg {
-        url: format!("http://127.0.0.2:{port}"),
+fn make_cfg(url: &str) -> IcaptchaCfg {
+    IcaptchaCfg {
+        url: url.to_string(),
         did: "did:key:zTEST".to_string(),
         level: 1,
         api_key: None,
+    }
+}
+
+#[test]
+fn obtain_proof_blackhole_tripwire() {
+    // Try to bind to 127.0.0.2 — skip if the OS doesn't route 127/8 as
+    // loopback (macOS needs an explicit alias).
+    let listener = match TcpListener::bind("127.0.0.2:0") {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("SKIP: 127.0.0.2 not available ({e}); skipping tripwire test");
+            return;
+        }
     };
+    let port = listener.local_addr().unwrap().port();
+    let url = format!("http://127.0.0.2:{port}");
+    serve_icaptcha(listener);
 
-    let solve = |_c: &Challenge| Some("silent".to_string());
-    let solver: &dyn Fn(&Challenge) -> Option<String> = &solve;
+    // ── Positive control: disarmed blackhole → obtain_proof succeeds ──────
+    let _disarmed_guard = support::disarm_proxy_env();
 
-    let result = obtain_proof(&cfg, Some(solver));
+    let solve: &dyn Fn(&Challenge) -> Option<String> = &|_c| Some("silent".to_string());
+    let cfg = make_cfg(&url);
+    let proof = obtain_proof(&cfg, Some(solve))
+        .expect("positive control: obtain_proof should succeed when the proxy is disarmed");
+    assert_eq!(
+        proof, "PROOF-TRIP",
+        "positive control: unexpected proof value"
+    );
+    drop(_disarmed_guard);
 
-    // The blackhole should block the connection via the proxy, producing a
-    // connect-level failure.  Narrowing the assertion to a reqwest connect
-    // error defends against fixture bugs that would otherwise make any error
-    // (e.g. deserialization of a truncated body) vacuously pass.
+    // ── Negative control: armed blackhole → obtain_proof fails with connect error ──
+    let _armed_guard = support::arm_blackhole("http://127.0.0.1:1");
+
+    let result = obtain_proof(&cfg, Some(solve));
+
     let err = result.expect_err(
         "blackhole tripwire: obtain_proof succeeded against 127.0.0.2, \
          meaning the proxy blackhole did not intercept the request; \

--- a/crates/icaptcha-client/tests/icaptcha_blackhole_tripwire.rs
+++ b/crates/icaptcha-client/tests/icaptcha_blackhole_tripwire.rs
@@ -1,0 +1,103 @@
+//! Tripwire: a committed negative case that locks the blackhole mechanism.
+//!
+//! The guard against non-loopback egress works because `obtain_proof` builds a
+//! stock `reqwest::blocking::Client` that inherits the process's proxy env vars.
+//! If the builder later gains `.no_proxy()` or a custom connector, the guard
+//! disarms silently and every existing test stays green (no live call is made
+//! during the normal mock-consumed run because the mock is on loopback and
+//! `NO_PROXY` covers it — the blackhole isn't even exercised).
+//!
+//! This test asserts that a non-loopback destination fails *while the blackhole
+//! is armed*. The destination is a local HTTP server on `127.0.0.2`, a loopback
+//! alias that `NO_PROXY` does NOT cover.  With the blackhole active the proxy
+//! intercepts the connection and blocks it; without the blackhole the request
+//! would reach the server directly and succeed, turning this test RED.
+//!
+//! Design constraints (see issue #211):
+//!   - An unresolvable host would keep the request failing even when the guard
+//!     is disarmed (DNS failure masquerading as the blackhole), so we must use
+//!     a reachable address.
+//!   - A real external host would make a live network call the moment the guard
+//!     disarms, and on any runner that cannot reach that host the connect error
+//!     again masquerades as the blackhole.  A local loopback alias avoids both
+//!     problems — it is always reachable when unblocked and never reaches the
+//!     real network.
+//!   - This depends on reqwest's `NO_PROXY` matching by exact IP (holds in the
+//!     pinned reqwest/hyper-util; recheck on upgrade) and on the OS routing
+//!     `127/8` as loopback (default on Linux; macOS may need an explicit alias).
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+
+use icaptcha_client::{obtain_proof, Challenge, IcaptchaCfg};
+
+mod support;
+
+/// A minimal HTTP server that responds to iCaptcha challenge and answer
+/// requests on a loopback alias NOT covered by NO_PROXY.
+///
+/// When the blackhole is working, the proxy should intercept these requests
+/// and `obtain_proof` should fail.  When the blackhole is disarmed, the
+/// requests reach this server and the flow succeeds.
+fn serve_icaptcha(listener: TcpListener) {
+    thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let mut buf = [0; 4096];
+            if stream.read(&mut buf).is_err() {
+                continue;
+            }
+            let request = String::from_utf8_lossy(&buf);
+            let body = if request.contains("/v1/answer") {
+                r#"{"status":"passed","proof":"PROOF-TRIP"}"#
+            } else {
+                r#"{"challengeId":"c1","type":"anagram","difficulty":1,"prompt":"listen","token":"tok-1"}"#
+            };
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            let _ = stream.write_all(response.as_bytes());
+        }
+    });
+}
+
+#[test]
+fn obtain_proof_fails_when_blackhole_blocks_non_loopback_destination() {
+    // Start a listener on 127.0.0.2, a loopback alias NOT listed in NO_PROXY.
+    let listener = TcpListener::bind("127.0.0.2:0")
+        .expect("bind on 127.0.0.2 (requires OS support for 127/8 loopback)");
+    let port = listener.local_addr().unwrap().port();
+    serve_icaptcha(listener);
+
+    support::arm_blackhole("http://127.0.0.1:1");
+
+    let cfg = IcaptchaCfg {
+        url: format!("http://127.0.0.2:{port}"),
+        did: "did:key:zTEST".to_string(),
+        level: 1,
+        api_key: None,
+    };
+
+    let solve = |_c: &Challenge| Some("silent".to_string());
+    let solver: &dyn Fn(&Challenge) -> Option<String> = &solve;
+
+    let result = obtain_proof(&cfg, Some(solver));
+
+    // The blackhole should block the connection via the proxy, producing a
+    // connect-level failure.  Narrowing the assertion to a reqwest connect
+    // error defends against fixture bugs that would otherwise make any error
+    // (e.g. deserialization of a truncated body) vacuously pass.
+    let err = result.expect_err(
+        "blackhole tripwire: obtain_proof succeeded against 127.0.0.2, \
+         meaning the proxy blackhole did not intercept the request; \
+         the no-live-call guard is disarmed",
+    );
+    assert!(
+        err.chain().any(|c| c
+            .downcast_ref::<reqwest::Error>()
+            .is_some_and(|e| e.is_connect())),
+        "expected a connect/proxy error, got: {err:#}",
+    );
+}

--- a/crates/icaptcha-client/tests/icaptcha_blackhole_tripwire.rs
+++ b/crates/icaptcha-client/tests/icaptcha_blackhole_tripwire.rs
@@ -27,7 +27,8 @@
 //!     real network.
 //!   - This depends on reqwest's `NO_PROXY` matching by exact IP (holds in the
 //!     pinned reqwest/hyper-util; recheck on upgrade) and on the OS routing
-//!     `127/8` as loopback (default on Linux; macOS may need an explicit alias).
+//!     `127/8` as loopback (default on Linux; macOS needs an explicit alias —
+//!     the test fails loudly, never skips, if `127.0.0.2` cannot be bound).
 
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -91,15 +92,19 @@ fn make_cfg(url: &str) -> IcaptchaCfg {
 
 #[test]
 fn obtain_proof_blackhole_tripwire() {
-    // Try to bind to 127.0.0.2 — skip if the OS doesn't route 127/8 as
-    // loopback (macOS needs an explicit alias).
-    let listener = match TcpListener::bind("127.0.0.2:0") {
-        Ok(l) => l,
-        Err(e) => {
-            eprintln!("SKIP: 127.0.0.2 not available ({e}); skipping tripwire test");
-            return;
-        }
-    };
+    // Bind to 127.0.0.2, a loopback alias NOT covered by NO_PROXY.  Linux
+    // routes the whole 127/8 block as loopback; macOS does not alias it by
+    // default (add one with `sudo ifconfig lo0 alias 127.0.0.2`).  Fail
+    // loudly on platforms that cannot bind it: a silent skip would report
+    // this tripwire as green while exercising none of the negative control,
+    // recreating the very gap it exists to close.
+    let listener = TcpListener::bind("127.0.0.2:0").expect(
+        "cannot bind 127.0.0.2 for the blackhole tripwire. Linux routes \
+         127/8 as loopback; on macOS add the alias first \
+         (`sudo ifconfig lo0 alias 127.0.0.2`). This test fails rather than \
+         silently skipping so a platform without the alias cannot count the \
+         negative control as passed.",
+    );
     let port = listener.local_addr().unwrap().port();
     let url = format!("http://127.0.0.2:{port}");
     serve_icaptcha(listener);

--- a/crates/icaptcha-client/tests/icaptcha_blackhole_tripwire.rs
+++ b/crates/icaptcha-client/tests/icaptcha_blackhole_tripwire.rs
@@ -47,11 +47,24 @@ fn serve_icaptcha(listener: TcpListener) {
     thread::spawn(move || {
         for stream in listener.incoming() {
             let Ok(mut stream) = stream else { continue };
-            let mut buf = [0; 4096];
-            let n = match stream.read(&mut buf) {
-                Ok(0) | Err(_) => continue,
-                Ok(n) => n,
-            };
+            // Read until the first \n (end of request line) so TCP
+            // segmentation cannot split the path out of a single read.
+            let mut buf = [0u8; 4096];
+            let mut n = 0usize;
+            while n < buf.len() {
+                match stream.read(&mut buf[n..]) {
+                    Ok(0) | Err(_) => break,
+                    Ok(read) => {
+                        n += read;
+                        if buf[..n].contains(&b'\n') {
+                            break;
+                        }
+                    }
+                }
+            }
+            if n == 0 {
+                continue;
+            }
             let request = String::from_utf8_lossy(&buf[..n]);
             let body = if request.contains("/v1/answer") {
                 r#"{"status":"passed","proof":"PROOF-TRIP"}"#

--- a/crates/icaptcha-client/tests/icaptcha_blackhole_tripwire.rs
+++ b/crates/icaptcha-client/tests/icaptcha_blackhole_tripwire.rs
@@ -7,14 +7,15 @@
 //! during the normal mock-consumed run because the mock is on loopback and
 //! `NO_PROXY` covers it — the blackhole isn't even exercised).
 //!
-//! This test asserts that a non-loopback destination fails *while the blackhole
-//! is armed*. The destination is a local HTTP server on `127.0.0.2`, a loopback
-//! alias that `NO_PROXY` does NOT cover.  With the blackhole active the proxy
-//! intercepts the connection and blocks it; without the blackhole the request
-//! would reach the server directly and succeed, turning this test RED.
+//! This test asserts that a destination the blackhole's `NO_PROXY` does NOT
+//! cover fails *while the blackhole is armed*.  The destination is a local HTTP
+//! server on `[::1]` (IPv6 loopback), which `NO_PROXY` (`127.0.0.1, localhost`)
+//! does not list.  With the blackhole active the proxy intercepts the
+//! connection and blocks it; without the blackhole the request would reach the
+//! server directly and succeed, turning this test RED.
 //!
 //! A positive control (disarmed blackhole) runs first, proving the fixture is
-//! valid and `127.0.0.2` is reachable.
+//! valid and `[::1]` is reachable.
 //!
 //! Design constraints (see issue #211):
 //!   - An unresolvable host would keep the request failing even when the guard
@@ -22,13 +23,17 @@
 //!     a reachable address.
 //!   - A real external host would make a live network call the moment the guard
 //!     disarms, and on any runner that cannot reach that host the connect error
-//!     again masquerades as the blackhole.  A local loopback alias avoids both
+//!     again masquerades as the blackhole.  A local loopback address avoids both
 //!     problems — it is always reachable when unblocked and never reaches the
 //!     real network.
-//!   - This depends on reqwest's `NO_PROXY` matching by exact IP (holds in the
-//!     pinned reqwest/hyper-util; recheck on upgrade) and on the OS routing
-//!     `127/8` as loopback (default on Linux; macOS needs an explicit alias —
-//!     the test fails loudly, never skips, if `127.0.0.2` cannot be bound).
+//!   - The address must NOT be covered by `NO_PROXY`, yet must exist on every
+//!     platform.  An arbitrary `127/8` alias is not portable: macOS only binds
+//!     `127.0.0.1` by default.  `[::1]` (IPv6 loopback) is present by default
+//!     on Linux, macOS, and Windows, and `NO_PROXY` only lists `127.0.0.1` and
+//!     `localhost`, so the blackhole still intercepts it.
+//!   - This depends on hyper-util's proxy matcher having no implicit loopback
+//!     bypass — a host is only proxied-around when literally listed in
+//!     `NO_PROXY` (verified in the pinned hyper-util; recheck on upgrade).
 
 use std::io::{Read, Write};
 use std::net::TcpListener;
@@ -39,7 +44,7 @@ use icaptcha_client::{obtain_proof, Challenge, IcaptchaCfg};
 mod support;
 
 /// A minimal HTTP server that responds to iCaptcha challenge and answer
-/// requests on a loopback alias NOT covered by NO_PROXY.
+/// requests on the IPv6 loopback address NOT covered by NO_PROXY.
 ///
 /// When the blackhole is working, the proxy should intercept these requests
 /// and `obtain_proof` should fail.  When the blackhole is disarmed, the
@@ -92,21 +97,21 @@ fn make_cfg(url: &str) -> IcaptchaCfg {
 
 #[test]
 fn obtain_proof_blackhole_tripwire() {
-    // Bind to 127.0.0.2, a loopback alias NOT covered by NO_PROXY.  Linux
-    // routes the whole 127/8 block as loopback; macOS does not alias it by
-    // default (add one with `sudo ifconfig lo0 alias 127.0.0.2`).  Fail
-    // loudly on platforms that cannot bind it: a silent skip would report
-    // this tripwire as green while exercising none of the negative control,
-    // recreating the very gap it exists to close.
-    let listener = TcpListener::bind("127.0.0.2:0").expect(
-        "cannot bind 127.0.0.2 for the blackhole tripwire. Linux routes \
-         127/8 as loopback; on macOS add the alias first \
-         (`sudo ifconfig lo0 alias 127.0.0.2`). This test fails rather than \
-         silently skipping so a platform without the alias cannot count the \
-         negative control as passed.",
+    // Bind to [::1], IPv6 loopback, which NO_PROXY (127.0.0.1, localhost)
+    // does not cover.  Unlike an arbitrary 127/8 alias, IPv6 loopback is
+    // present by default on Linux, macOS, and Windows, so the fixture is
+    // portable across platforms.  Fail loudly if it cannot be bound: a
+    // silent skip would report this tripwire as green while exercising
+    // none of the negative control, recreating the very gap it exists to
+    // close.
+    let listener = TcpListener::bind(("::1", 0)).expect(
+        "cannot bind [::1] for the blackhole tripwire. IPv6 loopback (::1) \
+         is present by default on Linux, macOS, and Windows. This test fails \
+         rather than silently skipping so a platform without it cannot count \
+         the negative control as passed.",
     );
     let port = listener.local_addr().unwrap().port();
-    let url = format!("http://127.0.0.2:{port}");
+    let url = format!("http://[::1]:{port}");
     serve_icaptcha(listener);
 
     // ── Positive control: disarmed blackhole → obtain_proof succeeds ──────
@@ -128,7 +133,7 @@ fn obtain_proof_blackhole_tripwire() {
     let result = obtain_proof(&cfg, Some(solve));
 
     let err = result.expect_err(
-        "blackhole tripwire: obtain_proof succeeded against 127.0.0.2, \
+        "blackhole tripwire: obtain_proof succeeded against [::1], \
          meaning the proxy blackhole did not intercept the request; \
          the no-live-call guard is disarmed",
     );

--- a/crates/icaptcha-client/tests/icaptcha_mock_consumed.rs
+++ b/crates/icaptcha-client/tests/icaptcha_mock_consumed.rs
@@ -28,13 +28,10 @@
 //! a runner with a working `HTTPS_PROXY` in its environment would route an https
 //! leak to `DEFAULT_URL` (which is https) through that proxy while the loopback
 //! mock is still consumed and this test stayed green. So we blackhole the
-//! scheme-specific variables too. No restore is needed: this file has a single
-//! `#[test]`, so it runs in its own process and the override never races a
-//! sibling test.
+//! scheme-specific variables too.
 
 use std::net::TcpListener;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::mpsc;
 use std::sync::Arc;
 
 use icaptcha_client::{obtain_proof, Challenge, IcaptchaCfg};
@@ -47,15 +44,10 @@ mod support;
 /// destination will be routed through this listener and increment the
 /// counter.  The test asserts zero connections, catching even
 /// fire-and-forget leaks whose errors are discarded.
-///
-/// Synchronization: a `flush()` call connects to the listener and waits
-/// for the accept thread to process it, ensuring all prior connections
-/// have been counted before returning.
 struct ProxyObserver {
     _listener: Arc<TcpListener>,
     port: u16,
     count: Arc<AtomicUsize>,
-    ack_rx: mpsc::Receiver<()>,
 }
 
 impl ProxyObserver {
@@ -64,14 +56,12 @@ impl ProxyObserver {
         let listener = Arc::new(TcpListener::bind("127.0.0.1:0").expect("bind proxy observer"));
         let port = listener.local_addr().unwrap().port();
         let count = Arc::new(AtomicUsize::new(0));
-        let (ack_tx, ack_rx) = mpsc::channel();
         let c = Arc::clone(&count);
         let l = Arc::clone(&listener);
         std::thread::spawn(move || {
             for stream in l.incoming() {
                 if stream.is_ok() {
                     c.fetch_add(1, Ordering::SeqCst);
-                    let _ = ack_tx.send(());
                 }
             }
         });
@@ -79,7 +69,6 @@ impl ProxyObserver {
             _listener: listener,
             port,
             count,
-            ack_rx,
         }
     }
 
@@ -87,32 +76,25 @@ impl ProxyObserver {
         self.port
     }
 
-    /// Block until all connections made up to this point have been counted
-    /// by the accept thread, then return the count of non-flush connections.
-    ///
-    /// We connect to ourselves to flush the accept backlog: the accept thread
-    /// picks up the flush connection, increments the count, and sends an ack.
-    /// Subtracting the flush connection from the total yields the leak count.
-    fn flush(&self) -> usize {
-        while self.ack_rx.try_recv().is_ok() {}
-
-        if let Ok(stream) = std::net::TcpStream::connect(format!("127.0.0.1:{}", self.port)) {
-            drop(stream);
+    /// Wait for the count to stabilise (no change across a sleep interval),
+    /// meaning all connections that were in the accept backlog when
+    /// `obtain_proof` returned have been drained and counted.
+    fn stabilise(&self) {
+        loop {
+            let prev = self.count.load(Ordering::SeqCst);
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            let curr = self.count.load(Ordering::SeqCst);
+            if curr == prev {
+                return;
+            }
         }
-        let _ = self
-            .ack_rx
-            .recv_timeout(std::time::Duration::from_millis(100));
-
-        self.count.load(Ordering::SeqCst).saturating_sub(1)
     }
 }
 
 #[test]
 fn obtain_proof_consumes_the_mocked_service_and_makes_no_live_call() {
-    // Start the proxy observer before setting env vars so the accept loop is
-    // ready when reqwest builds its client.
     let observer = ProxyObserver::bind();
-    support::arm_blackhole(&format!("http://127.0.0.1:{}", observer.port()));
+    let _guard = support::arm_blackhole(&format!("http://127.0.0.1:{}", observer.port()));
 
     let mut server = mockito::Server::new();
 
@@ -144,6 +126,8 @@ fn obtain_proof_consumes_the_mocked_service_and_makes_no_live_call() {
     let solve = |_c: &Challenge| Some("silent".to_string());
     let solver: &dyn Fn(&Challenge) -> Option<String> = &solve;
 
+    let count_before = observer.count.load(Ordering::SeqCst);
+
     let proof = obtain_proof(&cfg, Some(solver))
         .expect("obtain_proof should complete against the mocked service");
     assert_eq!(proof, "PROOF-XYZ");
@@ -151,13 +135,13 @@ fn obtain_proof_consumes_the_mocked_service_and_makes_no_live_call() {
     challenge.assert();
     answer.assert();
 
-    // Observer catch: flush any pending connections from the accept backlog,
-    // then assert zero. The flush synchronizes with the accept thread so a
-    // connection that arrived just before obtain_proof returned has been
-    // counted before we read.
+    // Stabilise the counter so any connections that arrived just before
+    // obtain_proof returned have been processed by the accept thread.
+    observer.stabilise();
+    let leak_count = observer.count.load(Ordering::SeqCst) - count_before;
+
     assert_eq!(
-        observer.flush(),
-        0,
+        leak_count, 0,
         "proxy observer caught leaked connections; \
          the blackhole failed to contain egress"
     );

--- a/crates/icaptcha-client/tests/icaptcha_mock_consumed.rs
+++ b/crates/icaptcha-client/tests/icaptcha_mock_consumed.rs
@@ -1,4 +1,4 @@
-//! INV-19 guard: the icaptcha flow must actually call the service (consume the
+//! INV-19 guard: the icaptcha flow must actually call the service (consuming the
 //! mock), not short-circuit or make a live call. If a future change let
 //! `obtain_proof` skip the network (e.g. a stray `cfg(test)` relaxation, which
 //! INV-19/INV-20 warn is inert across crates), the `.assert()` calls below go
@@ -8,10 +8,20 @@
 //! see a request that ALSO leaks the DID / answer / API key to `DEFAULT_URL` or
 //! any other origin (a different host the mock never observes). To make the
 //! "no live call" half of the guard load-bearing, the test blackholes every
-//! non-loopback destination: `NO_PROXY` lets the loopback mock through while a
-//! closed proxy port routes any other host nowhere, so the client contacting
-//! anything but the injected mock fails the request instead of silently
-//! succeeding. Point `cfg.url` at `DEFAULT_URL` and this test goes RED.
+//! non-loopback destination via a proxy observer: `NO_PROXY` lets the loopback
+//! mock through while every proxy variable routes any other host through a TCP
+//! listener that counts connections. Zero observed connections proves the
+//! blackhole held and no leak reached the network.
+//!
+//! Unlike a closed-port blackhole (which only catches propagating errors), the
+//! observer catches fire-and-forget leaks whose transport error is discarded.
+//!
+//! SCOPE: The observer only witnesses leaks issued on the path this test drives
+//! (a single passing round, 200 on both endpoints, no PoW, no Continue/Failed,
+//! no non-2xx response). A leak living on an error or retry branch makes no
+//! connection during the run and the zero-count assertion stays green. The
+//! guarantee covers only the exercised happy path and proxy-honoring transports;
+//! a future `.no_proxy()` or raw `TcpStream` bypasses the observer entirely.
 //!
 //! `ALL_PROXY` alone is NOT enough: reqwest honors the scheme-specific
 //! `HTTPS_PROXY` / `https_proxy` (and the http equivalents) OVER `ALL_PROXY`, so
@@ -22,36 +32,90 @@
 //! `#[test]`, so it runs in its own process and the override never races a
 //! sibling test.
 
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+
 use icaptcha_client::{obtain_proof, Challenge, IcaptchaCfg};
+
+mod support;
+
+/// A TCP listener that counts every accepted connection.
+///
+/// Acts as the proxy target: any leaked connection to a non-loopback
+/// destination will be routed through this listener and increment the
+/// counter.  The test asserts zero connections, catching even
+/// fire-and-forget leaks whose errors are discarded.
+///
+/// Synchronization: a `flush()` call connects to the listener and waits
+/// for the accept thread to process it, ensuring all prior connections
+/// have been counted before returning.
+struct ProxyObserver {
+    _listener: Arc<TcpListener>,
+    port: u16,
+    count: Arc<AtomicUsize>,
+    ack_rx: mpsc::Receiver<()>,
+}
+
+impl ProxyObserver {
+    /// Bind to a random port on loopback and start the accept loop.
+    fn bind() -> Self {
+        let listener = Arc::new(TcpListener::bind("127.0.0.1:0").expect("bind proxy observer"));
+        let port = listener.local_addr().unwrap().port();
+        let count = Arc::new(AtomicUsize::new(0));
+        let (ack_tx, ack_rx) = mpsc::channel();
+        let c = Arc::clone(&count);
+        let l = Arc::clone(&listener);
+        std::thread::spawn(move || {
+            for stream in l.incoming() {
+                if stream.is_ok() {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    let _ = ack_tx.send(());
+                }
+            }
+        });
+        ProxyObserver {
+            _listener: listener,
+            port,
+            count,
+            ack_rx,
+        }
+    }
+
+    fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Block until all connections made up to this point have been counted
+    /// by the accept thread, then return the count of non-flush connections.
+    ///
+    /// We connect to ourselves to flush the accept backlog: the accept thread
+    /// picks up the flush connection, increments the count, and sends an ack.
+    /// Subtracting the flush connection from the total yields the leak count.
+    fn flush(&self) -> usize {
+        while self.ack_rx.try_recv().is_ok() {}
+
+        if let Ok(stream) = std::net::TcpStream::connect(format!("127.0.0.1:{}", self.port)) {
+            drop(stream);
+        }
+        let _ = self
+            .ack_rx
+            .recv_timeout(std::time::Duration::from_millis(100));
+
+        self.count.load(Ordering::SeqCst).saturating_sub(1)
+    }
+}
 
 #[test]
 fn obtain_proof_consumes_the_mocked_service_and_makes_no_live_call() {
-    // Blackhole every non-loopback origin: the loopback mock bypasses the proxy
-    // (NO_PROXY); any other host is forced through a closed port and fails.
-    // reqwest reads these at client-build time, and obtain_proof builds its
-    // client fresh, so this bounds the transport for the whole flow.
-    //
-    // Set the scheme-specific vars too (both cases), not just ALL_PROXY: reqwest
-    // gives HTTPS_PROXY/https_proxy precedence over ALL_PROXY for https URLs, so
-    // an ALL_PROXY-only blackhole leaves an https leak to DEFAULT_URL open on a
-    // runner whose environment already has a working HTTPS_PROXY.
-    let blackhole = "http://127.0.0.1:1";
-    std::env::set_var("NO_PROXY", "127.0.0.1,localhost");
-    std::env::set_var("no_proxy", "127.0.0.1,localhost");
-    for var in [
-        "ALL_PROXY",
-        "all_proxy",
-        "HTTPS_PROXY",
-        "https_proxy",
-        "HTTP_PROXY",
-        "http_proxy",
-    ] {
-        std::env::set_var(var, blackhole);
-    }
+    // Start the proxy observer before setting env vars so the accept loop is
+    // ready when reqwest builds its client.
+    let observer = ProxyObserver::bind();
+    support::arm_blackhole(&format!("http://127.0.0.1:{}", observer.port()));
 
     let mut server = mockito::Server::new();
 
-    // The two endpoints the flow hits, each expected exactly once.
     let challenge = server
         .mock("POST", "/v1/challenge")
         .with_status(200)
@@ -77,9 +141,6 @@ fn obtain_proof_consumes_the_mocked_service_and_makes_no_live_call() {
         api_key: None,
     };
 
-    // "anagram" is not a built-in solvable type, so the flow consults this
-    // solver callback. The answer body itself does not matter: the mocked
-    // /v1/answer returns "passed" regardless of what is submitted.
     let solve = |_c: &Challenge| Some("silent".to_string());
     let solver: &dyn Fn(&Challenge) -> Option<String> = &solve;
 
@@ -87,8 +148,17 @@ fn obtain_proof_consumes_the_mocked_service_and_makes_no_live_call() {
         .expect("obtain_proof should complete against the mocked service");
     assert_eq!(proof, "PROOF-XYZ");
 
-    // INV-19: prove the client actually called the mocked endpoints. Had it made
-    // a live call or skipped the network, these would fail (mock never hit).
     challenge.assert();
     answer.assert();
+
+    // Observer catch: flush any pending connections from the accept backlog,
+    // then assert zero. The flush synchronizes with the accept thread so a
+    // connection that arrived just before obtain_proof returned has been
+    // counted before we read.
+    assert_eq!(
+        observer.flush(),
+        0,
+        "proxy observer caught leaked connections; \
+         the blackhole failed to contain egress"
+    );
 }

--- a/crates/icaptcha-client/tests/icaptcha_mock_consumed.rs
+++ b/crates/icaptcha-client/tests/icaptcha_mock_consumed.rs
@@ -10,17 +10,21 @@
 //! "no live call" half of the guard load-bearing, the test blackholes every
 //! non-loopback destination via a proxy observer: `NO_PROXY` lets the loopback
 //! mock through while every proxy variable routes any other host through a TCP
-//! listener that counts connections.  Zero observed connections (accepted
-//! during the `obtain_proof` call) proves no leak reached the network on the
-//! exercised synchronous path.
+//! listener that counts connections.  Zero observed connections proves no leak
+//! reached the network on the exercised path.
 //!
 //! The observer design counts every accepted connection regardless of whether
 //! the caller propagates the transport error, so it catches leaks that a
 //! closed-port blackhole (which only surfaces propagating errors) would miss.
-//! Because the accept loop runs in a detached thread, a leak whose TCP
-//! handshake completes after the counter is read is not observed — this is a
-//! known limitation of the single-threaded test harness, not a gap in the
-//! guard itself.
+//! To close the timing race inherent in a detached accept loop, the count is
+//! read only after a bounded drain: the test opens a flush connection and
+//! blocks until the accept thread has acknowledged (counted) it.  Because
+//! `accept()` hands out connections FIFO, every leak connection that completed
+//! its TCP handshake before the flush is counted before the flush — the
+//! assertion therefore covers all egress in flight when `obtain_proof`
+//! returned.  A leak that starts its handshake after the drain is outside the
+//! window; that is the irreducible limit of observing a detached accept loop,
+//! and it is the remaining, well-defined gap this guard accepts.
 //!
 //! SCOPE: The observer only witnesses leaks issued on the path this test drives
 //! (a single passing round, 200 on both endpoints, no PoW, no Continue/Failed,
@@ -36,9 +40,8 @@
 //! mock is still consumed and this test stayed green.  So we blackhole the
 //! scheme-specific variables too.
 
-use std::net::TcpListener;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Condvar, Mutex};
 
 use icaptcha_client::{obtain_proof, Challenge, IcaptchaCfg};
 
@@ -48,25 +51,30 @@ mod support;
 ///
 /// Acts as the proxy target: any leaked connection to a non-loopback
 /// destination will be routed through this listener and increment the
-/// counter.  The test then asserts zero connections (those accepted
-/// during the synchronous `obtain_proof` call).
+/// counter.  The count is guarded by a Mutex + Condvar so the test can block
+/// until the detached accept thread has acknowledged a specific connection
+/// (see [`ProxyObserver::drain`]).
 struct ProxyObserver {
     _listener: Arc<TcpListener>,
     port: u16,
-    count: Arc<AtomicUsize>,
+    count: Arc<Mutex<usize>>,
+    ack: Arc<Condvar>,
 }
 
 impl ProxyObserver {
     fn bind() -> Self {
         let listener = Arc::new(TcpListener::bind("127.0.0.1:0").expect("bind proxy observer"));
         let port = listener.local_addr().unwrap().port();
-        let count = Arc::new(AtomicUsize::new(0));
+        let count = Arc::new(Mutex::new(0usize));
+        let ack = Arc::new(Condvar::new());
         let c = Arc::clone(&count);
+        let a = Arc::clone(&ack);
         let l = Arc::clone(&listener);
         std::thread::spawn(move || {
             for stream in l.incoming() {
                 if stream.is_ok() {
-                    c.fetch_add(1, Ordering::SeqCst);
+                    *c.lock().unwrap() += 1;
+                    a.notify_all();
                 }
             }
         });
@@ -74,11 +82,42 @@ impl ProxyObserver {
             _listener: listener,
             port,
             count,
+            ack,
         }
     }
 
     fn port(&self) -> u16 {
         self.port
+    }
+
+    fn count(&self) -> usize {
+        *self.count.lock().unwrap()
+    }
+
+    /// Bounded acknowledgement barrier for the accept loop.
+    ///
+    /// Opens a flush connection to the listener and blocks until the accept
+    /// thread has counted it (bounded by a timeout).  Because `accept()`
+    /// hands out connections FIFO, once this flush is counted every
+    /// connection that completed its handshake before it is counted too.
+    /// This lets the test assert "no egress was accepted before this point"
+    /// without racing the detached accept loop.
+    fn drain(&self) {
+        let target = *self.count.lock().unwrap() + 1;
+        let _flush =
+            TcpStream::connect(("127.0.0.1", self.port)).expect("observer flush connection");
+        let mut count = self.count.lock().unwrap();
+        while *count < target {
+            let (guard, timed_out) = self
+                .ack
+                .wait_timeout(count, std::time::Duration::from_secs(5))
+                .unwrap();
+            count = guard;
+            assert!(
+                !timed_out.timed_out(),
+                "proxy observer drain timed out; accept loop stalled"
+            );
+        }
     }
 }
 
@@ -117,11 +156,7 @@ fn obtain_proof_consumes_the_mocked_service_and_makes_no_live_call() {
     let solve = |_c: &Challenge| Some("silent".to_string());
     let solver: &dyn Fn(&Challenge) -> Option<String> = &solve;
 
-    // Connections accepted during obtain_proof are counted by the
-    // detached accept thread.  We read the counter after the call
-    // returns; a leak whose TCP handshake completes after this read
-    // is outside the assertion's window (see module-level doc).
-    let count_before = observer.count.load(Ordering::SeqCst);
+    let count_before = observer.count();
 
     let proof = obtain_proof(&cfg, Some(solver))
         .expect("obtain_proof should complete against the mocked service");
@@ -130,7 +165,14 @@ fn obtain_proof_consumes_the_mocked_service_and_makes_no_live_call() {
     challenge.assert();
     answer.assert();
 
-    let leak_count = observer.count.load(Ordering::SeqCst) - count_before;
+    // Drain the accept loop before asserting: a leak connection that was
+    // accepted (or sitting in the backlog) when obtain_proof returned is
+    // counted ahead of the flush, so the count after drain reflects all
+    // egress in flight during the call.  The flush connection itself is
+    // accepted and counted too, so it is excluded from the leak accounting
+    // (exactly one connection).
+    observer.drain();
+    let leak_count = observer.count() - count_before - 1;
 
     assert_eq!(
         leak_count, 0,

--- a/crates/icaptcha-client/tests/icaptcha_mock_consumed.rs
+++ b/crates/icaptcha-client/tests/icaptcha_mock_consumed.rs
@@ -10,16 +10,22 @@
 //! "no live call" half of the guard load-bearing, the test blackholes every
 //! non-loopback destination via a proxy observer: `NO_PROXY` lets the loopback
 //! mock through while every proxy variable routes any other host through a TCP
-//! listener that counts connections. Zero observed connections proves the
-//! blackhole held and no leak reached the network.
+//! listener that counts connections.  Zero observed connections (accepted
+//! during the `obtain_proof` call) proves no leak reached the network on the
+//! exercised synchronous path.
 //!
-//! Unlike a closed-port blackhole (which only catches propagating errors), the
-//! observer catches fire-and-forget leaks whose transport error is discarded.
+//! The observer design counts every accepted connection regardless of whether
+//! the caller propagates the transport error, so it catches leaks that a
+//! closed-port blackhole (which only surfaces propagating errors) would miss.
+//! Because the accept loop runs in a detached thread, a leak whose TCP
+//! handshake completes after the counter is read is not observed — this is a
+//! known limitation of the single-threaded test harness, not a gap in the
+//! guard itself.
 //!
 //! SCOPE: The observer only witnesses leaks issued on the path this test drives
 //! (a single passing round, 200 on both endpoints, no PoW, no Continue/Failed,
-//! no non-2xx response). A leak living on an error or retry branch makes no
-//! connection during the run and the zero-count assertion stays green. The
+//! no non-2xx response).  A leak living on an error or retry branch makes no
+//! connection during the run and the zero-count assertion stays green.  The
 //! guarantee covers only the exercised happy path and proxy-honoring transports;
 //! a future `.no_proxy()` or raw `TcpStream` bypasses the observer entirely.
 //!
@@ -27,7 +33,7 @@
 //! `HTTPS_PROXY` / `https_proxy` (and the http equivalents) OVER `ALL_PROXY`, so
 //! a runner with a working `HTTPS_PROXY` in its environment would route an https
 //! leak to `DEFAULT_URL` (which is https) through that proxy while the loopback
-//! mock is still consumed and this test stayed green. So we blackhole the
+//! mock is still consumed and this test stayed green.  So we blackhole the
 //! scheme-specific variables too.
 
 use std::net::TcpListener;
@@ -42,8 +48,8 @@ mod support;
 ///
 /// Acts as the proxy target: any leaked connection to a non-loopback
 /// destination will be routed through this listener and increment the
-/// counter.  The test asserts zero connections, catching even
-/// fire-and-forget leaks whose errors are discarded.
+/// counter.  The test then asserts zero connections (those accepted
+/// during the synchronous `obtain_proof` call).
 struct ProxyObserver {
     _listener: Arc<TcpListener>,
     port: u16,
@@ -51,7 +57,6 @@ struct ProxyObserver {
 }
 
 impl ProxyObserver {
-    /// Bind to a random port on loopback and start the accept loop.
     fn bind() -> Self {
         let listener = Arc::new(TcpListener::bind("127.0.0.1:0").expect("bind proxy observer"));
         let port = listener.local_addr().unwrap().port();
@@ -74,20 +79,6 @@ impl ProxyObserver {
 
     fn port(&self) -> u16 {
         self.port
-    }
-
-    /// Wait for the count to stabilise (no change across a sleep interval),
-    /// meaning all connections that were in the accept backlog when
-    /// `obtain_proof` returned have been drained and counted.
-    fn stabilise(&self) {
-        loop {
-            let prev = self.count.load(Ordering::SeqCst);
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            let curr = self.count.load(Ordering::SeqCst);
-            if curr == prev {
-                return;
-            }
-        }
     }
 }
 
@@ -126,6 +117,10 @@ fn obtain_proof_consumes_the_mocked_service_and_makes_no_live_call() {
     let solve = |_c: &Challenge| Some("silent".to_string());
     let solver: &dyn Fn(&Challenge) -> Option<String> = &solve;
 
+    // Connections accepted during obtain_proof are counted by the
+    // detached accept thread.  We read the counter after the call
+    // returns; a leak whose TCP handshake completes after this read
+    // is outside the assertion's window (see module-level doc).
     let count_before = observer.count.load(Ordering::SeqCst);
 
     let proof = obtain_proof(&cfg, Some(solver))
@@ -135,9 +130,6 @@ fn obtain_proof_consumes_the_mocked_service_and_makes_no_live_call() {
     challenge.assert();
     answer.assert();
 
-    // Stabilise the counter so any connections that arrived just before
-    // obtain_proof returned have been processed by the accept thread.
-    observer.stabilise();
     let leak_count = observer.count.load(Ordering::SeqCst) - count_before;
 
     assert_eq!(

--- a/crates/icaptcha-client/tests/icaptcha_mock_consumed.rs
+++ b/crates/icaptcha-client/tests/icaptcha_mock_consumed.rs
@@ -18,10 +18,11 @@
 //! closed-port blackhole (which only surfaces propagating errors) would miss.
 //! To close the timing race inherent in a detached accept loop, the count is
 //! read only after a bounded drain: the test opens a flush connection and
-//! blocks until the accept thread has acknowledged (counted) it.  Because
-//! `accept()` hands out connections FIFO, every leak connection that completed
-//! its TCP handshake before the flush is counted before the flush — the
-//! assertion therefore covers all egress in flight when `obtain_proof`
+//! blocks until the accept thread has accepted *that specific connection*
+//! (tagged by its source port), not merely until any next counter tick.
+//! Because `accept()` hands out connections FIFO, every leak connection that
+//! completed its TCP handshake before the flush is counted before the flush —
+//! the assertion therefore covers all egress in flight when `obtain_proof`
 //! returned.  A leak that starts its handshake after the drain is outside the
 //! window; that is the irreducible limit of observing a detached accept loop,
 //! and it is the remaining, well-defined gap this guard accepts.
@@ -50,14 +51,18 @@ mod support;
 /// A TCP listener that counts every accepted connection.
 ///
 /// Acts as the proxy target: any leaked connection to a non-loopback
-/// destination will be routed through this listener and increment the
-/// counter.  The count is guarded by a Mutex + Condvar so the test can block
-/// until the detached accept thread has acknowledged a specific connection
-/// (see [`ProxyObserver::drain`]).
+/// destination will be routed through this listener and counted.  Every
+/// accepted connection is recorded by its source port so the test's own
+/// flush connection ([`ProxyObserver::drain`]) can be recognised and
+/// excluded from the leak count.
 struct ProxyObserver {
     _listener: Arc<TcpListener>,
     port: u16,
-    count: Arc<Mutex<usize>>,
+    /// Source ports of every accepted connection, in accept order.
+    accepted: Arc<Mutex<Vec<u16>>>,
+    /// Source ports of the test's own flush connections (never counted).
+    flush_ports: Arc<Mutex<Vec<u16>>>,
+    /// Signalled after each accept so `drain` can wait on the flush.
     ack: Arc<Condvar>,
 }
 
@@ -65,23 +70,26 @@ impl ProxyObserver {
     fn bind() -> Self {
         let listener = Arc::new(TcpListener::bind("127.0.0.1:0").expect("bind proxy observer"));
         let port = listener.local_addr().unwrap().port();
-        let count = Arc::new(Mutex::new(0usize));
+        let accepted = Arc::new(Mutex::new(Vec::new()));
+        let flush_ports = Arc::new(Mutex::new(Vec::new()));
         let ack = Arc::new(Condvar::new());
-        let c = Arc::clone(&count);
-        let a = Arc::clone(&ack);
+        let a = Arc::clone(&accepted);
+        let c = Arc::clone(&ack);
         let l = Arc::clone(&listener);
         std::thread::spawn(move || {
             for stream in l.incoming() {
-                if stream.is_ok() {
-                    *c.lock().unwrap() += 1;
-                    a.notify_all();
-                }
+                let Ok(stream) = stream else { continue };
+                a.lock()
+                    .unwrap()
+                    .push(stream.peer_addr().map(|a| a.port()).unwrap_or(0));
+                c.notify_all();
             }
         });
         ProxyObserver {
             _listener: listener,
             port,
-            count,
+            accepted,
+            flush_ports,
             ack,
         }
     }
@@ -90,29 +98,39 @@ impl ProxyObserver {
         self.port
     }
 
+    /// Number of accepted connections that are not the test's own flush
+    /// connections — i.e. the leak count.
     fn count(&self) -> usize {
-        *self.count.lock().unwrap()
+        let flush = self.flush_ports.lock().unwrap();
+        let accepted = self.accepted.lock().unwrap();
+        accepted.iter().filter(|p| !flush.contains(p)).count()
     }
 
     /// Bounded acknowledgement barrier for the accept loop.
     ///
-    /// Opens a flush connection to the listener and blocks until the accept
-    /// thread has counted it (bounded by a timeout).  Because `accept()`
-    /// hands out connections FIFO, once this flush is counted every
-    /// connection that completed its handshake before it is counted too.
-    /// This lets the test assert "no egress was accepted before this point"
-    /// without racing the detached accept loop.
+    /// Opens a flush connection and blocks until the accept thread has
+    /// accepted *that connection* (identified by its source port), bounded by
+    /// a timeout.  Because `accept()` hands out connections FIFO, once the
+    /// flush is accepted every connection that completed its handshake before
+    /// it has been accepted and recorded too — so counting on afterwards
+    /// cannot miss a leak that was already in flight.  The flush connection
+    /// itself is never counted.
+    ///
+    /// A counter-tick barrier would be unsound here: sampling "current + 1"
+    /// and waiting for any increment lets a leak accepted after the sample
+    /// satisfy the wait, and the flush is then miscounted as that leak.
     fn drain(&self) {
-        let target = *self.count.lock().unwrap() + 1;
-        let _flush =
+        let flush =
             TcpStream::connect(("127.0.0.1", self.port)).expect("observer flush connection");
-        let mut count = self.count.lock().unwrap();
-        while *count < target {
+        let flush_port = flush.local_addr().unwrap().port();
+        self.flush_ports.lock().unwrap().push(flush_port);
+        let mut accepted = self.accepted.lock().unwrap();
+        while !accepted.contains(&flush_port) {
             let (guard, timed_out) = self
                 .ack
-                .wait_timeout(count, std::time::Duration::from_secs(5))
+                .wait_timeout(accepted, std::time::Duration::from_secs(5))
                 .unwrap();
-            count = guard;
+            accepted = guard;
             assert!(
                 !timed_out.timed_out(),
                 "proxy observer drain timed out; accept loop stalled"
@@ -165,14 +183,13 @@ fn obtain_proof_consumes_the_mocked_service_and_makes_no_live_call() {
     challenge.assert();
     answer.assert();
 
-    // Drain the accept loop before asserting: a leak connection that was
-    // accepted (or sitting in the backlog) when obtain_proof returned is
-    // counted ahead of the flush, so the count after drain reflects all
-    // egress in flight during the call.  The flush connection itself is
-    // accepted and counted too, so it is excluded from the leak accounting
-    // (exactly one connection).
+    // Drain the accept loop before asserting: the flush connection is not
+    // counted, and because accept() is FIFO every leak connection that
+    // completed its handshake before the flush is recorded before the flush
+    // is — so the count after drain reflects all egress in flight during the
+    // call.
     observer.drain();
-    let leak_count = observer.count() - count_before - 1;
+    let leak_count = observer.count() - count_before;
 
     assert_eq!(
         leak_count, 0,

--- a/crates/icaptcha-client/tests/support/mod.rs
+++ b/crates/icaptcha-client/tests/support/mod.rs
@@ -1,6 +1,53 @@
-/// Set every proxy env var to point at `proxy_url`, with NO_PROXY covering
-/// loopback so the mock is reached directly.
-pub fn arm_blackhole(proxy_url: &str) {
+use std::ffi::OsString;
+
+const PROXY_VARS: &[&str] = &[
+    "NO_PROXY",
+    "no_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "REQUEST_METHOD",
+];
+
+/// Captures the current values of a set of env vars and restores them on drop.
+pub struct EnvSnapshot(Vec<(String, Option<OsString>)>);
+
+impl EnvSnapshot {
+    pub fn capture(vars: &[&str]) -> Self {
+        EnvSnapshot(
+            vars.iter()
+                .map(|v| (v.to_string(), std::env::var_os(v)))
+                .collect(),
+        )
+    }
+}
+
+impl Drop for EnvSnapshot {
+    fn drop(&mut self) {
+        for (var, val) in &self.0 {
+            match val {
+                Some(v) => std::env::set_var(var, v),
+                None => std::env::remove_var(var),
+            }
+        }
+    }
+}
+
+/// Guard that restores env vars captured at construction time.
+pub struct EnvGuard {
+    _prev: EnvSnapshot,
+}
+
+/// Override every proxy-related env var so that non-loopback destinations are
+/// forced through `proxy_url`, with NO_PROXY covering loopback.  Also clears
+/// REQUEST_METHOD, which causes hyper-util to ignore all proxy variables when
+/// set.  Restores prior values on drop.
+pub fn arm_blackhole(proxy_url: &str) -> EnvGuard {
+    let prev = EnvSnapshot::capture(PROXY_VARS);
+
     std::env::set_var("NO_PROXY", "127.0.0.1,localhost");
     std::env::set_var("no_proxy", "127.0.0.1,localhost");
     for var in [
@@ -13,4 +60,20 @@ pub fn arm_blackhole(proxy_url: &str) {
     ] {
         std::env::set_var(var, proxy_url);
     }
+    std::env::remove_var("REQUEST_METHOD");
+
+    EnvGuard { _prev: prev }
+}
+
+/// Clear every proxy-related env var so connections go direct.  Restores
+/// prior values on drop.
+#[allow(dead_code)]
+pub fn disarm_proxy_env() -> EnvGuard {
+    let prev = EnvSnapshot::capture(PROXY_VARS);
+
+    for var in PROXY_VARS {
+        std::env::remove_var(var);
+    }
+
+    EnvGuard { _prev: prev }
 }

--- a/crates/icaptcha-client/tests/support/mod.rs
+++ b/crates/icaptcha-client/tests/support/mod.rs
@@ -1,0 +1,16 @@
+/// Set every proxy env var to point at `proxy_url`, with NO_PROXY covering
+/// loopback so the mock is reached directly.
+pub fn arm_blackhole(proxy_url: &str) {
+    std::env::set_var("NO_PROXY", "127.0.0.1,localhost");
+    std::env::set_var("no_proxy", "127.0.0.1,localhost");
+    for var in [
+        "ALL_PROXY",
+        "all_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+    ] {
+        std::env::set_var(var, proxy_url);
+    }
+}

--- a/crates/icaptcha-client/tests/support/mod.rs
+++ b/crates/icaptcha-client/tests/support/mod.rs
@@ -1,3 +1,13 @@
+//! Shared helpers for the icaptcha-client integration tests.
+//!
+//! CONCURRENCY CONSTRAINT: [`arm_blackhole`] and [`disarm_proxy_env`] mutate
+//! process-wide proxy env vars and restore them on drop.  Each test binary
+//! that consumes this module currently has exactly one `#[test]`, so there is
+//! no concurrent use.  `cargo test` runs tests within a binary in parallel by
+//! default, so the NEXT test added to either file MUST be serialized against
+//! these helpers (e.g. a shared `Mutex` in this module, or the `serial_test`
+//! crate) or it will race on the proxy vars.
+
 use std::ffi::OsString;
 
 const PROXY_VARS: &[&str] = &[
@@ -45,6 +55,8 @@ pub struct EnvGuard {
 /// forced through `proxy_url`, with NO_PROXY covering loopback.  Also clears
 /// REQUEST_METHOD, which causes hyper-util to ignore all proxy variables when
 /// set.  Restores prior values on drop.
+///
+/// Not safe to call from concurrent tests (see module docs).
 pub fn arm_blackhole(proxy_url: &str) -> EnvGuard {
     let prev = EnvSnapshot::capture(PROXY_VARS);
 
@@ -67,6 +79,8 @@ pub fn arm_blackhole(proxy_url: &str) -> EnvGuard {
 
 /// Clear every proxy-related env var so connections go direct.  Restores
 /// prior values on drop.
+///
+/// Not safe to call from concurrent tests (see module docs).
 #[allow(dead_code)]
 pub fn disarm_proxy_env() -> EnvGuard {
     let prev = EnvSnapshot::capture(PROXY_VARS);


### PR DESCRIPTION
## Summary

Hardens the iCaptcha mock-consumed guard with a proxy observer (catches fire-and-forget leaks) and a blackhole tripwire (detects if the proxy guard is silently disarmed).

## Motivation & context

Closes #211

## Kind of change

- [ ] Security fix
- [ ] Tests / CI

## What changed

- **icaptcha-client**: Replaced the closed-port proxy with a `ProxyObserver` (TCP listener counting connections) so fire-and-forget leaks whose errors are discarded are caught
- **icaptcha-client**: Added a blackhole tripwire test asserting `obtain_proof` fails against `[::1]` (IPv6 loopback) while the proxy is armed; goes RED if `.no_proxy()` or a custom connector is added
- **icaptcha-client**: No dependency changes — `mockito` was already a dev-dependency

## How a reviewer can verify

```sh
cargo test -p icaptcha-client
cargo clippy -p icaptcha-client --all-targets -- -D warnings
cargo fmt --check -p icaptcha-client
```

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally
- [x] New behavior is covered by tests (required for fixes)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits
- [x] Docs / `.env.example` updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Protocol & signing impact

N/A - test-only crate change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for network protection during proof requests.
  * Verified proof requests succeed when protection is disabled and fail with a connection error when enabled.
  * Added monitoring to detect unexpected network connections and prevent unintended network access.
  * Improved test isolation by restoring temporary network settings automatically after each test.
  * Documented test limitations and synchronization behavior for more reliable validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

