### PR TITLE
test(icaptcha-client): bind new()'s empty-API-key filter (#216)

### DIFF
--- a/crates/icaptcha-client/src/lib.rs
+++ b/crates/icaptcha-client/src/lib.rs
@@ -720,4 +720,45 @@ mod tests {
 
         assert!(failures.is_empty(), "\n{}", failures.join("\n"));
     }
+
+    #[test]
+    fn new_normalizes_empty_api_key_to_none_on_trusted_origin() {
+        let guard = ICAPTCHA_ENV_LOCK.lock().unwrap();
+        let prev_key = std::env::var_os("GITLAWB_ICAPTCHA_API_KEY");
+        let prev_op = std::env::var_os("GITLAWB_ICAPTCHA_URL");
+
+        // Operator origin configured and resolved as trusted (no advert), so
+        // api_key reaches the env read and the emptiness filter is the only
+        // thing standing between a blank var and an empty bearer token.
+        std::env::set_var("GITLAWB_ICAPTCHA_URL", "https://icap.mynode.example");
+
+        // "Operator set the var but left it blank" must stay keyless: a
+        // Some("") would attach `Authorization: Bearer ` (empty token) to the
+        // challenge and answer requests instead of omitting the header.
+        std::env::set_var("GITLAWB_ICAPTCHA_API_KEY", "");
+        let empty = IcaptchaCfg::new("did:key:zTEST", None, None);
+
+        // Contrast arm: a real key on the same trusted path must survive the
+        // filter, so the filter can't regress to dropping every key.
+        std::env::set_var("GITLAWB_ICAPTCHA_API_KEY", "secret-bearer");
+        let non_empty = IcaptchaCfg::new("did:key:zTEST", None, None);
+
+        // Restore env and release the lock BEFORE asserting, so a failing
+        // assertion can't poison the shared lock or cascade into a sibling.
+        match prev_key {
+            Some(v) => std::env::set_var("GITLAWB_ICAPTCHA_API_KEY", v),
+            None => std::env::remove_var("GITLAWB_ICAPTCHA_API_KEY"),
+        }
+        match prev_op {
+            Some(v) => std::env::set_var("GITLAWB_ICAPTCHA_URL", v),
+            None => std::env::remove_var("GITLAWB_ICAPTCHA_URL"),
+        }
+        drop(guard);
+
+        assert_eq!(
+            empty.api_key, None,
+            "empty GITLAWB_ICAPTCHA_API_KEY must normalize to None"
+        );
+        assert_eq!(non_empty.api_key.as_deref(), Some("secret-bearer"));
+    }
 }


### PR DESCRIPTION
## Summary

Adds a guard test that drives an empty `GITLAWB_ICAPTCHA_API_KEY` through `IcaptchaCfg::new` on a trusted operator origin and asserts it normalizes to `None`, with a contrast arm showing a real key still attaches.

## Motivation & context

Closes #216

`new()` normalizes an empty key to `None` via `.filter(|s| !s.is_empty())` (`crates/icaptcha-client/src/lib.rs:213`). No test exercised the empty-string value, so dropping the filter shipped green and a trusted-origin solve would send an empty bearer token on the challenge and answer requests (`lib.rs:317`, `lib.rs:342`).

## Kind of change

- [ ] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [x] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

- `crates/icaptcha-client/src/lib.rs`: added `new_normalizes_empty_api_key_to_none_on_trusted_origin`

## How a reviewer can verify

```sh
cargo test -p icaptcha-client
```

Mutation check: remove `.filter(|s| !s.is_empty())` from the `api_key` read in `new()`. The new test fails; the other 21 lib tests stay green.

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally
- [x] New behavior is covered by tests (required for fixes)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` is clean
- [x] Commit titles use Conventional Commits (`test(...)`)
- [x] Docs / `.env.example` updated if behavior or config changed (N/A: test only)
- [x] Checked existing PRs so this isn't a duplicate (nearest is #213 for #212, which covers the `key_trusted` gate, not the emptiness filter)

## Protocol & signing impact

No protocol impact.

## Notes for reviewers

The test follows the same env-handling pattern as the sibling tests in the file: it saves and restores both env vars and releases `ICAPTCHA_ENV_LOCK` before asserting, so a failure cannot poison the shared lock or cascade into a sibling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that an empty CAPTCHA API key is treated as unset for trusted origins.
  * Verified that non-empty API keys remain preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->