### PR TITLE
fix(node): opaque GraphQL DB error messages (#250)

### DIFF
--- a/crates/gitlawb-node/src/graphql/mod.rs
+++ b/crates/gitlawb-node/src/graphql/mod.rs
@@ -14,16 +14,47 @@ use subscription::SubscriptionRoot;
 
 pub type GitlawbSchema = Schema<QueryRoot, MutationRoot, SubscriptionRoot>;
 
-/// Client-facing message for GraphQL resolver DB failures. The real error is
-/// logged server-side; never put sqlx/anyhow detail in the GraphQL `errors`
-/// array (#250 — sibling of #226, which only covers `AppError`).
+/// Client-facing message for GraphQL resolver failures that wrap a real
+/// `sqlx::Error`. The real error is logged server-side; never put sqlx/Postgres
+/// detail in the GraphQL `errors` array (#250).
+///
+/// Kept as its own constant on this PR's base (main still renders
+/// `AppError::Db` with `e.to_string()`). If/when #247's `DB_ERROR_MESSAGE`
+/// lands, fold this into that shared constant.
 pub const GRAPHQL_DB_ERROR_MESSAGE: &str = "a database error occurred";
 
-/// Map a database/`anyhow` failure to an opaque GraphQL error: log the full
-/// cause chain (`{e:#}` for anyhow) and return a generic client message.
-pub(crate) fn graphql_db_err(e: impl std::fmt::Display) -> async_graphql::Error {
-    tracing::error!(error = %format!("{e:#}"), "graphql database error");
-    async_graphql::Error::new(GRAPHQL_DB_ERROR_MESSAGE)
+fn anyhow_has_sqlx(e: &anyhow::Error) -> bool {
+    e.chain().any(|c| c.downcast_ref::<sqlx::Error>().is_some())
+}
+
+/// Map an `anyhow` failure from the db layer to a GraphQL error.
+///
+/// - Real DB faults (`sqlx::Error` anywhere in the chain) → opaque client
+///   message + `error!` log with the full `{e:#}` cause chain.
+/// - Application/business errors (e.g. claim race, not-in-claimed-state) →
+///   keep the actionable message; log at `warn!` so they are not mistaken for
+///   infrastructure failures (#250 review).
+pub(crate) fn graphql_db_err(e: anyhow::Error) -> async_graphql::Error {
+    if anyhow_has_sqlx(&e) {
+        tracing::error!(error = %format!("{e:#}"), "graphql database error");
+        async_graphql::Error::new(GRAPHQL_DB_ERROR_MESSAGE)
+    } else {
+        tracing::warn!(error = %format!("{e:#}"), "graphql application error");
+        async_graphql::Error::new(e.to_string())
+    }
+}
+
+/// Map an `AppError` from a shared collector (e.g. ref-update feed) to a
+/// GraphQL error. DB variants are opaque; other variants stay opaque too
+/// because `AppError::Internal` can still carry raw detail on this base.
+pub(crate) fn graphql_app_err(e: crate::error::AppError) -> async_graphql::Error {
+    match e {
+        crate::error::AppError::Db(sql) => graphql_db_err(sql.into()),
+        other => {
+            tracing::error!(error = %other, "graphql error");
+            async_graphql::Error::new(GRAPHQL_DB_ERROR_MESSAGE)
+        }
+    }
 }
 
 pub fn build_schema(
@@ -43,11 +74,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn graphql_db_err_is_opaque() {
+    fn graphql_db_err_opaques_sqlx_chain() {
         let leak = "error returned from database: column \"is_public\" does not exist";
-        let err = graphql_db_err(anyhow::anyhow!("{leak}"));
+        let err = graphql_db_err(anyhow::Error::from(sqlx::Error::Protocol(leak.into())));
         assert_eq!(err.message, GRAPHQL_DB_ERROR_MESSAGE);
         assert!(!err.message.contains("is_public"));
         assert!(!err.message.contains(leak));
+    }
+
+    #[test]
+    fn graphql_db_err_keeps_business_message() {
+        let msg = "task not claimable: not found or already claimed";
+        let err = graphql_db_err(anyhow::anyhow!("{msg}"));
+        assert_eq!(err.message, msg);
     }
 }

--- a/crates/gitlawb-node/src/graphql/mod.rs
+++ b/crates/gitlawb-node/src/graphql/mod.rs
@@ -47,10 +47,9 @@ pub(crate) fn graphql_db_err(e: anyhow::Error) -> async_graphql::Error {
 /// Map an `AppError` from a shared collector (e.g. ref-update feed) to a
 /// GraphQL error.
 ///
-/// - `Db` → opaque via [`graphql_db_err`] (sqlx detail stays in logs).
-/// - `Internal` → opaque (may carry raw anyhow/sqlx text on this base).
-/// - Other variants already carry safe, actionable messages → surface them
-///   and log at `warn!` (same posture as business errors in `graphql_db_err`).
+/// Fail closed: only explicitly curated variants surface their `Display`
+/// text. Unnamed variants (including `Git`, which may embed on-disk paths)
+/// render opaque so a future addition cannot leak by default (#255 review).
 pub(crate) fn graphql_app_err(e: crate::error::AppError) -> async_graphql::Error {
     match e {
         crate::error::AppError::Db(sql) => graphql_db_err(sql.into()),
@@ -58,9 +57,21 @@ pub(crate) fn graphql_app_err(e: crate::error::AppError) -> async_graphql::Error
             tracing::error!(error = %format!("{err:#}"), "graphql internal error");
             async_graphql::Error::new(GRAPHQL_DB_ERROR_MESSAGE)
         }
+        // Curated client-safe variants — `Display` is intentional API text.
+        safe @ (crate::error::AppError::RepoNotFound(_)
+        | crate::error::AppError::RepoExists(_)
+        | crate::error::AppError::NotFound(_)
+        | crate::error::AppError::Unauthorized(_)
+        | crate::error::AppError::Forbidden(_)
+        | crate::error::AppError::BadRequest(_)
+        | crate::error::AppError::TooManyRequests(_)
+        | crate::error::AppError::Incomplete(_)) => {
+            tracing::warn!(error = %safe, "graphql application error");
+            async_graphql::Error::new(safe.to_string())
+        }
         other => {
-            tracing::warn!(error = %other, "graphql application error");
-            async_graphql::Error::new(other.to_string())
+            tracing::error!(error = %other, "graphql unclassified AppError (opaque)");
+            async_graphql::Error::new(GRAPHQL_DB_ERROR_MESSAGE)
         }
     }
 }
@@ -84,10 +95,15 @@ mod tests {
     #[test]
     fn graphql_db_err_opaques_sqlx_chain() {
         let leak = "error returned from database: column \"is_public\" does not exist";
-        let err = graphql_db_err(anyhow::Error::from(sqlx::Error::Protocol(leak.into())));
+        // Context layer must not hide sqlx from the chain walk (db helpers
+        // wrap with `.context(...)` in several places).
+        let err = graphql_db_err(
+            anyhow::Error::from(sqlx::Error::Protocol(leak.into())).context("loading repos"),
+        );
         assert_eq!(err.message, GRAPHQL_DB_ERROR_MESSAGE);
         assert!(!err.message.contains("is_public"));
         assert!(!err.message.contains(leak));
+        assert!(!err.message.contains("loading repos"));
     }
 
     #[test]
@@ -130,5 +146,46 @@ mod tests {
             err.message
         );
         assert_ne!(err.message, GRAPHQL_DB_ERROR_MESSAGE);
+    }
+
+    #[test]
+    fn graphql_app_err_opaques_unclassified_variants() {
+        // `Git` may embed on-disk paths from libgit2; fail closed.
+        let path = "/var/lib/gitlawb/repos/owner/secret.git";
+        let err = graphql_app_err(crate::error::AppError::Git(format!(
+            "failed to open '{path}'"
+        )));
+        assert_eq!(err.message, GRAPHQL_DB_ERROR_MESSAGE);
+        assert!(!err.message.contains(path));
+        assert!(!err.message.contains("failed to open"));
+    }
+
+    /// Every `.map_err(` in the GraphQL query/mutation resolvers must route
+    /// through the opaque helpers, or discard the error (`|_|`). Same source-
+    /// scrape pattern as `api::authz_guard` (#255 review).
+    #[test]
+    fn every_graphql_map_err_uses_opaque_helpers() {
+        for (file, src) in [
+            ("query.rs", include_str!("query.rs")),
+            ("mutation.rs", include_str!("mutation.rs")),
+        ] {
+            for (lineno, line) in src.lines().enumerate() {
+                let code = line.split("//").next().unwrap_or(line);
+                let Some(idx) = code.find(".map_err(") else {
+                    continue;
+                };
+                let after = code[idx + ".map_err(".len()..].trim_start();
+                let ok = after.starts_with("crate::graphql::graphql_db_err")
+                    || after.starts_with("crate::graphql::graphql_app_err")
+                    || after.starts_with("|_|")
+                    || after.starts_with("|_ ");
+                assert!(
+                    ok,
+                    "{file}:{}: `.map_err(` must use graphql_db_err / graphql_app_err \
+                     or discard (`|_|`): {line}",
+                    lineno + 1
+                );
+            }
+        }
     }
 }

--- a/crates/gitlawb-node/src/graphql/mod.rs
+++ b/crates/gitlawb-node/src/graphql/mod.rs
@@ -14,6 +14,18 @@ use subscription::SubscriptionRoot;
 
 pub type GitlawbSchema = Schema<QueryRoot, MutationRoot, SubscriptionRoot>;
 
+/// Client-facing message for GraphQL resolver DB failures. The real error is
+/// logged server-side; never put sqlx/anyhow detail in the GraphQL `errors`
+/// array (#250 — sibling of #226, which only covers `AppError`).
+pub const GRAPHQL_DB_ERROR_MESSAGE: &str = "a database error occurred";
+
+/// Map a database/`anyhow` failure to an opaque GraphQL error: log the full
+/// cause chain (`{e:#}` for anyhow) and return a generic client message.
+pub(crate) fn graphql_db_err(e: impl std::fmt::Display) -> async_graphql::Error {
+    tracing::error!(error = %format!("{e:#}"), "graphql database error");
+    async_graphql::Error::new(GRAPHQL_DB_ERROR_MESSAGE)
+}
+
 pub fn build_schema(
     db: Arc<Db>,
     ref_update_tx: tokio::sync::broadcast::Sender<RefUpdateBroadcast>,
@@ -24,4 +36,18 @@ pub fn build_schema(
         .data(ref_update_tx)
         .data(task_event_tx)
         .finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graphql_db_err_is_opaque() {
+        let leak = "error returned from database: column \"is_public\" does not exist";
+        let err = graphql_db_err(anyhow::anyhow!("{leak}"));
+        assert_eq!(err.message, GRAPHQL_DB_ERROR_MESSAGE);
+        assert!(!err.message.contains("is_public"));
+        assert!(!err.message.contains(leak));
+    }
 }

--- a/crates/gitlawb-node/src/graphql/mod.rs
+++ b/crates/gitlawb-node/src/graphql/mod.rs
@@ -45,14 +45,22 @@ pub(crate) fn graphql_db_err(e: anyhow::Error) -> async_graphql::Error {
 }
 
 /// Map an `AppError` from a shared collector (e.g. ref-update feed) to a
-/// GraphQL error. DB variants are opaque; other variants stay opaque too
-/// because `AppError::Internal` can still carry raw detail on this base.
+/// GraphQL error.
+///
+/// - `Db` → opaque via [`graphql_db_err`] (sqlx detail stays in logs).
+/// - `Internal` → opaque (may carry raw anyhow/sqlx text on this base).
+/// - Other variants already carry safe, actionable messages → surface them
+///   and log at `warn!` (same posture as business errors in `graphql_db_err`).
 pub(crate) fn graphql_app_err(e: crate::error::AppError) -> async_graphql::Error {
     match e {
         crate::error::AppError::Db(sql) => graphql_db_err(sql.into()),
-        other => {
-            tracing::error!(error = %other, "graphql error");
+        crate::error::AppError::Internal(err) => {
+            tracing::error!(error = %format!("{err:#}"), "graphql internal error");
             async_graphql::Error::new(GRAPHQL_DB_ERROR_MESSAGE)
+        }
+        other => {
+            tracing::warn!(error = %other, "graphql application error");
+            async_graphql::Error::new(other.to_string())
         }
     }
 }
@@ -87,5 +95,40 @@ mod tests {
         let msg = "task not claimable: not found or already claimed";
         let err = graphql_db_err(anyhow::anyhow!("{msg}"));
         assert_eq!(err.message, msg);
+    }
+
+    #[test]
+    fn graphql_app_err_opaques_db_and_internal() {
+        let leak = "column \"is_public\" does not exist";
+        let db_err = graphql_app_err(crate::error::AppError::Db(sqlx::Error::Protocol(
+            leak.into(),
+        )));
+        assert_eq!(db_err.message, GRAPHQL_DB_ERROR_MESSAGE);
+        assert!(!db_err.message.contains("is_public"));
+
+        let internal = graphql_app_err(crate::error::AppError::Internal(anyhow::anyhow!(
+            "loading repo: {leak}"
+        )));
+        assert_eq!(internal.message, GRAPHQL_DB_ERROR_MESSAGE);
+        assert!(!internal.message.contains("is_public"));
+    }
+
+    #[test]
+    fn graphql_app_err_keeps_safe_variant_messages() {
+        let err = graphql_app_err(crate::error::AppError::NotFound("widget".into()));
+        assert!(
+            err.message.contains("widget"),
+            "safe NotFound message must reach the client: {}",
+            err.message
+        );
+        assert_ne!(err.message, GRAPHQL_DB_ERROR_MESSAGE);
+
+        let err = graphql_app_err(crate::error::AppError::BadRequest("bad cid".into()));
+        assert!(
+            err.message.contains("bad cid"),
+            "safe BadRequest message must reach the client: {}",
+            err.message
+        );
+        assert_ne!(err.message, GRAPHQL_DB_ERROR_MESSAGE);
     }
 }

--- a/crates/gitlawb-node/src/graphql/mutation.rs
+++ b/crates/gitlawb-node/src/graphql/mutation.rs
@@ -54,7 +54,7 @@ impl MutationRoot {
         };
         db.create_task(&task)
             .await
-            .map_err(|e| crate::graphql::graphql_db_err(e))?;
+            .map_err(crate::graphql::graphql_db_err)?;
         Ok(AgentTaskType::from(task))
     }
 
@@ -76,7 +76,7 @@ impl MutationRoot {
         let task = db
             .claim_task(&id, &assignee_did)
             .await
-            .map_err(|e| crate::graphql::graphql_db_err(e))?;
+            .map_err(crate::graphql::graphql_db_err)?;
         let _ = tx.send(TaskEventBroadcast {
             task_id: id,
             old_status: "pending".to_string(),
@@ -108,7 +108,7 @@ impl MutationRoot {
         let existing = db
             .get_task(&id)
             .await
-            .map_err(|e| crate::graphql::graphql_db_err(e))?
+            .map_err(crate::graphql::graphql_db_err)?
             .ok_or_else(|| async_graphql::Error::new("task not found"))?;
         if !crate::api::did_matches(caller, existing.assignee_did.as_deref().unwrap_or_default()) {
             return Err(async_graphql::Error::new(
@@ -118,7 +118,7 @@ impl MutationRoot {
         let task = db
             .finish_task(&id, "completed", input.result.as_deref())
             .await
-            .map_err(|e| crate::graphql::graphql_db_err(e))?;
+            .map_err(crate::graphql::graphql_db_err)?;
         let _ = tx.send(TaskEventBroadcast {
             task_id: id,
             old_status: "claimed".to_string(),
@@ -149,7 +149,7 @@ impl MutationRoot {
         let existing = db
             .get_task(&id)
             .await
-            .map_err(|e| crate::graphql::graphql_db_err(e))?
+            .map_err(crate::graphql::graphql_db_err)?
             .ok_or_else(|| async_graphql::Error::new("task not found"))?;
         if !crate::api::did_matches(caller, existing.assignee_did.as_deref().unwrap_or_default()) {
             return Err(async_graphql::Error::new(
@@ -160,7 +160,7 @@ impl MutationRoot {
         let task = db
             .finish_task(&id, "failed", Some(&reason))
             .await
-            .map_err(|e| crate::graphql::graphql_db_err(e))?;
+            .map_err(crate::graphql::graphql_db_err)?;
         let _ = tx.send(TaskEventBroadcast {
             task_id: id,
             old_status: "claimed".to_string(),
@@ -218,8 +218,9 @@ mod tests {
             errors(&resp)
         );
 
-        // 3. Signed as the claimed assignee → passes the auth gate (any remaining
-        //    error is the missing task, not an auth error).
+        // 3. Signed as the claimed assignee → passes the auth gate. The missing
+        //    task is a business error from claim_task, not a sqlx fault, so the
+        //    actionable message must survive (not the opaque DB string) (#250).
         let resp = schema
             .execute(Request::new(&q).data(AuthenticatedDid(assignee.into())))
             .await;
@@ -227,6 +228,47 @@ mod tests {
         assert!(
             !errs.contains("authentication required") && !errs.contains("authenticated signer"),
             "matching signer must pass the auth gate: {errs}"
+        );
+        assert!(
+            errs.contains("task not claimable"),
+            "claim race / missing task must keep its business message: {errs}"
+        );
+        assert!(
+            !errs.contains(crate::graphql::GRAPHQL_DB_ERROR_MESSAGE),
+            "business error must not be rewritten as opaque DB error: {errs}"
+        );
+    }
+
+    /// #250: mutation DB faults must be opaque; create_task hits agent_tasks.
+    #[sqlx::test]
+    async fn create_task_db_error_message_is_opaque(pool: PgPool) {
+        let state = crate::test_support::test_state(pool.clone()).await;
+        sqlx::query("ALTER TABLE agent_tasks DROP COLUMN status")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let delegator = "did:key:zGQLDELEGATORAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let q = format!(
+            r#"mutation {{
+                createTask(
+                    delegatorDid: "{delegator}",
+                    input: {{ kind: "build", capability: "repo:write" }}
+                ) {{ id }}
+            }}"#
+        );
+        let resp = state
+            .graphql_schema
+            .execute(Request::new(&q).data(AuthenticatedDid(delegator.into())))
+            .await;
+        let errs = errors(&resp);
+        assert!(
+            errs.contains(crate::graphql::GRAPHQL_DB_ERROR_MESSAGE),
+            "sqlx fault must be opaque: {errs}"
+        );
+        assert!(
+            !errs.contains("column") && !errs.contains("status"),
+            "schema text leaked: {errs}"
         );
     }
 

--- a/crates/gitlawb-node/src/graphql/mutation.rs
+++ b/crates/gitlawb-node/src/graphql/mutation.rs
@@ -54,7 +54,7 @@ impl MutationRoot {
         };
         db.create_task(&task)
             .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+            .map_err(|e| crate::graphql::graphql_db_err(e))?;
         Ok(AgentTaskType::from(task))
     }
 
@@ -76,7 +76,7 @@ impl MutationRoot {
         let task = db
             .claim_task(&id, &assignee_did)
             .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+            .map_err(|e| crate::graphql::graphql_db_err(e))?;
         let _ = tx.send(TaskEventBroadcast {
             task_id: id,
             old_status: "pending".to_string(),
@@ -108,7 +108,7 @@ impl MutationRoot {
         let existing = db
             .get_task(&id)
             .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?
+            .map_err(|e| crate::graphql::graphql_db_err(e))?
             .ok_or_else(|| async_graphql::Error::new("task not found"))?;
         if !crate::api::did_matches(caller, existing.assignee_did.as_deref().unwrap_or_default()) {
             return Err(async_graphql::Error::new(
@@ -118,7 +118,7 @@ impl MutationRoot {
         let task = db
             .finish_task(&id, "completed", input.result.as_deref())
             .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+            .map_err(|e| crate::graphql::graphql_db_err(e))?;
         let _ = tx.send(TaskEventBroadcast {
             task_id: id,
             old_status: "claimed".to_string(),
@@ -149,7 +149,7 @@ impl MutationRoot {
         let existing = db
             .get_task(&id)
             .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?
+            .map_err(|e| crate::graphql::graphql_db_err(e))?
             .ok_or_else(|| async_graphql::Error::new("task not found"))?;
         if !crate::api::did_matches(caller, existing.assignee_did.as_deref().unwrap_or_default()) {
             return Err(async_graphql::Error::new(
@@ -160,7 +160,7 @@ impl MutationRoot {
         let task = db
             .finish_task(&id, "failed", Some(&reason))
             .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+            .map_err(|e| crate::graphql::graphql_db_err(e))?;
         let _ = tx.send(TaskEventBroadcast {
             task_id: id,
             old_status: "claimed".to_string(),

--- a/crates/gitlawb-node/src/graphql/query.rs
+++ b/crates/gitlawb-node/src/graphql/query.rs
@@ -14,7 +14,7 @@ impl QueryRoot {
         let repos = db
             .list_all_repos_deduped()
             .await
-            .map_err(|e| crate::graphql::graphql_db_err(e))?;
+            .map_err(crate::graphql::graphql_db_err)?;
 
         // Apply the same "/" visibility gate the REST/per-repo endpoints use so
         // this surface does not enumerate private repos (#97). The caller DID is
@@ -27,7 +27,7 @@ impl QueryRoot {
         let rules_by_repo = db
             .list_visibility_rules_for_repos(&ids)
             .await
-            .map_err(|e| crate::graphql::graphql_db_err(e))?;
+            .map_err(crate::graphql::graphql_db_err)?;
 
         Ok(repos
             .into_iter()
@@ -71,7 +71,7 @@ impl QueryRoot {
         let updates =
             crate::api::events::collect_visible_ref_updates(db, repo.as_deref(), limit, caller)
                 .await
-                .map_err(|e| crate::graphql::graphql_db_err(e))?;
+                .map_err(crate::graphql::graphql_app_err)?;
 
         // Resolve the trusted display owner_did per row, identical to the REST
         // feed: the stored wire value is untrusted, so it is echoed only when it
@@ -86,7 +86,7 @@ impl QueryRoot {
         let owner_dids = db
             .resolve_ref_update_owner_dids(&pairs)
             .await
-            .map_err(|e| crate::graphql::graphql_db_err(e))?;
+            .map_err(crate::graphql::graphql_db_err)?;
 
         let resolved: Vec<RefUpdateType> = updates
             .into_iter()
@@ -113,10 +113,14 @@ impl QueryRoot {
         #[graphql(default = 50)] limit: i64,
     ) -> Result<Vec<AgentTaskType>> {
         let db = ctx.data_unchecked::<Arc<Db>>();
+        // Clamp before SQL: a negative LIMIT is a client fault that Postgres
+        // rejects with 2201W, which would otherwise trip the opaque DB path
+        // and write an error-level log on every probe (#250 review).
+        let limit = limit.clamp(0, 200);
         let tasks = db
             .list_tasks(status.as_deref(), assignee_did.as_deref(), limit)
             .await
-            .map_err(|e| crate::graphql::graphql_db_err(e))?;
+            .map_err(crate::graphql::graphql_db_err)?;
         Ok(tasks.into_iter().map(AgentTaskType::from).collect())
     }
 
@@ -125,7 +129,7 @@ impl QueryRoot {
         let t = db
             .get_task(&id)
             .await
-            .map_err(|e| crate::graphql::graphql_db_err(e))?;
+            .map_err(crate::graphql::graphql_db_err)?;
         Ok(t.map(AgentTaskType::from))
     }
 }
@@ -451,5 +455,30 @@ mod tests {
                 err.message
             );
         }
+    }
+
+    /// #250: negative tasks(limit) must not hit Postgres (and must not 500-log).
+    #[sqlx::test]
+    async fn tasks_negative_limit_clamped(pool: PgPool) {
+        let db = db(pool).await;
+        let schema = schema(db);
+        let resp = anon(&schema, "{ tasks(limit: -1) { id } }").await;
+        assert!(
+            resp.errors.is_empty(),
+            "negative limit must clamp, not fail: {:?}",
+            resp.errors
+        );
+        assert_eq!(count_tasks(&resp), 0);
+    }
+
+    fn count_tasks(resp: &async_graphql::Response) -> usize {
+        assert!(resp.errors.is_empty(), "graphql errors: {:?}", resp.errors);
+        let async_graphql::Value::Object(obj) = &resp.data else {
+            panic!("data not an object: {:?}", resp.data);
+        };
+        let async_graphql::Value::List(rows) = obj.get("tasks").expect("tasks key") else {
+            panic!("tasks not a list");
+        };
+        rows.len()
     }
 }

--- a/crates/gitlawb-node/src/graphql/query.rs
+++ b/crates/gitlawb-node/src/graphql/query.rs
@@ -475,6 +475,35 @@ mod tests {
         assert_eq!(count_tasks(&resp), 0);
     }
 
+    /// #255: ceiling of the tasks(limit) clamp must be held (schema promises Max 200).
+    #[sqlx::test]
+    async fn tasks_limit_ceiling_clamped_to_200(pool: PgPool) {
+        let db = db(pool).await;
+        let now = Utc::now().to_rfc3339();
+        for i in 0..201 {
+            db.create_task(&crate::db::AgentTask {
+                id: format!("task-ceil-{i}"),
+                repo_id: None,
+                kind: "build".into(),
+                status: "pending".into(),
+                delegator_did: OWNER.into(),
+                assignee_did: None,
+                capability: "repo:write".into(),
+                ucan_token: None,
+                payload: None,
+                result: None,
+                created_at: now.clone(),
+                updated_at: now.clone(),
+                deadline: None,
+            })
+            .await
+            .unwrap();
+        }
+        let schema = schema(db);
+        let resp = anon(&schema, "{ tasks(limit: 5000) { id } }").await;
+        assert_eq!(count_tasks(&resp), 200, "limit above 200 must clamp to 200");
+    }
+
     fn count_tasks(resp: &async_graphql::Response) -> usize {
         assert!(resp.errors.is_empty(), "graphql errors: {:?}", resp.errors);
         let async_graphql::Value::Object(obj) = &resp.data else {

--- a/crates/gitlawb-node/src/graphql/query.rs
+++ b/crates/gitlawb-node/src/graphql/query.rs
@@ -14,7 +14,7 @@ impl QueryRoot {
         let repos = db
             .list_all_repos_deduped()
             .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+            .map_err(|e| crate::graphql::graphql_db_err(e))?;
 
         // Apply the same "/" visibility gate the REST/per-repo endpoints use so
         // this surface does not enumerate private repos (#97). The caller DID is
@@ -27,7 +27,7 @@ impl QueryRoot {
         let rules_by_repo = db
             .list_visibility_rules_for_repos(&ids)
             .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+            .map_err(|e| crate::graphql::graphql_db_err(e))?;
 
         Ok(repos
             .into_iter()
@@ -71,7 +71,7 @@ impl QueryRoot {
         let updates =
             crate::api::events::collect_visible_ref_updates(db, repo.as_deref(), limit, caller)
                 .await
-                .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+                .map_err(|e| crate::graphql::graphql_db_err(e))?;
 
         // Resolve the trusted display owner_did per row, identical to the REST
         // feed: the stored wire value is untrusted, so it is echoed only when it
@@ -86,7 +86,7 @@ impl QueryRoot {
         let owner_dids = db
             .resolve_ref_update_owner_dids(&pairs)
             .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+            .map_err(|e| crate::graphql::graphql_db_err(e))?;
 
         let resolved: Vec<RefUpdateType> = updates
             .into_iter()
@@ -116,7 +116,7 @@ impl QueryRoot {
         let tasks = db
             .list_tasks(status.as_deref(), assignee_did.as_deref(), limit)
             .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+            .map_err(|e| crate::graphql::graphql_db_err(e))?;
         Ok(tasks.into_iter().map(AgentTaskType::from).collect())
     }
 
@@ -125,7 +125,7 @@ impl QueryRoot {
         let t = db
             .get_task(&id)
             .await
-            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+            .map_err(|e| crate::graphql::graphql_db_err(e))?;
         Ok(t.map(AgentTaskType::from))
     }
 }
@@ -418,5 +418,38 @@ mod tests {
         let schema = schema(db);
         let q = r#"{ refUpdates { repo } }"#;
         assert_eq!(count(&authed(&schema, q, "did:key:z6MkQuar").await), 0);
+    }
+
+    /// #250: anonymous GraphQL query DB failures must not leak sqlx/schema text.
+    #[sqlx::test]
+    async fn repos_query_db_error_message_is_opaque(pool: PgPool) {
+        let db = db(pool.clone()).await;
+        db.create_repo(&repo("r1", OWNER, "widget", true))
+            .await
+            .unwrap();
+        sqlx::query("ALTER TABLE repos DROP COLUMN is_public")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let schema = schema(db);
+        let resp = anon(&schema, "{ repos { name ownerDid } }").await;
+        assert!(
+            !resp.errors.is_empty(),
+            "DB failure must surface as a GraphQL error"
+        );
+        for err in &resp.errors {
+            assert_eq!(
+                err.message,
+                crate::graphql::GRAPHQL_DB_ERROR_MESSAGE,
+                "raw DB detail leaked into GraphQL error: {}",
+                err.message
+            );
+            assert!(
+                !err.message.contains("is_public") && !err.message.contains("column"),
+                "schema text leaked: {}",
+                err.message
+            );
+        }
     }
 }

--- a/crates/gitlawb-node/src/graphql/query.rs
+++ b/crates/gitlawb-node/src/graphql/query.rs
@@ -110,7 +110,11 @@ impl QueryRoot {
         ctx: &Context<'_>,
         status: Option<String>,
         assignee_did: Option<String>,
-        #[graphql(default = 50)] limit: i64,
+        #[graphql(
+            default = 50,
+            desc = "Max 200; larger requests are clamped to 200 (no error). Negative values clamp to 0."
+        )]
+        limit: i64,
     ) -> Result<Vec<AgentTaskType>> {
         let db = ctx.data_unchecked::<Arc<Db>>();
         // Clamp before SQL: a negative LIMIT is a client fault that Postgres


### PR DESCRIPTION
## Summary
- Add shared `graphql_db_err` helper that logs `{e:#}` server-side and returns a generic `"a database error occurred"` client message.
- Route all 6 `query.rs` and 6 `mutation.rs` DB `.map_err` sites through it.
- Closes the unauthenticated `POST /graphql` sqlx/Postgres leak described in #250 (bypasses `AppError`, so #226/#247 do not cover it).

## Test plan
- [x] `cargo test -p gitlawb-node graphql_db_err_is_opaque` — helper rejects raw schema text
- [x] `repos_query_db_error_message_is_opaque` — anonymous `{ repos { ... } }` after a schema break returns only the opaque message (CI / `DATABASE_URL`)

Fixes #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized GraphQL error handling so database and schema details are no longer exposed.
  * Preserved actionable business error messages while routing unexpected database and application failures to safe, consistent messages.
  * Improved task listing by clamping `limit` to `0..=200`; negative values return no tasks and larger values are capped at 200.
* **Tests**
  * Added coverage for database error masking, safe business messages, and task-list limit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->