### PR TITLE
ci: add a non-blocking Windows test lane for the shipped CLIs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -216,3 +216,34 @@ jobs:
 
       - name: Smoke test --version
         run: docker run --rm gitlawb-node:ci-test --version
+
+  test-windows:
+    name: test (windows, non-blocking)
+    runs-on: windows-latest
+    timeout-minutes: 45
+    # Non-blocking, mirroring the informational `beta` lane above. We ship `gl`
+    # and `git-remote-gitlawb` to Windows users (release.yml) with zero Windows
+    # test coverage, so run their suites here to make Windows-only regressions
+    # VISIBLE on the PR without gating merge (#228). These two are the client
+    # CLIs and depend on no database, so no Postgres service is needed (service
+    # containers do not run on windows-latest regardless). `git` is preinstalled
+    # on windows-latest, which the real_git_fetch harness relies on.
+    continue-on-error: true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: windows
+
+      - name: cargo test (shipped Windows crates)
+        run: cargo test -p gl -p git-remote-gitlawb


### PR DESCRIPTION
## What

Adds a `test-windows` job to `pr-checks.yml` that runs `cargo test -p gl -p git-remote-gitlawb` on `windows-latest`, non-blocking (`continue-on-error: true`).

## Why

We ship `gl` and `git-remote-gitlawb` to Windows users via `release.yml`, but run no Windows tests: `pr-checks.yml` is ubuntu-only, and the one `windows-latest` in the repo is the release build step, which never runs `cargo test`. So changes to the shipped Windows CLIs (for example the multi-round fetch fix in #192) reach Windows users with zero test runs on Windows.

The lane makes Windows-only regressions visible on the PR without gating merge, mirroring the existing informational `beta` lane. The two crates are the client CLIs and depend on no database, so the job needs no Postgres service (service containers do not run on `windows-latest` anyway); `git` is preinstalled on the runner for the `real_git_fetch` harness.

## Notes

- Non-blocking is deliberate. This is the first time these suites run on Windows, so the first run may surface real failures; those should be visible, not block merge, matching the best-effort Windows posture already in `release.yml`.
- Un-gating the currently `#[cfg(unix)]` harness tests so they exercise the shipped Windows path is the deferred follow-on in #228.

Closes #228.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added non-blocking Windows test coverage for the shipped Windows components.
  * Windows tests now run automatically with Rust tooling and dependency caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->