### PR TITLE
fix(node): use readiness for peer liveness

### DIFF
--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -444,8 +444,9 @@ pub async fn ping_peer(
         .ok_or_else(|| AppError::RepoNotFound(format!("peer {did} not found")))?;
 
     // Use DB-aware readiness rather than process liveness: `/health` stays 200
-    // during a mid-life database outage, while `/ready` reports 503. The shared
-    // helper also preserves the no-redirect SSRF guard on peer-controlled URLs.
+    // during a mid-life database outage, while `/ready` reports 503. A 404-only
+    // fallback keeps pre-readiness peers compatible. The shared helper also
+    // preserves the no-redirect SSRF guard on peer-controlled URLs.
     let ok = crate::ping_peer_readiness(&state.http_client, &peer.http_url).await;
 
     let _ = state.db.mark_peer_ping(&did, ok).await;

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -449,8 +449,9 @@ pub async fn ping_peer(
     // preserves the no-redirect SSRF guard on peer-controlled URLs.
     let ok = crate::ping_peer_readiness(&state.http_client, &peer.http_url).await;
 
-    let _ = state.db.mark_peer_ping(&did, ok).await;
-
+    // This anonymous diagnostic endpoint is intentionally read-only. The
+    // periodic gossip loop owns the persisted federation-reachability gate and
+    // requires consecutive failures before marking a peer unreachable.
     Ok(Json(serde_json::json!({
         "did": did,
         "http_url": peer.http_url,
@@ -557,7 +558,7 @@ mod tests {
     use axum::body::Body;
     use axum::extract::ConnectInfo;
     use axum::http::{header, Method, Request, StatusCode};
-    use axum::routing::post;
+    use axum::routing::{get, post};
     use axum::{middleware, Extension, Router};
     use gitlawb_core::http_sig::sign_request;
     use gitlawb_core::identity::Keypair;
@@ -767,6 +768,74 @@ mod tests {
             .await
             .unwrap();
         did
+    }
+
+    #[sqlx::test]
+    async fn manual_ping_uses_readiness_without_mutating_federation_gate(pool: PgPool) {
+        let mut server = mockito::Server::new_async().await;
+        let ready = server
+            .mock("GET", "/ready")
+            .with_status(503)
+            .expect(1)
+            .create_async()
+            .await;
+        let health = server
+            .mock("GET", "/health")
+            .with_status(200)
+            .expect(0)
+            .create_async()
+            .await;
+
+        let mut state = test_state(pool.clone()).await;
+        state.http_client =
+            Arc::new(crate::build_http_client().expect("production HTTP client should build"));
+        let did = Keypair::generate().did().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        sqlx::query(
+            "INSERT INTO peers (did, http_url, last_seen, last_ping_ok, announced_at)
+             VALUES ($1, $2, $3, TRUE, $3)",
+        )
+        .bind(&did)
+        .bind(server.url())
+        .bind(now)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let response = Router::new()
+            .route("/api/v1/peers/{did}/ping", get(super::ping_peer))
+            .with_state(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(format!("/api/v1/peers/{did}/ping"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["reachable"], false);
+        ready.assert_async().await;
+        health.assert_async().await;
+
+        let peer = state
+            .db
+            .list_peers()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|peer| peer.did == did)
+            .unwrap();
+        assert!(
+            peer.last_ping_ok,
+            "an anonymous manual sample must not rewrite the federation gate"
+        );
     }
 
     #[sqlx::test]

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -443,18 +443,10 @@ pub async fn ping_peer(
         .find(|p| p.did == did)
         .ok_or_else(|| AppError::RepoNotFound(format!("peer {did} not found")))?;
 
-    // Async ping
-    let url = format!("{}/health", peer.http_url.trim_end_matches('/'));
-    // Use the shared no-redirect client: bare `reqwest::get` follows redirects,
-    // so a peer could answer with `302 -> http://127.0.0.1/` and turn the ping
-    // into an SSRF probe.
-    let ok = state
-        .http_client
-        .get(&url)
-        .send()
-        .await
-        .map(|r| r.status().is_success())
-        .unwrap_or(false);
+    // Use DB-aware readiness rather than process liveness: `/health` stays 200
+    // during a mid-life database outage, while `/ready` reports 503. The shared
+    // helper also preserves the no-redirect SSRF guard on peer-controlled URLs.
+    let ok = crate::ping_peer_readiness(&state.http_client, &peer.http_url).await;
 
     let _ = state.db.mark_peer_ping(&did, ok).await;
 

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -1101,16 +1101,19 @@ async fn sweep_rate_limiters(state: &AppState) {
 /// runs, not a hand-rolled equivalent.
 fn build_http_client() -> reqwest::Result<reqwest::Client> {
     reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(OUTBOUND_HTTP_TIMEOUT)
         .redirect(reqwest::redirect::Policy::none())
         .build()
 }
+
+const OUTBOUND_HTTP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Ping a peer's DB-aware `/ready` endpoint and report whether it answered 2xx.
 ///
 /// A 404 falls back to `/health` for compatibility with nodes released before
 /// `/ready` existed. Other readiness failures, including 503 during a database
-/// outage, fail closed and must not use the liveness-only endpoint.
+/// outage, fail closed and must not use the liveness-only endpoint. The complete
+/// `/ready`-then-`/health` probe shares one timeout budget.
 ///
 /// Takes the client by reference so callers supply the shared, no-redirect
 /// `state.http_client`. Peer URLs are attacker-influenceable, so a `3xx` to a
@@ -1118,19 +1121,31 @@ fn build_http_client() -> reqwest::Result<reqwest::Client> {
 /// `reqwest::Client::new()`: its default follows redirects and would
 /// reintroduce the SSRF this guards against (#93).
 pub(crate) async fn ping_peer_readiness(client: &reqwest::Client, http_url: &str) -> bool {
-    let base_url = http_url.trim_end_matches('/');
-    let readiness = client.get(format!("{base_url}/ready")).send().await;
+    ping_peer_readiness_with_timeout(client, http_url, OUTBOUND_HTTP_TIMEOUT).await
+}
 
-    match readiness {
-        Ok(response) if response.status().is_success() => true,
-        Ok(response) if response.status() == reqwest::StatusCode::NOT_FOUND => client
-            .get(format!("{base_url}/health"))
-            .send()
-            .await
-            .map(|response| response.status().is_success())
-            .unwrap_or(false),
-        _ => false,
-    }
+async fn ping_peer_readiness_with_timeout(
+    client: &reqwest::Client,
+    http_url: &str,
+    timeout: std::time::Duration,
+) -> bool {
+    let base_url = http_url.trim_end_matches('/');
+    tokio::time::timeout(timeout, async {
+        let readiness = client.get(format!("{base_url}/ready")).send().await;
+
+        match readiness {
+            Ok(response) if response.status().is_success() => true,
+            Ok(response) if response.status() == reqwest::StatusCode::NOT_FOUND => client
+                .get(format!("{base_url}/health"))
+                .send()
+                .await
+                .map(|response| response.status().is_success())
+                .unwrap_or(false),
+            _ => false,
+        }
+    })
+    .await
+    .unwrap_or(false)
 }
 
 fn load_or_create_keypair(config: &Config) -> Result<Keypair> {
@@ -1168,7 +1183,11 @@ fn load_or_create_keypair(config: &Config) -> Result<Keypair> {
 
 #[cfg(test)]
 mod gossip_ssrf_tests {
-    use super::ping_peer_readiness;
+    use super::{ping_peer_readiness, ping_peer_readiness_with_timeout};
+    use axum::{http::StatusCode, routing::get, Router};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
 
     // Build the client exactly as production does (super::build_http_client) so
     // these tests bind the redirect guarantee to the real shared client the
@@ -1265,6 +1284,62 @@ mod gossip_ssrf_tests {
         );
         ready.assert_async().await;
         health.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn ping_peer_readiness_legacy_fallback_shares_deadline() {
+        let health_requests = Arc::new(AtomicUsize::new(0));
+        let health_requests_for_route = Arc::clone(&health_requests);
+        let app = Router::new()
+            .route(
+                "/ready",
+                get(|| async {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    StatusCode::NOT_FOUND
+                }),
+            )
+            .route(
+                "/health",
+                get(move || {
+                    let health_requests = Arc::clone(&health_requests_for_route);
+                    async move {
+                        health_requests.fetch_add(1, Ordering::Relaxed);
+                        tokio::time::sleep(Duration::from_millis(300)).await;
+                        StatusCode::OK
+                    }
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind delayed legacy peer");
+        let peer_url = format!(
+            "http://{}",
+            listener
+                .local_addr()
+                .expect("delayed legacy peer has no local address")
+        );
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("delayed legacy peer failed");
+        });
+
+        let ok = ping_peer_readiness_with_timeout(
+            &production_http_client(),
+            &peer_url,
+            // Each response arrives within 350 ms, but the two serial requests
+            // cannot both finish within one 350 ms probe budget.
+            Duration::from_millis(350),
+        )
+        .await;
+
+        assert!(!ok, "the fallback must not start a fresh timeout budget");
+        assert_eq!(
+            health_requests.load(Ordering::Relaxed),
+            1,
+            "the delayed 404 should reach the legacy fallback"
+        );
+        server.abort();
     }
 
     #[tokio::test]

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -1011,6 +1011,7 @@ async fn gossip_task(
 
     // Periodic ping every 5 minutes — exit on shutdown.
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(300));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut failed_once: HashSet<String> = HashSet::new();
     loop {
         tokio::select! {
@@ -1019,25 +1020,13 @@ async fn gossip_task(
                     Ok(p) => p,
                     Err(_) => continue,
                 };
-                {
-                    let current_dids: HashSet<&str> =
-                        peers.iter().map(|peer| peer.did.as_str()).collect();
-                    failed_once.retain(|did| current_dids.contains(did.as_str()));
-                }
-                for peer in peers {
-                    let ok = ping_peer_readiness(&client, &peer.http_url).await;
-                    match peer_ping_db_update(&mut failed_once, &peer.did, ok) {
-                        Some(reachable) => {
-                            if let Err(error) = state.db.mark_peer_ping(&peer.did, reachable).await {
-                                warn!(did = %peer.did, err = %error, "failed to persist peer readiness");
-                            }
-                        }
-                        None => warn!(
-                            did = %peer.did,
-                            "peer readiness probe failed once; preserving previous federation status"
-                        ),
-                    }
-                }
+                gossip_ping_round(
+                    state.db.as_ref(),
+                    client.as_ref(),
+                    &mut failed_once,
+                    peers,
+                )
+                .await;
             }
             _ = shutdown_rx.changed() => {
                 if *shutdown_rx.borrow() {
@@ -1106,6 +1095,32 @@ async fn sweep_rate_limiters(state: &AppState) {
     state.sync_trigger_rate_limiter.cleanup().await;
     state.peer_write_rate_limiter.cleanup().await;
     state.ipfs_rate_limiter.cleanup().await;
+}
+
+async fn gossip_ping_round(
+    db: &Db,
+    client: &reqwest::Client,
+    failed_once: &mut HashSet<String>,
+    peers: Vec<db::PeerRecord>,
+) {
+    {
+        let current_dids: HashSet<&str> = peers.iter().map(|peer| peer.did.as_str()).collect();
+        failed_once.retain(|did| current_dids.contains(did.as_str()));
+    }
+    for peer in peers {
+        let ok = ping_peer_readiness(client, &peer.http_url).await;
+        match peer_ping_db_update(failed_once, &peer.did, ok) {
+            Some(reachable) => {
+                if let Err(error) = db.mark_peer_ping(&peer.did, reachable).await {
+                    warn!(did = %peer.did, err = %error, "failed to persist peer readiness");
+                }
+            }
+            None => warn!(
+                did = %peer.did,
+                "peer readiness probe failed once; preserving previous federation status"
+            ),
+        }
+    }
 }
 
 /// Decide whether one readiness sample should update the persisted federation
@@ -1260,8 +1275,12 @@ fn load_or_create_keypair(config: &Config) -> Result<Keypair> {
 
 #[cfg(test)]
 mod gossip_ssrf_tests {
-    use super::{peer_ping_db_update, ping_peer_readiness, ping_peer_readiness_with_timeout};
+    use super::{
+        gossip_ping_round, peer_ping_db_update, ping_peer_readiness,
+        ping_peer_readiness_with_timeout,
+    };
     use axum::{http::StatusCode, routing::get, Router};
+    use sqlx::PgPool;
     use std::collections::HashSet;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -1300,6 +1319,80 @@ mod gossip_ssrf_tests {
             None,
             "a success must reset the consecutive-failure state"
         );
+    }
+
+    #[sqlx::test]
+    async fn gossip_ping_round_requires_two_failures_before_persisting_unreachable(pool: PgPool) {
+        let mut server = mockito::Server::new_async().await;
+        let ready = server
+            .mock("GET", "/ready")
+            .with_status(503)
+            .expect(2)
+            .create_async()
+            .await;
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let did = "did:key:z6MkGossipHysteresis";
+        let now = chrono::Utc::now().to_rfc3339();
+        sqlx::query(
+            "INSERT INTO peers (did, http_url, last_seen, last_ping_ok, announced_at)
+             VALUES ($1, $2, $3, TRUE, $3)",
+        )
+        .bind(did)
+        .bind(server.url())
+        .bind(now)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut failed_once = HashSet::from(["did:key:z6MkRemovedPeer".to_owned()]);
+        gossip_ping_round(
+            state.db.as_ref(),
+            &production_http_client(),
+            &mut failed_once,
+            state.db.list_peers().await.unwrap(),
+        )
+        .await;
+        assert!(
+            !failed_once.contains("did:key:z6MkRemovedPeer"),
+            "failure tracking must prune peers outside the current snapshot"
+        );
+        assert!(
+            failed_once.contains(did),
+            "the first failed sample must be retained for the next round"
+        );
+        assert!(
+            state
+                .db
+                .list_peers()
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|peer| peer.did == did)
+                .unwrap()
+                .last_ping_ok,
+            "one transient failure must preserve the persisted federation gate"
+        );
+
+        gossip_ping_round(
+            state.db.as_ref(),
+            &production_http_client(),
+            &mut failed_once,
+            state.db.list_peers().await.unwrap(),
+        )
+        .await;
+        assert!(
+            !state
+                .db
+                .list_peers()
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|peer| peer.did == did)
+                .unwrap()
+                .last_ping_ok,
+            "two consecutive failed rounds must persist the peer as unreachable"
+        );
+        ready.assert_async().await;
     }
 
     // A peer answering `/ready` with a 302 toward an internal address must not

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -939,7 +939,7 @@ async fn gossip_task(
     }
 
     // Reuse the shared no-redirect client for every gossip outbound call (the
-    // bootstrap announce POST and the periodic peer /health ping). Peer URLs are
+    // bootstrap announce POST and the periodic peer /ready ping). Peer URLs are
     // attacker-influenceable, so a 3xx to a private address must not be followed.
     // Do NOT fall back to reqwest::Client::new(): its default follows redirects
     // and would reintroduce the SSRF closed here (#93).
@@ -1018,7 +1018,7 @@ async fn gossip_task(
                     Err(_) => continue,
                 };
                 for peer in peers {
-                    let ok = ping_peer_health(&client, &peer.http_url).await;
+                    let ok = ping_peer_readiness(&client, &peer.http_url).await;
                     let _ = state.db.mark_peer_ping(&peer.did, ok).await;
                 }
             }
@@ -1106,15 +1106,15 @@ fn build_http_client() -> reqwest::Result<reqwest::Client> {
         .build()
 }
 
-/// Ping a peer's `/health` endpoint and report whether it answered 2xx.
+/// Ping a peer's DB-aware `/ready` endpoint and report whether it answered 2xx.
 ///
 /// Takes the client by reference so callers supply the shared, no-redirect
 /// `state.http_client`. Peer URLs are attacker-influenceable, so a `3xx` to a
 /// private address must not be followed. Do NOT call this with a bare
 /// `reqwest::Client::new()`: its default follows redirects and would
 /// reintroduce the SSRF this guards against (#93).
-async fn ping_peer_health(client: &reqwest::Client, http_url: &str) -> bool {
-    let url = format!("{}/health", http_url.trim_end_matches('/'));
+pub(crate) async fn ping_peer_readiness(client: &reqwest::Client, http_url: &str) -> bool {
+    let url = format!("{}/ready", http_url.trim_end_matches('/'));
     client
         .get(&url)
         .send()
@@ -1158,20 +1158,20 @@ fn load_or_create_keypair(config: &Config) -> Result<Keypair> {
 
 #[cfg(test)]
 mod gossip_ssrf_tests {
-    use super::ping_peer_health;
+    use super::ping_peer_readiness;
 
     // Build the client exactly as production does (super::build_http_client) so
     // these tests bind the redirect guarantee to the real shared client the
     // node runs. A regression that makes build_http_client follow redirects
-    // fails ping_peer_health_does_not_follow_redirect.
+    // fails ping_peer_readiness_does_not_follow_redirect.
     fn production_http_client() -> reqwest::Client {
         super::build_http_client().expect("failed to build production http client")
     }
 
-    // A peer answering `/health` with a 302 toward an internal address must not
+    // A peer answering `/ready` with a 302 toward an internal address must not
     // be followed: the redirect target must never be requested (#93).
     #[tokio::test]
-    async fn ping_peer_health_does_not_follow_redirect() {
+    async fn ping_peer_readiness_does_not_follow_redirect() {
         let mut server = mockito::Server::new_async().await;
         let internal = server
             .mock("GET", "/internal-metadata")
@@ -1179,14 +1179,14 @@ mod gossip_ssrf_tests {
             .expect(0)
             .create_async()
             .await;
-        let _health = server
-            .mock("GET", "/health")
+        let _ready = server
+            .mock("GET", "/ready")
             .with_status(302)
             .with_header("location", &format!("{}/internal-metadata", server.url()))
             .create_async()
             .await;
 
-        let ok = ping_peer_health(&production_http_client(), &server.url()).await;
+        let ok = ping_peer_readiness(&production_http_client(), &server.url()).await;
 
         assert!(!ok, "a 302 must not count as a healthy peer");
         // expect(0) is enforced only at assert time; this fails if the redirect
@@ -1195,24 +1195,47 @@ mod gossip_ssrf_tests {
     }
 
     #[tokio::test]
-    async fn ping_peer_health_reports_success_on_200() {
+    async fn ping_peer_readiness_reports_success_on_200() {
         let mut server = mockito::Server::new_async().await;
-        let _health = server
-            .mock("GET", "/health")
+        let _ready = server
+            .mock("GET", "/ready")
             .with_status(200)
             .create_async()
             .await;
 
-        let ok = ping_peer_health(&production_http_client(), &server.url()).await;
+        let ok = ping_peer_readiness(&production_http_client(), &server.url()).await;
 
-        assert!(ok, "a 200 /health must count as a healthy peer");
+        assert!(ok, "a 200 /ready must count as a ready peer");
+    }
+
+    #[tokio::test]
+    async fn ping_peer_readiness_ignores_liveness_only_health() {
+        let mut server = mockito::Server::new_async().await;
+        let health = server
+            .mock("GET", "/health")
+            .with_status(200)
+            .expect(0)
+            .create_async()
+            .await;
+        let ready = server
+            .mock("GET", "/ready")
+            .with_status(503)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let ok = ping_peer_readiness(&production_http_client(), &server.url()).await;
+
+        assert!(!ok, "a peer with an unavailable database must not be ready");
+        health.assert_async().await;
+        ready.assert_async().await;
     }
 
     // A transport error (nothing listening) must map to unhealthy, never a
     // spurious healthy — the .unwrap_or(false) arm.
     #[tokio::test]
-    async fn ping_peer_health_reports_unhealthy_on_connection_error() {
-        let ok = ping_peer_health(&production_http_client(), "http://127.0.0.1:1").await;
-        assert!(!ok, "a connection error must count as an unhealthy peer");
+    async fn ping_peer_readiness_reports_unready_on_connection_error() {
+        let ok = ping_peer_readiness(&production_http_client(), "http://127.0.0.1:1").await;
+        assert!(!ok, "a connection error must count as an unready peer");
     }
 }

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -31,6 +31,7 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
 use clap::Parser;
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::net::TcpListener;
@@ -1010,6 +1011,7 @@ async fn gossip_task(
 
     // Periodic ping every 5 minutes — exit on shutdown.
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(300));
+    let mut failed_once = HashSet::new();
     loop {
         tokio::select! {
             _ = interval.tick() => {
@@ -1019,7 +1021,17 @@ async fn gossip_task(
                 };
                 for peer in peers {
                     let ok = ping_peer_readiness(&client, &peer.http_url).await;
-                    let _ = state.db.mark_peer_ping(&peer.did, ok).await;
+                    match peer_ping_db_update(&mut failed_once, &peer.did, ok) {
+                        Some(reachable) => {
+                            if let Err(error) = state.db.mark_peer_ping(&peer.did, reachable).await {
+                                warn!(did = %peer.did, err = %error, "failed to persist peer readiness");
+                            }
+                        }
+                        None => warn!(
+                            did = %peer.did,
+                            "peer readiness probe failed once; preserving previous federation status"
+                        ),
+                    }
                 }
             }
             _ = shutdown_rx.changed() => {
@@ -1091,6 +1103,21 @@ async fn sweep_rate_limiters(state: &AppState) {
     state.ipfs_rate_limiter.cleanup().await;
 }
 
+/// Decide whether one readiness sample should update the persisted federation
+/// gate. A success is authoritative immediately. A failure must repeat on the
+/// next gossip tick before it can mark a peer unreachable, so one transient
+/// database hiccup does not hide the peer's repositories for five minutes.
+fn peer_ping_db_update(failed_once: &mut HashSet<String>, did: &str, ready: bool) -> Option<bool> {
+    if ready {
+        failed_once.remove(did);
+        Some(true)
+    } else if failed_once.insert(did.to_owned()) {
+        None
+    } else {
+        Some(false)
+    }
+}
+
 /// Build the shared node HTTP client used for every outbound fan-out (sync
 /// trigger, profile/repo fetches, gossip announce + peer pings).
 ///
@@ -1130,22 +1157,67 @@ async fn ping_peer_readiness_with_timeout(
     timeout: std::time::Duration,
 ) -> bool {
     let base_url = http_url.trim_end_matches('/');
-    tokio::time::timeout(timeout, async {
+    let result = tokio::time::timeout(timeout, async {
         let readiness = client.get(format!("{base_url}/ready")).send().await;
 
         match readiness {
             Ok(response) if response.status().is_success() => true,
-            Ok(response) if response.status() == reqwest::StatusCode::NOT_FOUND => client
-                .get(format!("{base_url}/health"))
-                .send()
-                .await
-                .map(|response| response.status().is_success())
-                .unwrap_or(false),
-            _ => false,
+            Ok(response) if response.status() == reqwest::StatusCode::NOT_FOUND => {
+                info!(
+                    peer_url = %http_url,
+                    "peer has no readiness endpoint; falling back to legacy health probe"
+                );
+                match client.get(format!("{base_url}/health")).send().await {
+                    Ok(response) if response.status().is_success() => true,
+                    Ok(response) => {
+                        warn!(
+                            peer_url = %http_url,
+                            status = %response.status(),
+                            "legacy peer health probe reported unhealthy"
+                        );
+                        false
+                    }
+                    Err(error) => {
+                        warn!(
+                            peer_url = %http_url,
+                            err = %error,
+                            "legacy peer health probe failed"
+                        );
+                        false
+                    }
+                }
+            }
+            Ok(response) => {
+                warn!(
+                    peer_url = %http_url,
+                    status = %response.status(),
+                    "peer readiness probe reported unready"
+                );
+                false
+            }
+            Err(error) => {
+                warn!(
+                    peer_url = %http_url,
+                    err = %error,
+                    "peer readiness probe failed"
+                );
+                false
+            }
         }
     })
-    .await
-    .unwrap_or(false)
+    .await;
+
+    match result {
+        Ok(ready) => ready,
+        Err(_) => {
+            warn!(
+                peer_url = %http_url,
+                timeout_ms = timeout.as_millis(),
+                "peer readiness probe timed out"
+            );
+            false
+        }
+    }
 }
 
 fn load_or_create_keypair(config: &Config) -> Result<Keypair> {
@@ -1183,8 +1255,9 @@ fn load_or_create_keypair(config: &Config) -> Result<Keypair> {
 
 #[cfg(test)]
 mod gossip_ssrf_tests {
-    use super::{ping_peer_readiness, ping_peer_readiness_with_timeout};
+    use super::{peer_ping_db_update, ping_peer_readiness, ping_peer_readiness_with_timeout};
     use axum::{http::StatusCode, routing::get, Router};
+    use std::collections::HashSet;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
@@ -1195,6 +1268,33 @@ mod gossip_ssrf_tests {
     // fails ping_peer_readiness_does_not_follow_redirect.
     fn production_http_client() -> reqwest::Client {
         super::build_http_client().expect("failed to build production http client")
+    }
+
+    #[test]
+    fn peer_ping_requires_two_failures_before_marking_unreachable() {
+        let mut failed_once = HashSet::new();
+        let did = "did:key:z6MkPeer";
+
+        assert_eq!(
+            peer_ping_db_update(&mut failed_once, did, false),
+            None,
+            "one transient failure must preserve the persisted federation gate"
+        );
+        assert_eq!(
+            peer_ping_db_update(&mut failed_once, did, false),
+            Some(false),
+            "a sustained failure must mark the peer unreachable"
+        );
+        assert_eq!(
+            peer_ping_db_update(&mut failed_once, did, true),
+            Some(true),
+            "a success must restore reachability immediately"
+        );
+        assert_eq!(
+            peer_ping_db_update(&mut failed_once, did, false),
+            None,
+            "a success must reset the consecutive-failure state"
+        );
     }
 
     // A peer answering `/ready` with a 302 toward an internal address must not

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -806,8 +806,8 @@ fn build_degraded_router(node_did: String, db_startup: Arc<DbStartupStatus>) -> 
         db_startup,
     };
     // Everything answers 503 with the same body — including /health and
-    // /ready, so peer pings (which treat any 2xx /health as alive) and
-    // uptime monitors correctly see a node that cannot serve traffic.
+    // /ready, so peer readiness probes and uptime monitors correctly see a
+    // node that cannot serve traffic.
     // `/` additionally carries the node identity for probing peers.
     Router::new()
         .route("/", get(degraded_node_info))
@@ -1108,19 +1108,29 @@ fn build_http_client() -> reqwest::Result<reqwest::Client> {
 
 /// Ping a peer's DB-aware `/ready` endpoint and report whether it answered 2xx.
 ///
+/// A 404 falls back to `/health` for compatibility with nodes released before
+/// `/ready` existed. Other readiness failures, including 503 during a database
+/// outage, fail closed and must not use the liveness-only endpoint.
+///
 /// Takes the client by reference so callers supply the shared, no-redirect
 /// `state.http_client`. Peer URLs are attacker-influenceable, so a `3xx` to a
 /// private address must not be followed. Do NOT call this with a bare
 /// `reqwest::Client::new()`: its default follows redirects and would
 /// reintroduce the SSRF this guards against (#93).
 pub(crate) async fn ping_peer_readiness(client: &reqwest::Client, http_url: &str) -> bool {
-    let url = format!("{}/ready", http_url.trim_end_matches('/'));
-    client
-        .get(&url)
-        .send()
-        .await
-        .map(|r| r.status().is_success())
-        .unwrap_or(false)
+    let base_url = http_url.trim_end_matches('/');
+    let readiness = client.get(format!("{base_url}/ready")).send().await;
+
+    match readiness {
+        Ok(response) if response.status().is_success() => true,
+        Ok(response) if response.status() == reqwest::StatusCode::NOT_FOUND => client
+            .get(format!("{base_url}/health"))
+            .send()
+            .await
+            .map(|response| response.status().is_success())
+            .unwrap_or(false),
+        _ => false,
+    }
 }
 
 fn load_or_create_keypair(config: &Config) -> Result<Keypair> {
@@ -1229,6 +1239,59 @@ mod gossip_ssrf_tests {
         assert!(!ok, "a peer with an unavailable database must not be ready");
         health.assert_async().await;
         ready.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn ping_peer_readiness_falls_back_for_legacy_peer() {
+        let mut server = mockito::Server::new_async().await;
+        let ready = server
+            .mock("GET", "/ready")
+            .with_status(404)
+            .expect(1)
+            .create_async()
+            .await;
+        let health = server
+            .mock("GET", "/health")
+            .with_status(200)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let ok = ping_peer_readiness(&production_http_client(), &server.url()).await;
+
+        assert!(
+            ok,
+            "a legacy peer with a healthy /health must remain reachable"
+        );
+        ready.assert_async().await;
+        health.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn ping_peer_readiness_legacy_fallback_does_not_follow_redirect() {
+        let mut server = mockito::Server::new_async().await;
+        let internal = server
+            .mock("GET", "/internal-metadata")
+            .with_status(200)
+            .expect(0)
+            .create_async()
+            .await;
+        let _ready = server
+            .mock("GET", "/ready")
+            .with_status(404)
+            .create_async()
+            .await;
+        let _health = server
+            .mock("GET", "/health")
+            .with_status(302)
+            .with_header("location", &format!("{}/internal-metadata", server.url()))
+            .create_async()
+            .await;
+
+        let ok = ping_peer_readiness(&production_http_client(), &server.url()).await;
+
+        assert!(!ok, "the legacy fallback must not follow redirects");
+        internal.assert_async().await;
     }
 
     // A transport error (nothing listening) must map to unhealthy, never a

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -1011,7 +1011,7 @@ async fn gossip_task(
 
     // Periodic ping every 5 minutes — exit on shutdown.
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(300));
-    let mut failed_once = HashSet::new();
+    let mut failed_once: HashSet<String> = HashSet::new();
     loop {
         tokio::select! {
             _ = interval.tick() => {
@@ -1019,6 +1019,11 @@ async fn gossip_task(
                     Ok(p) => p,
                     Err(_) => continue,
                 };
+                {
+                    let current_dids: HashSet<&str> =
+                        peers.iter().map(|peer| peer.did.as_str()).collect();
+                    failed_once.retain(|did| current_dids.contains(did.as_str()));
+                }
                 for peer in peers {
                     let ok = ping_peer_readiness(&client, &peer.http_url).await;
                     match peer_ping_db_update(&mut failed_once, &peer.did, ok) {

--- a/docs/RUN-A-NODE.md
+++ b/docs/RUN-A-NODE.md
@@ -177,7 +177,7 @@ GITLAWB_ENFORCE_OWNER_PUSH=true
 | Missed heartbeats | After 3 days without one, you're excluded from rewards until you beat again |
 | Operator key | Dedicated wallet, small ETH balance, not your main treasury |
 | Monitoring | Watch `lastHeartbeat` on-chain; alert if > 22h since last beat |
-| Public URL | Must resolve and serve `/health` — peers will ping it |
+| Public URL | Must resolve and serve `/health` for liveness and DB-aware `/ready` for peer readiness |
 
 ---
 


### PR DESCRIPTION
## Summary

Use the database-aware `/ready` endpoint for periodic and manual peer checks, while falling back to `/health` only when an older peer returns 404 for `/ready`. Periodic federation state now requires two consecutive failed samples before marking a peer unreachable; the anonymous manual-ping endpoint is read-only.

## Motivation & context

`/health` intentionally reports process liveness and remains successful during a database outage. Using it for peer reachability lets a node continue treating a peer as healthy even though that peer cannot serve database-backed requests. A single transient readiness failure also should not remove a peer from federated repository results for the next five-minute interval.

Closes #176

## Kind of change

- [x] Bug fix
- [ ] Feature
- [ ] Security fix
- [x] Docs
- [x] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

- Changed the shared peer probe from `/health` to `/ready`, with a 404-only `/health` fallback for nodes released before `/ready` existed.
- Reused that helper from the manual peer-ping API so both paths have identical readiness and no-redirect behavior.
- Kept the anonymous manual-ping endpoint read-only; only the periodic gossip loop updates persisted federation reachability.
- Required two consecutive periodic failures before marking a peer unreachable, while restoring reachability immediately after a successful sample.
- Added structured logs for readiness failures, legacy fallback, fallback failures, transport failures, and timeout exhaustion.
- Added regression coverage proving the manual handler uses readiness without mutating the federation gate, one transient failure preserves the gate, sustained failure clears it, success restores it, legacy peers remain compatible, and neither request path follows redirects.
- Updated the operator guide and degraded-router comment to distinguish liveness from readiness.

## How a reviewer can verify

```sh
DATABASE_URL=postgres://postgres:postgres@localhost:5432/gitlawb_test cargo test --workspace
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo build --release --workspace
```

The focused regressions can also be run with:

```sh
cargo test -p gitlawb-node gossip_ssrf_tests
DATABASE_URL=postgres://postgres:postgres@localhost:5432/gitlawb_test \
  cargo test -p gitlawb-node manual_ping_uses_readiness_without_mutating_federation_gate
```

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally
- [x] New behavior is covered by tests (required for fixes)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`feat(...)`, `fix(...)`, `docs(...)`)
- [x] Docs / `.env.example` updated if behavior or config changed (N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Protocol & signing impact

N/A — this does not change identity, signatures, UCANs, ref certificates, or P2P wire formats.

## Notes for reviewers

The repository's current MSRV lane fails before compilation because newly resolved AWS crates require Rust 1.91.1 while CI installs `1.91` (currently 1.91.0). That existing manifest/lock/dependency drift is tracked in #242 and #243; stable tests, clippy, formatting, and the release build are clean for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer monitoring now uses the database-aware `/ready` endpoint, with fallback to `/health` when unavailable.
* **Bug Fixes**
  * Peer reachability status now requires multiple consecutive failed readiness checks before marking a peer unreachable.
  * Successful checks restore reachability immediately, while stale failure records are removed.
  * Improved handling of redirects, HTTP errors, connection failures, and readiness-to-health fallback timing.
  * Health checks no longer alter persisted reachability status during individual probes.
* **Documentation**
  * Updated the public URL checklist to require both `GET /health` and `GET /ready`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
