### PR TITLE
fix(ci): make the docker dependency cache work and unbreak Dockerfile.bins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,20 +8,33 @@ FROM rust:1.91-bookworm AS builder
 
 WORKDIR /build
 
-# Cache dependencies first for faster rebuilds
+# Cache dependencies first for faster rebuilds.
+# EVERY workspace member's manifest must be copied here, not just the ones this
+# image ships: cargo loads the whole workspace before it resolves anything, so a
+# missing member's Cargo.toml (or a path dependency pointing at one) aborts the
+# layer before a single crate is fetched.
 COPY Cargo.toml Cargo.lock ./
 COPY crates/gitlawb-core/Cargo.toml crates/gitlawb-core/
 COPY crates/gitlawb-node/Cargo.toml crates/gitlawb-node/
 COPY crates/gl/Cargo.toml crates/gl/
 COPY crates/git-remote-gitlawb/Cargo.toml crates/git-remote-gitlawb/
+COPY crates/gitlawb-attest/Cargo.toml crates/gitlawb-attest/
+COPY crates/icaptcha-client/Cargo.toml crates/icaptcha-client/
 
-# Fetch deps (this layer caches until Cargo.{toml,lock} change)
-RUN mkdir -p crates/gitlawb-core/src crates/gitlawb-node/src crates/gl/src crates/git-remote-gitlawb/src && \
+# Fetch deps (this layer caches until Cargo.{toml,lock} change).
+# No `|| true`: this layer is expected to succeed, and swallowing its exit code
+# is what let it sit dead from the moment gl gained a path dependency on
+# icaptcha-client. A failure here should stop the build, not silently turn every
+# image build into a cold one.
+RUN mkdir -p crates/gitlawb-core/src crates/gitlawb-node/src crates/gl/src \
+        crates/git-remote-gitlawb/src crates/gitlawb-attest/src crates/icaptcha-client/src && \
     echo 'fn main() {}' > crates/gitlawb-node/src/main.rs && \
     echo 'fn main() {}' > crates/gl/src/main.rs && \
     echo 'fn main() {}' > crates/git-remote-gitlawb/src/main.rs && \
     echo '' > crates/gitlawb-core/src/lib.rs && \
-    cargo build --release --locked -p gitlawb-node -p gl -p git-remote-gitlawb || true
+    echo '' > crates/gitlawb-attest/src/lib.rs && \
+    echo '' > crates/icaptcha-client/src/lib.rs && \
+    cargo build --release --locked -p gitlawb-node -p gl -p git-remote-gitlawb
 
 # Now copy real sources and build for real.
 # Force-bump mtimes so cargo's fingerprint check rebuilds — without this,

--- a/Dockerfile.bins
+++ b/Dockerfile.bins
@@ -3,7 +3,10 @@
 # Used by scripts/build-bins.sh — not used for node deployment.
 ARG TARGET=x86_64-unknown-linux-musl
 
-FROM rust:1.85-bookworm AS builder
+# Must stay at or above the workspace `rust-version` in Cargo.toml. An unmet
+# MSRV is a hard cargo error, and nothing in CI builds this file, so a stale
+# base image here fails only when someone runs scripts/build-bins.sh.
+FROM rust:1.91-bookworm AS builder
 ARG TARGET
 
 WORKDIR /build


### PR DESCRIPTION
Two container builds that do not work, both found while adding `--locked` to the shipping builds in #243.

Closes #265. Closes #266.

## The dependency-cache layer never cached anything

`Dockerfile` primed its dependency cache from four crate manifests, but the workspace has six members and `crates/gl` takes a path dependency on `icaptcha-client`. Cargo loads the whole workspace before resolving anything, so the layer aborted on the missing manifest and `|| true` swallowed it. Every image build has been a cold build of the full dependency graph since `icaptcha-client` was added, including the `docker-build` smoke test on every PR.

Copying all six manifests fixes it. Dropping the `|| true` is the part that keeps it fixed: the guard is what let this sit unnoticed, and this layer has no reason to tolerate failure.

Before, building the first 24 lines unchanged:

```
--- target/release/deps rlib count ---
0
--- registry cache size ---
no registry cache
```

After:

```
--- rlib count after the fixed cache layer ---
619
--- registry cache ---
508M	/usr/local/cargo/registry
```

## Dockerfile.bins could not build at all

It pinned `rust:1.85-bookworm` against a workspace `rust-version = "1.91"`. An unmet MSRV is a hard cargo error, so `scripts/build-bins.sh` has been broken for both Linux musl targets. Nothing in CI builds this file, which is why it stayed quiet. Released binaries are unaffected: `release.yml` builds those on matching-arch runners.

Bumping the base image to `rust:1.91-bookworm`, matching the main `Dockerfile`, is the whole fix. Verified by building it: it now completes and produces a 158 MB image.

## Verification

Real `docker build` runs, not reasoning about the files:

- The full `gitlawb-node` image builds end to end with the fixed cache layer.
- Removing one member manifest from the fixed layer now **fails the build** with exit 101 (`failed to read /build/crates/icaptcha-client/Cargo.toml`) instead of continuing silently, so the removed `|| true` is load-bearing and the next crate added to the workspace cannot break this quietly again.
- `Dockerfile.bins` with the new base image builds to completion for `aarch64-unknown-linux-musl`; on the old base it fails with `error: rustc 1.85.1 is not supported by the following packages`. It fails identically with and without `--locked`, so #243's flag was never the cause.

One consequence worth naming: until now the cache layer produced no artifacts at all, so the dummy-binary guard at `Dockerfile:26-38` (mtime bump, binary removal, fingerprint removal) was never actually exercised. It is now. I checked the built image rather than assuming it held: it ships a 36 MB `gitlawb-node` reporting `0.7.0` and a 12 MB `gl` reporting `0.7.0`, not the `fn main() {}` stubs.

## Base

Stacked on `ci/242-lock-sync-release` (#243), which touches the same `Dockerfile` line. GitHub will retarget this to `main` when #243 merges. Nothing here depends on #243 semantically, only textually.
