### PR TITLE
test(node): add missing owner_did field to fails-closed seed update

### DIFF
--- a/crates/gitlawb-node/src/test_support.rs
+++ b/crates/gitlawb-node/src/test_support.rs
@@ -1577,6 +1577,7 @@ mod tests {
                 cert_id: None,
                 received_at: Utc::now().to_rfc3339(),
                 from_peer: "peer".to_string(),
+                owner_did: None,
             })
             .await
             .expect("seed private gossip update");


### PR DESCRIPTION
## Summary

Adds the `owner_did` field missing from one `ReceivedRefUpdate` test initializer, unbreaking compilation of test targets on main (and CI on release PR #182).

## Motivation & context

#113 and #145 raced: #145 added `owner_did` to `ReceivedRefUpdate` and updated its own call sites, but the seed initializer in `list_repo_events_fails_closed_when_repo_lookup_errors` (added by #113) predates it. Merged main fails `clippy --all-targets`, `cargo test`, and MSRV with E0063; `build --release` passes, which is why this slipped through. Blocks #182.

## Kind of change

- [x] Tests / CI

## What changed

- `gitlawb-node`: set `owner_did: None` in the fails-closed test's seed update — None on purpose, the test exercises the legacy None-branch slug fallback.

## How a reviewer can verify

```sh
cargo clippy --workspace --all-targets -- -D warnings   # fails on main, clean here
cargo test --workspace                                   # 985 passed locally w/ Postgres

Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] cargo test --workspace passes locally
- [x] New behavior is covered by tests (required for fixes)
- [x] cargo fmt --all and cargo clippy --workspace --all-targets -- -D warnings are clean
- [x] Commit titles use Conventional Commits (feat(...), fix(...), docs(...))
- [x] Docs / .env.example updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for repository event handling when repository lookups fail.
  * Clarified test data by explicitly representing missing owner information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->