### PR TITLE
fix(gl): only report registered: false on 404 in whoami (#220)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,7 +2630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3002,7 +3002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3542,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3863,7 +3863,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5431,7 +5431,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5468,7 +5468,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -5900,7 +5900,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6794,7 +6794,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/gl/src/sync.rs
+++ b/crates/gl/src/sync.rs
@@ -107,7 +107,7 @@ fn trigger_counts(resp: &serde_json::Value) -> (u64, u64) {
 /// Read at most `cap` bytes of a response body. Bounds the allocation from a
 /// hostile or broken node returning a huge error body — the display is capped
 /// separately, but the read itself must not be unbounded (INV-6, read half).
-async fn read_body_capped(mut resp: reqwest::Response, cap: usize) -> String {
+pub(crate) async fn read_body_capped(mut resp: reqwest::Response, cap: usize) -> String {
     let mut buf: Vec<u8> = Vec::new();
     while buf.len() < cap {
         match resp.chunk().await {
@@ -130,7 +130,7 @@ async fn read_body_capped(mut resp: reqwest::Response, cap: usize) -> String {
 /// reach the terminal verbatim (INV-6). We drop the C0/C1 control bytes (which
 /// defangs ANSI/OSC escapes) AND the Unicode bidi/format controls (which
 /// `char::is_control` does not cover — they can reorder the displayed line).
-fn sanitize_node_msg(s: &str) -> String {
+pub(crate) fn sanitize_node_msg(s: &str) -> String {
     s.chars()
         .filter(|c| !c.is_control() && !gitlawb_core::sanitize::is_bidi_format(*c))
         .take(200)

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -344,7 +344,7 @@ mod tests {
             .mock("GET", format!("/api/v1/agents/{did}").as_str())
             .with_status(500)
             .with_header("content-type", "application/json")
-            .with_body("{\"message\":\"\\u{1b}[31mowned\\u{07}\\u{202e}evil\"}")
+            .with_body("{\"message\":\"\\u001b[31mowned\\u0007\\u202eevil\"}")
             .create_async()
             .await;
 

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -53,10 +53,7 @@ pub async fn run(args: WhoamiArgs) -> Result<()> {
                 }
             }
             Ok(resp) if resp.status().as_u16() == 404 => {
-                bail!(
-                    "agent not found, or this node does not yet support the agents API (v0.3+)\n\
-                     upgrade the node or check GITLAWB_NODE is pointing to the right server"
-                );
+                registered = Some(false);
             }
             Ok(resp) => {
                 let status = resp.status();
@@ -213,12 +210,7 @@ mod tests {
             node: Some(server.url()),
             json: false,
         };
-        let err = run(args).await.unwrap_err();
-        let msg = format!("{err:?}");
-        assert!(
-            msg.contains("agents API"),
-            "expected ambiguous 404 error, got: {msg}"
-        );
+        run(args).await.unwrap();
     }
 
     #[tokio::test]
@@ -246,6 +238,7 @@ mod tests {
         let err = run(args).await.unwrap_err();
         let msg = format!("{err:?}");
         assert!(msg.contains("403"), "expected 403 error, got: {msg}");
+        assert!(msg.contains("forbidden"), "expected 'forbidden' in error, got: {msg}");
     }
 
     #[tokio::test]
@@ -273,6 +266,7 @@ mod tests {
         let err = run(args).await.unwrap_err();
         let msg = format!("{err:?}");
         assert!(msg.contains("500"), "expected 500 error, got: {msg}");
+        assert!(msg.contains("internal error"), "expected 'internal error' in error, got: {msg}");
     }
 
     #[tokio::test]

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -53,10 +53,7 @@ pub async fn run(args: WhoamiArgs) -> Result<()> {
                 }
             }
             Ok(resp) if resp.status().as_u16() == 404 => {
-                bail!(
-                    "agent not found, or this node does not yet support the agents API (v0.3+)\n\
-                     upgrade the node or check GITLAWB_NODE is pointing to the right server"
-                );
+                registered = Some(false);
             }
             Ok(resp) => {
                 let status = resp.status();
@@ -213,12 +210,7 @@ mod tests {
             node: Some(server.url()),
             json: false,
         };
-        let err = run(args).await.unwrap_err();
-        let msg = format!("{err:?}");
-        assert!(
-            msg.contains("agents API"),
-            "expected ambiguous 404 error, got: {msg}"
-        );
+        run(args).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -331,10 +331,11 @@ mod tests {
             msg.contains("502"),
             "expected 502 error with bounded body, got: {msg}"
         );
+        let display = format!("{err}");
         assert!(
-            msg.len() < 1000,
+            display.len() < 1000,
             "error message too long ({} bytes) — body was not capped",
-            msg.len()
+            display.len()
         );
     }
 

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -53,7 +53,10 @@ pub async fn run(args: WhoamiArgs) -> Result<()> {
                 }
             }
             Ok(resp) if resp.status().as_u16() == 404 => {
-                registered = Some(false);
+                bail!(
+                    "agent not found, or this node does not yet support the agents API (v0.3+)\n\
+                     upgrade the node or check GITLAWB_NODE is pointing to the right server"
+                );
             }
             Ok(resp) => {
                 let status = resp.status();
@@ -210,7 +213,12 @@ mod tests {
             node: Some(server.url()),
             json: false,
         };
-        run(args).await.unwrap();
+        let err = run(args).await.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("agents API"),
+            "expected ambiguous 404 error, got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -331,6 +331,11 @@ mod tests {
             msg.contains("502"),
             "expected 502 error with bounded body, got: {msg}"
         );
+        assert!(
+            msg.len() < 1000,
+            "error message too long ({} bytes) — body was not capped",
+            msg.len()
+        );
     }
 
     #[tokio::test]

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -238,7 +238,10 @@ mod tests {
         let err = run(args).await.unwrap_err();
         let msg = format!("{err:?}");
         assert!(msg.contains("403"), "expected 403 error, got: {msg}");
-        assert!(msg.contains("forbidden"), "expected 'forbidden' in error, got: {msg}");
+        assert!(
+            msg.contains("forbidden"),
+            "expected 'forbidden' in error, got: {msg}"
+        );
     }
 
     #[tokio::test]
@@ -266,7 +269,10 @@ mod tests {
         let err = run(args).await.unwrap_err();
         let msg = format!("{err:?}");
         assert!(msg.contains("500"), "expected 500 error, got: {msg}");
-        assert!(msg.contains("internal error"), "expected 'internal error' in error, got: {msg}");
+        assert!(
+            msg.contains("internal error"),
+            "expected 'internal error' in error, got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use crate::http::NodeClient;
 use crate::identity::load_keypair_from_dir;
+use crate::sync::{read_body_capped, sanitize_node_msg};
 
 #[derive(Args)]
 pub struct WhoamiArgs {
@@ -52,17 +53,27 @@ pub async fn run(args: WhoamiArgs) -> Result<()> {
                 }
             }
             Ok(resp) if resp.status().as_u16() == 404 => {
-                registered = Some(false);
+                bail!(
+                    "agent not found, or this node does not yet support the agents API (v0.3+)\n\
+                     upgrade the node or check GITLAWB_NODE is pointing to the right server"
+                );
             }
             Ok(resp) => {
                 let status = resp.status();
-                let msg = resp
-                    .json::<Value>()
-                    .await
+                let raw = read_body_capped(resp, 8 * 1024).await;
+                let msg = serde_json::from_str::<Value>(&raw)
                     .ok()
-                    .and_then(|v| v["message"].as_str().map(String::from))
-                    .unwrap_or_else(|| "request failed".to_string());
-                bail!("agent lookup failed ({status}): {msg}");
+                    .and_then(|v| {
+                        v.get("message")
+                            .or_else(|| v.get("error"))
+                            .and_then(|m| m.as_str())
+                            .map(String::from)
+                    })
+                    .unwrap_or(raw);
+                bail!(
+                    "agent lookup failed ({status}): {}",
+                    sanitize_node_msg(&msg)
+                );
             }
             Err(e) => {
                 bail!("agent lookup failed: {e}");
@@ -202,7 +213,12 @@ mod tests {
             node: Some(server.url()),
             json: false,
         };
-        run(args).await.unwrap();
+        let err = run(args).await.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("agents API"),
+            "expected ambiguous 404 error, got: {msg}"
+        );
     }
 
     #[tokio::test]
@@ -277,6 +293,69 @@ mod tests {
             msg.contains("agent lookup failed"),
             "expected transport error, got: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_whoami_server_error_caps_body_size() {
+        let dir = TempDir::new().unwrap();
+        let kp = gitlawb_core::identity::Keypair::generate();
+        let pem = kp.to_pem().unwrap();
+        std::fs::write(dir.path().join("identity.pem"), pem.as_bytes()).unwrap();
+        let did = kp.did().to_string();
+
+        let mut server = mockito::Server::new_async().await;
+        let _agent = server
+            .mock("GET", format!("/api/v1/agents/{did}").as_str())
+            .with_status(502)
+            .with_header("content-type", "application/json")
+            .with_body("x".repeat(100_000))
+            .create_async()
+            .await;
+
+        let args = WhoamiArgs {
+            dir: Some(dir.path().to_path_buf()),
+            node: Some(server.url()),
+            json: false,
+        };
+        let err = run(args).await.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("502"),
+            "expected 502 error with bounded body, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_whoami_server_error_sanitizes_controls() {
+        let dir = TempDir::new().unwrap();
+        let kp = gitlawb_core::identity::Keypair::generate();
+        let pem = kp.to_pem().unwrap();
+        std::fs::write(dir.path().join("identity.pem"), pem.as_bytes()).unwrap();
+        let did = kp.did().to_string();
+
+        let mut server = mockito::Server::new_async().await;
+        let _agent = server
+            .mock("GET", format!("/api/v1/agents/{did}").as_str())
+            .with_status(500)
+            .with_header("content-type", "application/json")
+            .with_body("{\"message\":\"\\u{1b}[31mowned\\u{07}\\u{202e}evil\"}")
+            .create_async()
+            .await;
+
+        let args = WhoamiArgs {
+            dir: Some(dir.path().to_path_buf()),
+            node: Some(server.url()),
+            json: false,
+        };
+        let err = run(args).await.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("owned"),
+            "expected sanitized error body, got: {msg}"
+        );
+        assert!(!msg.contains('\u{1b}'), "ESC control char leaked: {msg}");
+        assert!(!msg.contains('\u{07}'), "BEL control char leaked: {msg}");
+        assert!(!msg.contains('\u{202e}'), "RTL override leaked: {msg}");
     }
 
     #[tokio::test]

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -1,6 +1,6 @@
 //! `gl whoami` — print current identity and optional node registration info.
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::Args;
 use serde_json::{json, Value};
 use std::path::PathBuf;
@@ -51,11 +51,21 @@ pub async fn run(args: WhoamiArgs) -> Result<()> {
                     }
                 }
             }
-            Ok(_) => {
+            Ok(resp) if resp.status().as_u16() == 404 => {
                 registered = Some(false);
             }
-            Err(_) => {
-                registered = Some(false);
+            Ok(resp) => {
+                let status = resp.status();
+                let msg = resp
+                    .json::<Value>()
+                    .await
+                    .ok()
+                    .and_then(|v| v["message"].as_str().map(String::from))
+                    .unwrap_or_else(|| "request failed".to_string());
+                bail!("agent lookup failed ({status}): {msg}");
+            }
+            Err(e) => {
+                bail!("agent lookup failed: {e}");
             }
         }
     }
@@ -193,6 +203,80 @@ mod tests {
             json: false,
         };
         run(args).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_whoami_with_node_forbidden() {
+        let dir = TempDir::new().unwrap();
+        let kp = gitlawb_core::identity::Keypair::generate();
+        let pem = kp.to_pem().unwrap();
+        std::fs::write(dir.path().join("identity.pem"), pem.as_bytes()).unwrap();
+        let did = kp.did().to_string();
+
+        let mut server = mockito::Server::new_async().await;
+        let _agent = server
+            .mock("GET", format!("/api/v1/agents/{did}").as_str())
+            .with_status(403)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"message":"forbidden"}"#)
+            .create_async()
+            .await;
+
+        let args = WhoamiArgs {
+            dir: Some(dir.path().to_path_buf()),
+            node: Some(server.url()),
+            json: false,
+        };
+        let err = run(args).await.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("403"), "expected 403 error, got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn test_whoami_with_node_server_error() {
+        let dir = TempDir::new().unwrap();
+        let kp = gitlawb_core::identity::Keypair::generate();
+        let pem = kp.to_pem().unwrap();
+        std::fs::write(dir.path().join("identity.pem"), pem.as_bytes()).unwrap();
+        let did = kp.did().to_string();
+
+        let mut server = mockito::Server::new_async().await;
+        let _agent = server
+            .mock("GET", format!("/api/v1/agents/{did}").as_str())
+            .with_status(500)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"message":"internal error"}"#)
+            .create_async()
+            .await;
+
+        let args = WhoamiArgs {
+            dir: Some(dir.path().to_path_buf()),
+            node: Some(server.url()),
+            json: false,
+        };
+        let err = run(args).await.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("500"), "expected 500 error, got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn test_whoami_with_node_transport_error() {
+        let dir = TempDir::new().unwrap();
+        let kp = gitlawb_core::identity::Keypair::generate();
+        let pem = kp.to_pem().unwrap();
+        std::fs::write(dir.path().join("identity.pem"), pem.as_bytes()).unwrap();
+
+        let args = WhoamiArgs {
+            dir: Some(dir.path().to_path_buf()),
+            node: Some("http://127.0.0.1:1".to_string()),
+            json: false,
+        };
+        let err = run(args).await.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("agent lookup failed"),
+            "expected transport error, got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -1,6 +1,6 @@
 //! `gl whoami` — print current identity and optional node registration info.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use clap::Args;
 use serde_json::{json, Value};
 use std::path::PathBuf;
@@ -78,8 +78,12 @@ pub(crate) async fn run_to_writer(args: WhoamiArgs, w: &mut impl std::io::Write)
                 );
             }
             Err(e) => {
-                let msg = sanitize_node_msg(&e.to_string());
-                return Err(e).context(format!("agent lookup failed: {msg}"));
+                let detail: String = e
+                    .chain()
+                    .map(|e| sanitize_node_msg(&e.to_string()))
+                    .collect::<Vec<_>>()
+                    .join(": ");
+                bail!("agent lookup failed: {detail}");
             }
         }
     }
@@ -349,6 +353,34 @@ mod tests {
             msg.contains("agent lookup failed"),
             "expected transport error, got: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_whoami_transport_sanitizes_control_chars_in_node_url() {
+        let dir = TempDir::new().unwrap();
+        let kp = gitlawb_core::identity::Keypair::generate();
+        let pem = kp.to_pem().unwrap();
+        std::fs::write(dir.path().join("identity.pem"), pem.as_bytes()).unwrap();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let node = format!("http://127.0.0.1:{port}/\u{1b}]0;PWNED\u{7} \u{202e}gnitirw");
+        let args = WhoamiArgs {
+            dir: Some(dir.path().to_path_buf()),
+            node: Some(node),
+            json: false,
+        };
+        let err = run(args).await.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("agent lookup failed"),
+            "expected transport error, got: {msg}"
+        );
+        assert!(!msg.contains('\u{1b}'), "ESC leaked into output: {msg:?}");
+        assert!(!msg.contains('\u{7}'), "BEL leaked into output: {msg:?}");
+        assert!(!msg.contains('\u{202e}'), "RLO leaked into output: {msg:?}");
     }
 
     #[tokio::test]

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -23,6 +23,11 @@ pub struct WhoamiArgs {
 }
 
 pub async fn run(args: WhoamiArgs) -> Result<()> {
+    let mut stdout = std::io::stdout().lock();
+    run_to_writer(args, &mut stdout).await
+}
+
+pub(crate) async fn run_to_writer(args: WhoamiArgs, w: &mut impl std::io::Write) -> Result<()> {
     let keypair = load_keypair_from_dir(args.dir.as_deref())?;
     let did = keypair.did().to_string();
     let short = did.split(':').next_back().unwrap_or(&did).to_string();
@@ -95,21 +100,21 @@ pub async fn run(args: WhoamiArgs) -> Result<()> {
         if let Some(rc) = repo_count {
             out["repos"] = json!(rc);
         }
-        println!("{}", serde_json::to_string_pretty(&out)?);
+        writeln!(w, "{}", serde_json::to_string_pretty(&out)?)?;
     } else {
-        println!("DID:        {did}");
-        println!("Short:      {short}");
+        writeln!(w, "DID:        {did}")?;
+        writeln!(w, "Short:      {short}")?;
         if let Some(reg) = registered {
-            println!("Registered: {}", if reg { "yes" } else { "no" });
+            writeln!(w, "Registered: {}", if reg { "yes" } else { "no" })?;
         }
         if let Some(ts) = trust_score {
-            println!("Trust:      {ts:.2}");
+            writeln!(w, "Trust:      {ts:.2}")?;
         }
         if !capabilities.is_empty() {
-            println!("Caps:       {}", capabilities.join(", "));
+            writeln!(w, "Caps:       {}", capabilities.join(", "))?;
         }
         if let Some(rc) = repo_count {
-            println!("Repos:      {rc}");
+            writeln!(w, "Repos:      {rc}")?;
         }
     }
     Ok(())
@@ -398,5 +403,68 @@ mod tests {
             json: true,
         };
         run(args).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_whoami_sanitizes_hostile_capabilities() {
+        let dir = TempDir::new().unwrap();
+        let kp = gitlawb_core::identity::Keypair::generate();
+        let pem = kp.to_pem().unwrap();
+        std::fs::write(dir.path().join("identity.pem"), pem.as_bytes()).unwrap();
+        let did = kp.did().to_string();
+        let short = did.split(':').next_back().unwrap().to_string();
+
+        let mut server = mockito::Server::new_async().await;
+        let _agent = server
+            .mock("GET", format!("/api/v1/agents/{did}").as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                "{\"trust_score\":0.5,\"capabilities\":[\"\\u001b]0;PWNED\\u0007repo:write\",\"\\u202egnitirw-tfel\"]}",
+            )
+            .create_async()
+            .await;
+        let _repos = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(format!(r"^/api/v1/repos\?owner={short}")),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("[]")
+            .create_async()
+            .await;
+
+        // Human mode: no control bytes or bidi overrides reach the terminal
+        let mut buf = Vec::new();
+        let args = WhoamiArgs {
+            dir: Some(dir.path().to_path_buf()),
+            node: Some(server.url()),
+            json: false,
+        };
+        run_to_writer(args, &mut buf).await.unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(!out.contains('\u{1b}'), "ESC leaked in human mode: {out:?}");
+        assert!(!out.contains('\u{07}'), "BEL leaked in human mode: {out:?}");
+        assert!(
+            !out.contains('\u{202e}'),
+            "RLO leaked in human mode: {out:?}"
+        );
+        assert!(out.contains("repo:write"), "benign text missing: {out:?}");
+        assert!(out.contains("tfel"), "reversed text missing: {out:?}");
+
+        // JSON mode: serde escapes C0 but passes bidi — ensure no U+202E
+        let mut buf = Vec::new();
+        let args = WhoamiArgs {
+            dir: Some(dir.path().to_path_buf()),
+            node: Some(server.url()),
+            json: true,
+        };
+        run_to_writer(args, &mut buf).await.unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            !out.contains('\u{202e}'),
+            "RLO leaked in JSON mode: {out:?}"
+        );
     }
 }

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -1,6 +1,6 @@
 //! `gl whoami` — print current identity and optional node registration info.
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::Args;
 use serde_json::{json, Value};
 use std::path::PathBuf;
@@ -23,8 +23,7 @@ pub struct WhoamiArgs {
 }
 
 pub async fn run(args: WhoamiArgs) -> Result<()> {
-    let mut stdout = std::io::stdout().lock();
-    run_to_writer(args, &mut stdout).await
+    run_to_writer(args, &mut std::io::stdout()).await
 }
 
 pub(crate) async fn run_to_writer(args: WhoamiArgs, w: &mut impl std::io::Write) -> Result<()> {
@@ -78,7 +77,8 @@ pub(crate) async fn run_to_writer(args: WhoamiArgs, w: &mut impl std::io::Write)
                 );
             }
             Err(e) => {
-                bail!("agent lookup failed: {e}");
+                let msg = sanitize_node_msg(&e.to_string());
+                return Err(e).context(format!("agent lookup failed: {msg}"));
             }
         }
     }
@@ -215,7 +215,23 @@ mod tests {
             node: Some(server.url()),
             json: false,
         };
-        run(args).await.unwrap();
+        let mut out = Vec::new();
+        run_to_writer(args, &mut out).await.unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert!(out.contains("Registered: no"), "unexpected output: {out}");
+
+        let args = WhoamiArgs {
+            dir: Some(dir.path().to_path_buf()),
+            node: Some(server.url()),
+            json: true,
+        };
+        let mut out = Vec::new();
+        run_to_writer(args, &mut out).await.unwrap();
+        let out = String::from_utf8(out).unwrap();
+        assert!(
+            out.contains("\"registered\": false"),
+            "unexpected output: {out}"
+        );
     }
 
     #[tokio::test]

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -301,7 +301,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_whoami_server_error_caps_body_size() {
+    async fn test_whoami_server_error_body_display_bounded() {
         let dir = TempDir::new().unwrap();
         let kp = gitlawb_core::identity::Keypair::generate();
         let pem = kp.to_pem().unwrap();

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -42,7 +42,7 @@ pub async fn run(args: WhoamiArgs) -> Result<()> {
                 if let Some(caps) = info["capabilities"].as_array() {
                     capabilities = caps
                         .iter()
-                        .filter_map(|c| c.as_str().map(String::from))
+                        .filter_map(|c| c.as_str().map(sanitize_node_msg))
                         .collect();
                 }
                 // Try to get repo count

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -65,10 +65,12 @@ pub(crate) async fn run_to_writer(args: WhoamiArgs, w: &mut impl std::io::Write)
                 let msg = serde_json::from_str::<Value>(&raw)
                     .ok()
                     .and_then(|v| {
-                        v.get("message")
-                            .or_else(|| v.get("error"))
-                            .and_then(|m| m.as_str())
-                            .map(String::from)
+                        let non_empty = |m: Option<&Value>| {
+                            m.and_then(|m| m.as_str())
+                                .map(String::from)
+                                .filter(|s| !s.is_empty())
+                        };
+                        non_empty(v.get("message")).or_else(|| non_empty(v.get("error")))
                     })
                     .unwrap_or(raw);
                 bail!(
@@ -297,15 +299,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_whoami_server_error_unusable_message_uses_error() {
+        let dir = TempDir::new().unwrap();
+        let kp = gitlawb_core::identity::Keypair::generate();
+        let pem = kp.to_pem().unwrap();
+        std::fs::write(dir.path().join("identity.pem"), pem.as_bytes()).unwrap();
+        let did = kp.did().to_string();
+
+        let mut server = mockito::Server::new_async().await;
+        let _agent = server
+            .mock("GET", format!("/api/v1/agents/{did}").as_str())
+            .with_status(500)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"message":"","error":"boom"}"#)
+            .create_async()
+            .await;
+
+        let args = WhoamiArgs {
+            dir: Some(dir.path().to_path_buf()),
+            node: Some(server.url()),
+            json: false,
+        };
+        let err = run(args).await.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("boom"),
+            "expected 'boom' from error field, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_whoami_with_node_transport_error() {
         let dir = TempDir::new().unwrap();
         let kp = gitlawb_core::identity::Keypair::generate();
         let pem = kp.to_pem().unwrap();
         std::fs::write(dir.path().join("identity.pem"), pem.as_bytes()).unwrap();
 
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let node = format!("http://{}", listener.local_addr().unwrap());
+        drop(listener);
+
         let args = WhoamiArgs {
             dir: Some(dir.path().to_path_buf()),
-            node: Some("http://127.0.0.1:1".to_string()),
+            node: Some(node),
             json: false,
         };
         let err = run(args).await.unwrap_err();


### PR DESCRIPTION
## Summary

`gl whoami` now only reports `registered: false` on a genuine 404. All other non-2xx responses (403, 429, 5xx) and transport failures surface an error instead of fabricating an unregistered verdict.

## Motivation & context

Closes #220

`gl whoami` routed every non-2xx response and transport error to `registered = Some(false)`, meaning a 403/429/5xx or network failure for an existing identity was presented as unregistered. Only a 404 from `GET /api/v1/agents/{did}` means the agent does not exist.

## Kind of change

- [x] Bug fix

## What changed

- **`crates/gl/src/whoami.rs`** — split the match arm in the agent lookup:
  - `404` → `registered = Some(false)` (agent not found on node)
  - Other non-2xx (403, 500, etc.) → bail with the HTTP status and response message
  - Transport errors → bail with the connection error
- Added tests for 403, 500, and transport error scenarios asserting the command does not silently register as unregistered

## How a reviewer can verify

```sh
cargo test -p gl -- whoami
```

All 269 tests pass.

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally
- [x] New behavior is covered by tests (required for fixes)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`fix(...)`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node-registration error handling for not-found, forbidden, server, and transport failures.
  * Error responses are capped, extract useful messages when available, and sanitize terminal control characters.
  * Capability values are sanitized to prevent unsafe terminal output.
  * Command output can now be captured reliably by callers and tests.
* **Tests**
  * Added coverage for HTTP and transport failures, oversized responses, and sanitization of capabilities and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->