### PR TITLE
fix(node): stop a peer-supplied repo slug from escaping repos_dir (#272)

### DIFF
--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -381,6 +381,14 @@ pub async fn notify_sync(
         )));
     }
 
+    // #272: the slug reaches a PathBuf::join in the sync worker, where an extra
+    // separator or a traversal segment places the mirror outside repos_dir. Reject
+    // it here, before the queue row and the ref-update row are written. The message
+    // names the field and nothing about where repos live on disk.
+    if let Err(e) = crate::git::repo_store::validate_repo_slug(&req.repo) {
+        return Err(AppError::BadRequest(format!("invalid repo field: {e}")));
+    }
+
     state
         .db
         .enqueue_sync(&req.repo, &req.node_did, &req.ref_name, &req.new_sha, None)
@@ -584,7 +592,9 @@ mod tests {
         state.config = Arc::new(cfg);
     }
 
-    const NOTIFY_BODY: &str = r#"{"repo":"demo","ref_name":"refs/heads/main","new_sha":"0000000000000000000000000000000000000000","node_did":"PEER_DID"}"#;
+    // The slug must be a well-formed owner/name (#272); these brake tests are about
+    // the rate limiter, so the body carries a valid slug and reaches the brake.
+    const NOTIFY_BODY: &str = r#"{"repo":"z6Mkfoo/hello","ref_name":"refs/heads/main","new_sha":"0000000000000000000000000000000000000000","node_did":"PEER_DID"}"#;
 
     // ── trigger: mandatory signature ──────────────────────────────────────────
 
@@ -863,6 +873,197 @@ mod tests {
             trigger.status(),
             StatusCode::UNAUTHORIZED,
             "trigger must hit its own bucket (401 from the sig gate), not the drained peer_write bucket (429)"
+        );
+    }
+
+    // ── notify: repo slug validation (#272) ───────────────────────────────────
+    //
+    // An unsigned caller who has announced their own DID is a "known peer", so
+    // the slug they send reaches the sync worker's path join. `a//tmp/probe`
+    // resolved to /tmp/probe.git, outside repos_dir entirely. notify must reject
+    // anything that is not a well-formed owner/name slug before it is queued.
+
+    /// Every slug shape the boundary must refuse. `a//tmp/gitlawb-probe` is the
+    /// verified escape; the rest are the traversal and empty-half neighbours.
+    const MALFORMED_SLUGS: [&str; 9] = [
+        "a//tmp/gitlawb-probe",
+        "../hello",
+        "./hello",
+        "../../etc/evil",
+        "a/../../x",
+        "..",
+        "demo",
+        "/hello",
+        "z6Mkfoo/",
+    ];
+
+    fn notify_body(repo: &str, peer_did: &str) -> String {
+        serde_json::json!({
+            "repo": repo,
+            "ref_name": "refs/heads/main",
+            "new_sha": "0000000000000000000000000000000000000000",
+            "node_did": peer_did,
+        })
+        .to_string()
+    }
+
+    #[sqlx::test]
+    async fn sync_notify_rejects_malformed_repo_slugs(pool: PgPool) {
+        let state = test_state(pool).await;
+        let db = state.db.clone();
+        let peer_did = seed_peer(&state).await;
+        let router = crate::server::build_router(state);
+        for (i, slug) in MALFORMED_SLUGS.iter().enumerate() {
+            // Distinct source IPs so the per-IP brake never masks the 400.
+            let ip = format!("198.51.100.{}:5000", i + 1);
+            let resp = router
+                .clone()
+                .oneshot(unsigned_post(
+                    "/api/v1/sync/notify",
+                    &notify_body(slug, &peer_did),
+                    &ip,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::BAD_REQUEST,
+                "slug {slug:?} must be rejected"
+            );
+        }
+        let queued = db.dequeue_pending_syncs(100).await.unwrap();
+        assert!(
+            queued.is_empty(),
+            "no malformed slug may be queued, got {:?}",
+            queued.iter().map(|q| &q.repo).collect::<Vec<_>>()
+        );
+    }
+
+    #[sqlx::test]
+    async fn sync_notify_rejection_body_names_field_not_path(pool: PgPool) {
+        // R3: the client learns which field was bad, never where repos live on
+        // disk. A message carrying the resolved path would hand an unsigned
+        // caller the server's layout.
+        let state = test_state(pool).await;
+        let repos_dir = state.config.repos_dir.display().to_string();
+        let peer_did = seed_peer(&state).await;
+        let router = crate::server::build_router(state);
+        let resp = router
+            .oneshot(unsigned_post(
+                "/api/v1/sync/notify",
+                &notify_body("a//tmp/gitlawb-probe", &peer_did),
+                "198.51.100.20:5000",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(body.contains("repo"), "body must name the field: {body}");
+        assert!(
+            !body.contains(&repos_dir),
+            "body must not leak repos_dir ({repos_dir}): {body}"
+        );
+        for trimmed in repos_dir.trim_start_matches("./").split('/') {
+            assert!(
+                trimmed.is_empty() || !body.contains(trimmed),
+                "body must not leak a repos_dir segment ({trimmed}): {body}"
+            );
+        }
+        // A rooted path is a leading '/' with something after it. A bare quoted
+        // '/' is the separator the message is allowed to talk about.
+        assert!(
+            !body
+                .split(|c: char| c.is_whitespace() || c == '"' || c == '\'')
+                .any(|tok| tok.starts_with('/') && tok.len() > 1),
+            "body must not contain a rooted filesystem path: {body}"
+        );
+    }
+
+    #[sqlx::test]
+    async fn sync_notify_rejection_writes_no_ref_update(pool: PgPool) {
+        // The second half of R1: the ref-update feed row sits after enqueue_sync,
+        // so the early return must skip it too. Asserted, not argued.
+        let state = test_state(pool.clone()).await;
+        let peer_did = seed_peer(&state).await;
+        let router = crate::server::build_router(state);
+        let resp = router
+            .oneshot(unsigned_post(
+                "/api/v1/sync/notify",
+                &notify_body("a//tmp/gitlawb-probe", &peer_did),
+                "198.51.100.21:5000",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM received_ref_updates")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            count, 0,
+            "a rejected notify must not seed the ref-update feed"
+        );
+    }
+
+    #[sqlx::test]
+    async fn sync_notify_accepts_valid_slug_and_records_ref_update(pool: PgPool) {
+        // must-not-break, and the control that keeps the two negative assertions
+        // above from being vacuous: a well-formed slug still queues and still
+        // writes its ref-update row.
+        let state = test_state(pool.clone()).await;
+        let db = state.db.clone();
+        let peer_did = seed_peer(&state).await;
+        let router = crate::server::build_router(state);
+        let resp = router
+            .oneshot(unsigned_post(
+                "/api/v1/sync/notify",
+                &notify_body("z6Mkfoo/hello", &peer_did),
+                "198.51.100.22:5000",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let queued = db.dequeue_pending_syncs(100).await.unwrap();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].repo, "z6Mkfoo/hello");
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM received_ref_updates WHERE repo = $1")
+                .bind("z6Mkfoo/hello")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            count, 1,
+            "the valid path must still write the ref-update row"
+        );
+    }
+
+    #[sqlx::test]
+    async fn sync_notify_unknown_peer_wins_over_malformed_slug(pool: PgPool) {
+        // Ordering: the slug check sits after the peer gate, so an unknown peer
+        // still gets the unknown-peer message rather than a slug complaint.
+        let state = test_state(pool).await;
+        let stranger = Keypair::generate().did().to_string();
+        let router = crate::server::build_router(state);
+        let resp = router
+            .oneshot(unsigned_post(
+                "/api/v1/sync/notify",
+                &notify_body("a//tmp/gitlawb-probe", &stranger),
+                "198.51.100.23:5000",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(
+            body.contains("unknown peer DID"),
+            "peer gate must still fire first: {body}"
         );
     }
 

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -1068,6 +1068,74 @@ mod tests {
     }
 
     #[sqlx::test]
+    async fn unsigned_announce_then_notify_cannot_queue_a_repos_dir_escape(pool: PgPool) {
+        // The reachability case for #272, committed in its attack form. Two
+        // unsigned requests through the shipped router, no signature and no
+        // config change: announce the attacker's own DID (which is what makes
+        // them a "known peer"), then notify with `a/<abs>/gitlawb-probe`. That
+        // slug used to reach PathBuf::join in the sync worker, where the
+        // absolute second component discarded repos_dir and planted a mirror at
+        // /<abs>/gitlawb-probe.git. The notify must now be refused outright.
+        //
+        // This has to run over crate::server::build_router rather than a
+        // directly mounted handler: the point of the test is that the default
+        // layer stack (optional_signature, not require_signature) leaves the
+        // route open, so mounting the handler alone would assert nothing about
+        // reachability.
+        let state = test_state(pool).await;
+        let db = state.db.clone();
+        let attacker = Keypair::generate().did().to_string();
+        let router = crate::server::build_router(state);
+
+        let announce =
+            format!(r#"{{"did":"{attacker}","http_url":"https://attacker.example.com"}}"#);
+        let resp = router
+            .clone()
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &announce,
+                "198.51.100.40:5000",
+            ))
+            .await
+            .unwrap();
+        // Asserted, not assumed: this plan does not change announce, and the
+        // whole attack rests on an unsigned announce still succeeding.
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "unsigned announce still admits an attacker-generated DID"
+        );
+
+        let outside = tempfile::TempDir::new().unwrap();
+        let escape_dir = outside.path().join("gitlawb-probe");
+        let slug = format!("a/{}", escape_dir.display());
+        let resp = router
+            .oneshot(unsigned_post(
+                "/api/v1/sync/notify",
+                &notify_body(&slug, &attacker),
+                "198.51.100.41:5000",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "notify must refuse the escaping slug {slug:?}"
+        );
+
+        let queued = db.dequeue_pending_syncs(100).await.unwrap();
+        assert!(
+            queued.is_empty(),
+            "sync_queue must stay empty, got {:?}",
+            queued.iter().map(|q| &q.repo).collect::<Vec<_>>()
+        );
+        assert!(
+            !escape_dir.with_extension("git").exists(),
+            "nothing may be written at the escape target"
+        );
+    }
+
+    #[sqlx::test]
     async fn announce_still_accepts_unsigned_in_default_mode(pool: PgPool) {
         // must-not-over-reach: adding the brake must not tighten announce's
         // rolling-upgrade behavior — an unsigned announce with a public URL still

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -1647,25 +1647,39 @@ impl Db {
         Ok(())
     }
 
-    /// Claim the next batch of pending syncs, oldest attempt first.
+    /// Take up to `limit` pending syncs — the least recently attempted ones —
+    /// and stamp each with the time it was handed out.
     ///
-    /// This both selects and stamps, in one statement, and that is deliberate.
-    /// A row the worker cannot make progress on stays `pending` so it is
-    /// retried, and if its ordering key never moved it would remain among the
-    /// oldest rows forever, holding a fixed-size window against every healthy
-    /// repo behind it. Stamping on the way out makes the key "least recently
-    /// handed out", so a stuck row rotates to the back instead.
-    ///
-    /// Doing it here rather than at each deferral branch in the worker is what
-    /// makes that true by construction: no call site can forget, a batch that
-    /// dies mid-loop still leaves its rows stamped, and a failed stamp is a
-    /// failed dequeue the caller already handles rather than a silently
-    /// swallowed error. `enqueued_at` is left alone so backlog age stays
+    /// Selecting and stamping in one statement is deliberate. A row the worker
+    /// cannot make progress on stays `pending` so it is retried, and if its
+    /// ordering key never moved it would remain among the oldest rows forever,
+    /// holding a fixed-size window against every healthy repo behind it.
+    /// Stamping on the way out makes the key "least recently handed out", so a
+    /// stuck row rotates to the back instead. Doing it here rather than at each
+    /// deferral branch in the worker is what makes that hold by construction:
+    /// no call site can forget it, and a batch that dies mid-loop still leaves
+    /// its rows stamped. `enqueued_at` is left alone so backlog age stays
     /// measurable.
+    ///
+    /// Two things this deliberately does not promise. The returned rows are the
+    /// right *set*, in no particular order — `RETURNING` does not sort, and
+    /// nothing in `process_batch` depends on the order within a batch. And this
+    /// is not a claim: the rows stay `pending` with no row lock held past the
+    /// statement, so two workers against one database can still be handed the
+    /// same batch. Single-worker deployment is the existing assumption;
+    /// `FOR UPDATE SKIP LOCKED` is what would change that, and it is not here.
+    ///
+    /// Errors surface to the caller, which logs and skips the poll. That is
+    /// worth knowing now that this writes: it can fail for reasons a plain
+    /// SELECT could not, such as a read-only transaction or a lock timeout.
     pub async fn dequeue_pending_syncs(&self, limit: i64) -> Result<Vec<SyncQueueItem>> {
         let rows = sqlx::query(
+            // The outer `status = 'pending'` is not redundant with the
+            // subquery's: between the two, a concurrent worker can settle a row,
+            // and without it the UPDATE would still stamp and return a row that
+            // had already left the pending set.
             "UPDATE sync_queue SET attempted_at = $2
-             WHERE id IN (
+             WHERE status = 'pending' AND id IN (
                  SELECT id FROM sync_queue WHERE status = 'pending'
                  ORDER BY COALESCE(attempted_at, enqueued_at) ASC LIMIT $1
              )

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -883,8 +883,16 @@ const MIGRATIONS: &[Migration] = &[
             "ALTER TABLE received_ref_updates ADD COLUMN IF NOT EXISTS owner_did TEXT",
         ],
     },
+    // Reservation: v17, deliberately not main's current_max + 1 (which is 12).
+    // The runner keys the applied set on the integer alone, so a version another
+    // in-flight branch also claims is skipped in full on whichever side merges
+    // second — no error, no warning, and schema_migrations still reads healthy
+    // while the column is simply absent. Two open branches already claim into
+    // this range: #135/#173 holds through 14 (15 once it rebases past v11), and
+    // #253 took 16. 17 clears both. Gaps are harmless: the runner iterates the
+    // array and never requires contiguity.
     Migration {
-        version: 12,
+        version: 17,
         name: "sync_queue_attempted_at",
         stmts: &[
             // Scheduling key for dequeue_pending_syncs: when the row was last
@@ -3698,7 +3706,7 @@ mod migration_tests {
         db.migrate().await.unwrap();
     }
 
-    // ── sync_queue scheduling (attempted_at, v12) ────────────────────────────
+    // ── sync_queue scheduling (attempted_at, v17) ────────────────────────────
 
     async fn enqueue_one(db: &super::Db, repo: &str) {
         db.enqueue_sync(
@@ -3721,7 +3729,7 @@ mod migration_tests {
     }
 
     /// Upgrade-path test: simulate a node already at v11 and let the real
-    /// migration entry point apply v12, rather than hand-copying its SQL.
+    /// migration entry point apply v17, rather than hand-copying its SQL.
     ///
     /// This is the test that catches the column being added to the v1
     /// statement array instead of a new migration. v1 never re-runs on an
@@ -3729,7 +3737,7 @@ mod migration_tests {
     /// while staying invisible to every other test here, since `#[sqlx::test]`
     /// hands out a fresh database that runs the whole chain.
     #[sqlx::test]
-    async fn migration_v12_adds_sync_queue_attempted_at(pool: sqlx::PgPool) {
+    async fn migration_v17_adds_sync_queue_attempted_at(pool: sqlx::PgPool) {
         let db = super::Db::for_testing(pool);
         db.migrate().await.unwrap();
 
@@ -3738,7 +3746,7 @@ mod migration_tests {
             .execute(&db.pool)
             .await
             .unwrap();
-        sqlx::query("DELETE FROM schema_migrations WHERE version = 12")
+        sqlx::query("DELETE FROM schema_migrations WHERE version = 17")
             .execute(&db.pool)
             .await
             .unwrap();
@@ -3760,11 +3768,11 @@ mod migration_tests {
         assert_eq!(col.1, "YES", "attempted_at must be nullable");
 
         let recorded: (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM schema_migrations WHERE version = 12")
+            sqlx::query_as("SELECT COUNT(*) FROM schema_migrations WHERE version = 17")
                 .fetch_one(&db.pool)
                 .await
                 .unwrap();
-        assert_eq!(recorded.0, 1, "v12 must be recorded as applied");
+        assert_eq!(recorded.0, 1, "v17 must be recorded as applied");
 
         // The pre-existing row survives with a null key and is still dequeued.
         assert_eq!(attempted_at_of(&db, "z6Mkfoo/legacy").await, None);

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -883,6 +883,16 @@ const MIGRATIONS: &[Migration] = &[
             "ALTER TABLE received_ref_updates ADD COLUMN IF NOT EXISTS owner_did TEXT",
         ],
     },
+    Migration {
+        version: 12,
+        name: "sync_queue_attempted_at",
+        stmts: &[
+            // Scheduling key for dequeue_pending_syncs: when the row was last
+            // handed to a worker. Null until first dequeued, which is why the
+            // ordering coalesces onto enqueued_at.
+            "ALTER TABLE sync_queue ADD COLUMN IF NOT EXISTS attempted_at TEXT",
+        ],
+    },
 ];
 
 // ── Repos ─────────────────────────────────────────────────────────────────────
@@ -1637,13 +1647,32 @@ impl Db {
         Ok(())
     }
 
+    /// Claim the next batch of pending syncs, oldest attempt first.
+    ///
+    /// This both selects and stamps, in one statement, and that is deliberate.
+    /// A row the worker cannot make progress on stays `pending` so it is
+    /// retried, and if its ordering key never moved it would remain among the
+    /// oldest rows forever, holding a fixed-size window against every healthy
+    /// repo behind it. Stamping on the way out makes the key "least recently
+    /// handed out", so a stuck row rotates to the back instead.
+    ///
+    /// Doing it here rather than at each deferral branch in the worker is what
+    /// makes that true by construction: no call site can forget, a batch that
+    /// dies mid-loop still leaves its rows stamped, and a failed stamp is a
+    /// failed dequeue the caller already handles rather than a silently
+    /// swallowed error. `enqueued_at` is left alone so backlog age stays
+    /// measurable.
     pub async fn dequeue_pending_syncs(&self, limit: i64) -> Result<Vec<SyncQueueItem>> {
         let rows = sqlx::query(
-            "SELECT id, repo, node_did, ref_name, new_sha, cid, status, enqueued_at
-             FROM sync_queue WHERE status = 'pending'
-             ORDER BY enqueued_at ASC LIMIT $1",
+            "UPDATE sync_queue SET attempted_at = $2
+             WHERE id IN (
+                 SELECT id FROM sync_queue WHERE status = 'pending'
+                 ORDER BY COALESCE(attempted_at, enqueued_at) ASC LIMIT $1
+             )
+             RETURNING id, repo, node_did, ref_name, new_sha, cid, status, enqueued_at",
         )
         .bind(limit)
+        .bind(Utc::now().to_rfc3339())
         .fetch_all(&self.pool)
         .await?;
         Ok(rows
@@ -3653,6 +3682,186 @@ mod migration_tests {
 
         // (d) Re-run: idempotent — ADD COLUMN IF NOT EXISTS must not error.
         db.migrate().await.unwrap();
+    }
+
+    // ── sync_queue scheduling (attempted_at, v12) ────────────────────────────
+
+    async fn enqueue_one(db: &super::Db, repo: &str) {
+        db.enqueue_sync(
+            repo,
+            "did:key:zPEER",
+            "refs/heads/main",
+            &"0".repeat(40),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn attempted_at_of(db: &super::Db, repo: &str) -> Option<String> {
+        sqlx::query_scalar("SELECT attempted_at FROM sync_queue WHERE repo = $1")
+            .bind(repo)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap()
+    }
+
+    /// Upgrade-path test: simulate a node already at v11 and let the real
+    /// migration entry point apply v12, rather than hand-copying its SQL.
+    ///
+    /// This is the test that catches the column being added to the v1
+    /// statement array instead of a new migration. v1 never re-runs on an
+    /// existing install, so that mistake breaks every deployed node's dequeue
+    /// while staying invisible to every other test here, since `#[sqlx::test]`
+    /// hands out a fresh database that runs the whole chain.
+    #[sqlx::test]
+    async fn migration_v12_adds_sync_queue_attempted_at(pool: sqlx::PgPool) {
+        let db = super::Db::for_testing(pool);
+        db.migrate().await.unwrap();
+
+        // Roll back to v11: drop the column and forget the version.
+        sqlx::query("ALTER TABLE sync_queue DROP COLUMN attempted_at")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM schema_migrations WHERE version = 12")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+
+        // A row written by the old node, before the column existed.
+        enqueue_one(&db, "z6Mkfoo/legacy").await;
+
+        db.migrate().await.unwrap();
+
+        let col: (String, String) = sqlx::query_as(
+            "SELECT data_type, is_nullable
+             FROM information_schema.columns
+             WHERE table_name = 'sync_queue' AND column_name = 'attempted_at'",
+        )
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+        assert_eq!(col.0, "text");
+        assert_eq!(col.1, "YES", "attempted_at must be nullable");
+
+        let recorded: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM schema_migrations WHERE version = 12")
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        assert_eq!(recorded.0, 1, "v12 must be recorded as applied");
+
+        // The pre-existing row survives with a null key and is still dequeued.
+        assert_eq!(attempted_at_of(&db, "z6Mkfoo/legacy").await, None);
+        let items = db.dequeue_pending_syncs(10).await.unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].repo, "z6Mkfoo/legacy");
+
+        // Idempotent re-run.
+        db.migrate().await.unwrap();
+    }
+
+    #[sqlx::test]
+    async fn dequeue_stamps_attempted_at_on_every_row_it_hands_out(pool: sqlx::PgPool) {
+        // The stamp is what stops a deferred row from holding the window, and
+        // it happens here rather than at the deferral branches so no call site
+        // can forget it.
+        let db = super::Db::for_testing(pool);
+        db.migrate().await.unwrap();
+        enqueue_one(&db, "z6Mkfoo/a").await;
+        assert_eq!(
+            attempted_at_of(&db, "z6Mkfoo/a").await,
+            None,
+            "a freshly enqueued row has no attempt yet"
+        );
+
+        let items = db.dequeue_pending_syncs(10).await.unwrap();
+        assert_eq!(items.len(), 1);
+        assert!(
+            attempted_at_of(&db, "z6Mkfoo/a").await.is_some(),
+            "dequeue must stamp the row it returns, whatever the worker does next"
+        );
+    }
+
+    #[sqlx::test]
+    async fn dequeue_orders_by_last_attempt_then_enqueue_time(pool: sqlx::PgPool) {
+        let db = super::Db::for_testing(pool);
+        db.migrate().await.unwrap();
+        enqueue_one(&db, "z6Mkfoo/older").await;
+        enqueue_one(&db, "z6Mkfoo/newer").await;
+        sqlx::query("UPDATE sync_queue SET enqueued_at = $1 WHERE repo = $2")
+            .bind("2026-07-29T00:00:00Z")
+            .bind("z6Mkfoo/older")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE sync_queue SET enqueued_at = $1 WHERE repo = $2")
+            .bind("2026-07-29T00:00:01Z")
+            .bind("z6Mkfoo/newer")
+            .execute(&db.pool)
+            .await
+            .unwrap();
+
+        // Never-attempted rows fall back to enqueue order.
+        let first = db.dequeue_pending_syncs(1).await.unwrap();
+        assert_eq!(first[0].repo, "z6Mkfoo/older");
+
+        // Having been attempted, it now sorts behind the untried row.
+        let second = db.dequeue_pending_syncs(1).await.unwrap();
+        assert_eq!(
+            second[0].repo, "z6Mkfoo/newer",
+            "an attempted row must yield to one that has never been tried"
+        );
+    }
+
+    #[sqlx::test]
+    async fn dequeue_leaves_enqueued_at_untouched(pool: sqlx::PgPool) {
+        // enqueued_at keeps meaning enqueue time, so backlog age stays
+        // measurable; that is the reason attempted_at is a separate column.
+        let db = super::Db::for_testing(pool);
+        db.migrate().await.unwrap();
+        enqueue_one(&db, "z6Mkfoo/a").await;
+        let before: String =
+            sqlx::query_scalar("SELECT enqueued_at FROM sync_queue WHERE repo = 'z6Mkfoo/a'")
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+
+        db.dequeue_pending_syncs(10).await.unwrap();
+
+        let after: String =
+            sqlx::query_scalar("SELECT enqueued_at FROM sync_queue WHERE repo = 'z6Mkfoo/a'")
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[sqlx::test]
+    async fn dequeue_does_not_touch_settled_rows(pool: sqlx::PgPool) {
+        // The stamping UPDATE must not reach a row that already left the
+        // pending set, or a terminal row could be dragged back into rotation.
+        let db = super::Db::for_testing(pool);
+        db.migrate().await.unwrap();
+        enqueue_one(&db, "z6Mkfoo/failed").await;
+        enqueue_one(&db, "z6Mkfoo/done").await;
+        let ids: Vec<(String, String)> =
+            sqlx::query_as("SELECT repo, id FROM sync_queue ORDER BY repo")
+                .fetch_all(&db.pool)
+                .await
+                .unwrap();
+        for (repo, id) in &ids {
+            if repo.ends_with("failed") {
+                db.mark_sync_failed(id).await.unwrap();
+            } else {
+                db.mark_sync_done(id).await.unwrap();
+            }
+        }
+
+        assert!(db.dequeue_pending_syncs(10).await.unwrap().is_empty());
+        assert_eq!(attempted_at_of(&db, "z6Mkfoo/failed").await, None);
+        assert_eq!(attempted_at_of(&db, "z6Mkfoo/done").await, None);
     }
 }
 

--- a/crates/gitlawb-node/src/git/repo_store.rs
+++ b/crates/gitlawb-node/src/git/repo_store.rs
@@ -336,6 +336,89 @@ pub(crate) fn validate_repo_slug(slug: &str) -> Result<(&str, &str)> {
     Ok((owner, name))
 }
 
+/// The answer from [`path_within_root`].
+///
+/// Three-valued rather than a bool because the two negative answers call for
+/// opposite handling. `Outside` is a deterministic verdict about a hostile or
+/// misconfigured path: the same input fails the same way forever, so the caller
+/// can retire the work. `IoError` says the question could not be answered at
+/// all (EACCES, an unmounted root), which is transient, so the caller must keep
+/// the work and try again rather than permanently retire a legitimate repo.
+#[derive(Debug)]
+pub(crate) enum Containment {
+    /// The candidate resolves inside the root.
+    Contained,
+    /// The candidate resolves outside the root.
+    Outside,
+    /// The filesystem could not answer the question.
+    IoError(std::io::Error),
+}
+
+/// Does `candidate` canonically resolve inside `root`?
+///
+/// The third layer of path defence, after the character allowlist and the
+/// component walk on `RepoStore::local_path`. Those two read the path as text
+/// and cannot see a symlink standing between the root and the target (#272).
+///
+/// One contract covers both the clone and the fetch branch. `symlink_metadata`
+/// decides which:
+///
+///   * The candidate exists (including as a symlink), so the candidate itself is
+///     canonicalized. That resolves the link and catches a mirror path that is a
+///     symlink to a bare repo outside the root, which a parent-only check misses
+///     entirely: the parent canonicalizes clean, `exists()` follows the link, and
+///     the fetch then writes through it.
+///   * The candidate does not exist, so its parent is canonicalized instead.
+///     This is the first-clone case. Canonicalizing the candidate unconditionally
+///     would reject every first clone, since `canonicalize` errors on a path that
+///     does not exist.
+///
+/// Pure: it reads the filesystem and never creates, moves, or removes anything.
+/// Callers that need the parent directory to exist create it themselves before
+/// asking, because a predicate that created a directory as a side effect of
+/// being asked would be wrong for a caller asking about a path it is about to
+/// delete.
+pub(crate) fn path_within_root(candidate: &Path, root: &Path) -> Containment {
+    let root = match root.canonicalize() {
+        Ok(p) => p,
+        // A root that cannot be resolved is an operator condition, never a
+        // verdict on the candidate, so every error kind is retryable here.
+        Err(e) => return Containment::IoError(e),
+    };
+
+    let resolved = match std::fs::symlink_metadata(candidate) {
+        // The candidate exists as an entry: resolve it, links and all. A failure
+        // now (a dangling symlink, a permission change mid-flight) is an I/O
+        // answer, since the entry was there a moment ago.
+        Ok(_) => match candidate.canonicalize() {
+            Ok(p) => p,
+            Err(e) => return Containment::IoError(e),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let Some(parent) = candidate.parent() else {
+                return Containment::Outside;
+            };
+            match parent.canonicalize() {
+                Ok(p) => p,
+                // A parent that is not there is a real answer about where this
+                // path sits; anything else is the filesystem failing to answer.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Containment::Outside;
+                }
+                Err(e) => return Containment::IoError(e),
+            }
+        }
+        // Neither "it is there" nor "it is not there": we cannot tell.
+        Err(e) => return Containment::IoError(e),
+    };
+
+    if resolved.starts_with(&root) {
+        Containment::Contained
+    } else {
+        Containment::Outside
+    }
+}
+
 fn validate_owner_did(owner_did: &str) -> Result<()> {
     if owner_did.is_empty() {
         anyhow::bail!("owner_did is empty");
@@ -532,6 +615,137 @@ mod tests {
         let long_name = format!("z6Mkfoo/{}", "n".repeat(101));
         assert!(validate_repo_slug(&long_owner).is_err());
         assert!(validate_repo_slug(&long_name).is_err());
+    }
+
+    // ── canonical containment (#272) ───────────────────────────────────────
+
+    use tempfile::TempDir;
+
+    #[test]
+    fn containment_accepts_a_path_inside_the_root() {
+        let root = TempDir::new().unwrap();
+        let inside = root.path().join("z6Mkfoo");
+        std::fs::create_dir_all(&inside).unwrap();
+        assert!(matches!(
+            path_within_root(&inside.join("hello.git"), root.path()),
+            Containment::Contained
+        ));
+    }
+
+    #[test]
+    fn containment_rejects_a_sibling_outside_the_root() {
+        let base = TempDir::new().unwrap();
+        let root = base.path().join("root");
+        let sibling = base.path().join("other");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&sibling).unwrap();
+        assert!(matches!(
+            path_within_root(&sibling, &root),
+            Containment::Outside
+        ));
+    }
+
+    #[test]
+    fn containment_rejects_a_symlinked_directory_inside_the_root() {
+        use std::os::unix::fs::symlink;
+        let base = TempDir::new().unwrap();
+        let root = base.path().join("root");
+        let outside = base.path().join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let link = root.join("owner");
+        symlink(&outside, &link).unwrap();
+        assert!(matches!(
+            path_within_root(&link, &root),
+            Containment::Outside
+        ));
+    }
+
+    #[test]
+    fn containment_rejects_a_symlinked_file_inside_the_root() {
+        use std::os::unix::fs::symlink;
+        let base = TempDir::new().unwrap();
+        let root = base.path().join("root");
+        std::fs::create_dir_all(&root).unwrap();
+        let outside = base.path().join("secret.txt");
+        std::fs::write(&outside, b"x").unwrap();
+        let link = root.join("hello.git");
+        symlink(&outside, &link).unwrap();
+        assert!(matches!(
+            path_within_root(&link, &root),
+            Containment::Outside
+        ));
+    }
+
+    #[test]
+    fn containment_accepts_a_missing_candidate_whose_parent_is_inside() {
+        // The first-clone case: the mirror path does not exist yet, so only the
+        // parent can be canonicalized. Rejecting this is total loss of mirroring.
+        let root = TempDir::new().unwrap();
+        let owner = root.path().join("z6Mkfoo");
+        std::fs::create_dir_all(&owner).unwrap();
+        let candidate = owner.join("hello.git");
+        assert!(!candidate.exists());
+        assert!(matches!(
+            path_within_root(&candidate, root.path()),
+            Containment::Contained
+        ));
+    }
+
+    #[test]
+    fn containment_rejects_a_missing_candidate_under_a_symlinked_parent() {
+        use std::os::unix::fs::symlink;
+        let base = TempDir::new().unwrap();
+        let root = base.path().join("root");
+        let outside = base.path().join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, root.join("z6Mkfoo")).unwrap();
+        let candidate = root.join("z6Mkfoo").join("hello.git");
+        assert!(matches!(
+            path_within_root(&candidate, &root),
+            Containment::Outside
+        ));
+    }
+
+    #[test]
+    fn containment_reports_io_error_for_a_dangling_symlink() {
+        // The link entry exists, so the candidate is the thing to resolve, and
+        // resolving it fails. That is an I/O answer, not a verdict of Outside:
+        // the worker must retry rather than permanently retire the row.
+        use std::os::unix::fs::symlink;
+        let root = TempDir::new().unwrap();
+        let link = root.path().join("hello.git");
+        symlink(root.path().join("nothing-here"), &link).unwrap();
+        assert!(matches!(
+            path_within_root(&link, root.path()),
+            Containment::IoError(_)
+        ));
+    }
+
+    #[test]
+    fn containment_reports_io_error_for_an_uncanonicalizable_root() {
+        // A repos_dir that cannot be resolved is an operator condition (an
+        // unmounted volume, a bad config), not a hostile path.
+        let base = TempDir::new().unwrap();
+        let root = base.path().join("not-mounted");
+        let candidate = base.path().join("not-mounted").join("hello.git");
+        assert!(matches!(
+            path_within_root(&candidate, &root),
+            Containment::IoError(_)
+        ));
+    }
+
+    #[test]
+    fn containment_creates_nothing_on_disk() {
+        // The predicate is pure: the admin purge path asks it about directories
+        // it is about to delete, so creating one as a side effect would be wrong.
+        let root = TempDir::new().unwrap();
+        let candidate = root.path().join("z6Mkfoo").join("hello.git");
+        let _ = path_within_root(&candidate, root.path());
+        assert!(!candidate.exists());
+        assert!(!root.path().join("z6Mkfoo").exists());
+        assert_eq!(std::fs::read_dir(root.path()).unwrap().count(), 0);
     }
 
     // ── repo_name validation ───────────────────────────────────────────────

--- a/crates/gitlawb-node/src/git/repo_store.rs
+++ b/crates/gitlawb-node/src/git/repo_store.rs
@@ -303,6 +303,39 @@ fn validate_path_components(owner_did: &str, repo_name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Validate a peer-supplied `owner/name` sync slug and return its two halves.
+///
+/// The sync queue carries a single `repo` string that peers control, and the
+/// worker turns it into a filesystem path. `PathBuf::join` does not normalize,
+/// and an absolute second component replaces the accumulated path, so an
+/// unvalidated `a//tmp/x` resolved to `/tmp/x.git` outside `repos_dir` (#272).
+///
+/// The halves are checked with the same validators that guard
+/// `RepoStore::local_path`, so there is one owner rule and one name rule in the
+/// crate. The one rule added here is the leading `.`/`-` check on the owner
+/// half: `validate_owner_did` has no such rule (it also serves full DIDs, which
+/// always start with `d`), and without it an owner half of `.` puts a
+/// peer-controlled mirror at the `repos_dir` root, which canonicalizes back
+/// inside the root and so passes containment.
+pub(crate) fn validate_repo_slug(slug: &str) -> Result<(&str, &str)> {
+    let mut parts = slug.split('/');
+    let (Some(owner), Some(name)) = (parts.next(), parts.next()) else {
+        anyhow::bail!("repo slug must be 'owner/name'");
+    };
+    if parts.next().is_some() {
+        anyhow::bail!("repo slug must contain exactly one '/'");
+    }
+    if owner.is_empty() || name.is_empty() {
+        anyhow::bail!("repo slug has an empty owner or name");
+    }
+    if owner.starts_with('.') || owner.starts_with('-') {
+        anyhow::bail!("repo slug owner must not start with '.' or '-'");
+    }
+    validate_owner_did(owner)?;
+    validate_repo_name(name)?;
+    Ok((owner, name))
+}
+
 fn validate_owner_did(owner_did: &str) -> Result<()> {
     if owner_did.is_empty() {
         anyhow::bail!("owner_did is empty");
@@ -404,6 +437,102 @@ fn advisory_lock_key(owner_slug: &str, repo_name: &str) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── sync slug validation (#272) ────────────────────────────────────────
+
+    #[test]
+    fn slug_accepts_owner_and_name() {
+        let (owner, name) = validate_repo_slug("z6Mkfoo/hello").expect("valid slug");
+        assert_eq!(owner, "z6Mkfoo");
+        assert_eq!(name, "hello");
+    }
+
+    #[test]
+    fn slug_rejects_traversal_in_owner_half() {
+        assert!(validate_repo_slug("../hello").is_err());
+    }
+
+    #[test]
+    fn slug_rejects_owner_half_only_the_did_validator_catches() {
+        // These are the cases that isolate the `validate_owner_did` delegation.
+        // `../hello` does NOT: the leading-character rule above rejects it
+        // first, so deleting the delegation leaves that case green. Each owner
+        // half here has exactly one separator, a non-empty name, and a leading
+        // character the slug rules allow, so only the delegation can reject it.
+        for bad in [
+            "a..b/hello",    // interior `..` sequence
+            "a%2e%2e/hello", // percent-encoded, disallowed `%`
+            "own\\er/hello", // backslash
+        ] {
+            assert!(validate_repo_slug(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn slug_rejects_extra_separator() {
+        // The verified #272 escape: `a//tmp/x` joined to an absolute
+        // `/tmp/x.git` outside repos_dir.
+        assert!(validate_repo_slug("a//tmp/gitlawb-probe").is_err());
+        assert!(validate_repo_slug("../../etc/evil").is_err());
+        assert!(validate_repo_slug("a/../../x").is_err());
+    }
+
+    #[test]
+    fn slug_rejects_trailing_segment_only_the_separator_count_catches() {
+        // The case that isolates the separator-count rule. Every slug in
+        // `slug_rejects_extra_separator` is caught by some earlier rule
+        // instead: `a//tmp/...` has an empty name half, `../../etc/evil` trips
+        // the leading-character rule, and `a/../../x` has `..` as its name. Here
+        // both halves are individually valid, so only the count can reject it.
+        // It matters because the worker would otherwise join
+        // `repos_dir/z6Mkfoo/hello.git` while composing the remote URL from the
+        // full three-segment slug, silently mirroring one repo under another's
+        // path.
+        assert!(validate_repo_slug("z6Mkfoo/hello/extra").is_err());
+    }
+
+    #[test]
+    fn slug_rejects_missing_separator() {
+        for bad in ["..", "demo", ""] {
+            assert!(validate_repo_slug(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn slug_rejects_empty_half() {
+        for bad in ["/hello", "z6Mkfoo/"] {
+            assert!(validate_repo_slug(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn slug_rejects_leading_dot_or_dash_owner() {
+        // `./hello` would otherwise resolve to a mirror at the repos_dir root,
+        // which the containment check would approve.
+        for bad in ["./hello", "-owner/hello"] {
+            assert!(validate_repo_slug(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn slug_rejects_bad_name_half() {
+        for bad in [
+            "z6Mkfoo/he\0llo",
+            "z6Mkfoo/.hidden",
+            "z6Mkfoo/-dash",
+            "z6Mkfoo/a..b",
+        ] {
+            assert!(validate_repo_slug(bad).is_err(), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn slug_rejects_overlong_halves() {
+        let long_owner = format!("{}/hello", "z".repeat(257));
+        let long_name = format!("z6Mkfoo/{}", "n".repeat(101));
+        assert!(validate_repo_slug(&long_owner).is_err());
+        assert!(validate_repo_slug(&long_name).is_err());
+    }
 
     // ── repo_name validation ───────────────────────────────────────────────
 

--- a/crates/gitlawb-node/src/git/repo_store.rs
+++ b/crates/gitlawb-node/src/git/repo_store.rs
@@ -331,6 +331,15 @@ pub(crate) fn validate_repo_slug(slug: &str) -> Result<(&str, &str)> {
     if owner.starts_with('.') || owner.starts_with('-') {
         anyhow::bail!("repo slug owner must not start with '.' or '-'");
     }
+    // The owner half becomes one path component, so it is bounded by NAME_MAX
+    // (255), not by the DID column's 256. The two differ by exactly one, and
+    // that one length is the gap that matters: validate_owner_did accepts 256,
+    // create_dir_all then fails with ENAMETOOLONG on every attempt, and the
+    // worker leaves such a row pending, so it is re-picked forever. Rejecting
+    // it here means an undeliverable slug never enters the queue at all.
+    if owner.len() > 255 {
+        anyhow::bail!("repo slug owner exceeds 255 chars");
+    }
     validate_owner_did(owner)?;
     validate_repo_name(name)?;
     Ok((owner, name))
@@ -615,6 +624,20 @@ mod tests {
         let long_name = format!("z6Mkfoo/{}", "n".repeat(101));
         assert!(validate_repo_slug(&long_owner).is_err());
         assert!(validate_repo_slug(&long_name).is_err());
+    }
+
+    #[test]
+    fn slug_rejects_owner_half_at_the_filesystem_name_limit() {
+        // The owner half becomes a single path component, and Linux NAME_MAX is
+        // 255, so 256 is accepted by validate_owner_did (which bails only above
+        // 256) but can never be created on disk. That made the sync row
+        // permanently un-runnable: create_dir_all failed with ENAMETOOLONG on
+        // every pass and the worker left the row pending, so ten unsigned
+        // requests could hold the whole oldest-first batch forever.
+        assert!(validate_repo_slug(&format!("{}/hello", "z".repeat(256))).is_err());
+        // 255 is the largest creatable component and must still be accepted, so
+        // the bound is not quietly over-tightened.
+        assert!(validate_repo_slug(&format!("{}/hello", "z".repeat(255))).is_ok());
     }
 
     // ── canonical containment (#272) ───────────────────────────────────────

--- a/crates/gitlawb-node/src/metrics.rs
+++ b/crates/gitlawb-node/src/metrics.rs
@@ -235,7 +235,11 @@ pub fn record_auth_failure(route: &str, reason: &str) {
     }
 }
 
-/// Record one sync_queue item outcome. `status` ∈ {done, failed, skipped}.
+/// Record one sync_queue item outcome. `status` ∈ {done, failed, skipped,
+/// rejected, deferred}. `rejected` is terminal and caused by a guard (a
+/// malformed slug, or a path resolving outside repos_dir); `deferred` leaves
+/// the row pending for a later pass, so a queue stalled on an operator
+/// condition is visible rather than looking idle.
 pub fn record_sync_processed(status: &str) {
     if let Some(c) = SYNC_PROCESSED.get() {
         c.with_label_values(&[status]).inc();

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -253,16 +253,25 @@ async fn process_batch(
         // the check then covers clone and fetch alike.
         let owner_dir = config.repos_dir.join(owner_short);
         if let Err(e) = std::fs::create_dir_all(&owner_dir) {
-            // Split by whether the error can ever clear. A read-only or briefly
-            // unmounted repos_dir is transient, so the row stays pending and is
-            // retried. A path that is simply not creatable never clears, and
-            // leaving it pending would re-pick it on every poll: since
-            // dequeue_pending_syncs is oldest-first with a fixed batch size, a
-            // handful of such rows hold the whole window and starve every
-            // healthy repo behind them.
+            // Split by whether retrying could ever change the answer. A
+            // read-only or briefly unmounted repos_dir is transient, so the row
+            // stays pending and is retried. A path that is simply not creatable
+            // is not going to become creatable on the next poll, and leaving it
+            // pending re-picks it forever.
+            //
+            // AlreadyExists is in this set because create_dir_all only reports
+            // it when something that is not a directory occupies the path — a
+            // regular file, a dangling symlink, a link loop. The concurrent
+            // mkdir race that looks like a false positive resolves to Ok
+            // instead, since the implementation falls back to is_dir() on
+            // EEXIST and a racing mkdir leaves a directory there. Clearing it
+            // takes an operator (or, for a dangling link, its target appearing),
+            // never a retry. This is also what the pre-#272 code did: the same
+            // state failed the clone and hit the terminal Err arm below.
             let permanent = matches!(
                 e.kind(),
-                std::io::ErrorKind::InvalidFilename
+                std::io::ErrorKind::AlreadyExists
+                    | std::io::ErrorKind::InvalidFilename
                     | std::io::ErrorKind::InvalidInput
                     | std::io::ErrorKind::NotADirectory
             );
@@ -1623,6 +1632,75 @@ mod tests {
 
         assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "done");
         assert!(repos_dir.join("z6Mkfoo").join("hello.git").is_dir());
+    }
+
+    #[sqlx::test]
+    async fn process_batch_terminally_fails_when_a_file_occupies_the_owner_path(pool: PgPool) {
+        // A plain file at `repos_dir/<owner>` makes `create_dir_all` fail with
+        // `AlreadyExists`, and retrying cannot change that. Before this was
+        // classified permanent the row stayed pending and, because
+        // `dequeue_pending_syncs` is oldest-first over a fixed batch, ten such
+        // rows held the whole window and starved every healthy repo behind them.
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+        let owner_path = repos_dir.join("z6Mkfoo");
+        std::fs::write(&owner_path, b"not a directory\n").unwrap();
+
+        let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkOrigin";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, "z6Mkfoo/hello", did).await;
+
+        run_batch(&state, &repos_dir).await;
+
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "failed");
+        // Terminal, not merely skipped: the row leaves the pending set, so it
+        // can never come back as a poison item.
+        assert!(state.db.dequeue_pending_syncs(10).await.unwrap().is_empty());
+        run_batch(&state, &repos_dir).await;
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "failed");
+
+        // The occupied path is left exactly as it was, and no mirror landed.
+        assert_eq!(
+            std::fs::read(&owner_path).unwrap(),
+            b"not a directory\n".to_vec()
+        );
+        assert!(mirrors_under(home.path()).is_empty());
+    }
+
+    #[sqlx::test]
+    async fn process_batch_terminally_fails_when_a_dangling_symlink_occupies_the_owner_path(
+        pool: PgPool,
+    ) {
+        // Same `AlreadyExists` classification through a different filesystem
+        // state: `mkdir` returns EEXIST and `is_dir()` is false because the
+        // link resolves to nothing.
+        use std::os::unix::fs::symlink;
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+        let owner_path = repos_dir.join("z6Mkfoo");
+        symlink(home.path().join("no-such-target"), &owner_path).unwrap();
+
+        let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkOrigin";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, "z6Mkfoo/hello", did).await;
+
+        run_batch(&state, &repos_dir).await;
+
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "failed");
+        assert!(state.db.dequeue_pending_syncs(10).await.unwrap().is_empty());
+        run_batch(&state, &repos_dir).await;
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "failed");
+
+        // The link is untouched and its target was never created on our behalf.
+        assert!(owner_path.is_symlink());
+        assert!(!home.path().join("no-such-target").exists());
+        assert!(mirrors_under(home.path()).is_empty());
     }
 
     #[sqlx::test]

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -252,13 +252,26 @@ async fn process_batch(
         // the check then covers clone and fetch alike.
         let owner_dir = config.repos_dir.join(owner_short);
         if let Err(e) = std::fs::create_dir_all(&owner_dir) {
-            // Leave the row pending: a read-only or briefly unmounted repos_dir
-            // is transient, and marking failed is terminal (dequeue_pending_syncs
-            // only ever selects pending rows).
+            // Split by whether the error can ever clear. A read-only or briefly
+            // unmounted repos_dir is transient, so the row stays pending and is
+            // retried. A path that is simply not creatable never clears, and
+            // leaving it pending would re-pick it on every poll: since
+            // dequeue_pending_syncs is oldest-first with a fixed batch size, a
+            // handful of such rows hold the whole window and starve every
+            // healthy repo behind them.
+            let permanent = matches!(
+                e.kind(),
+                std::io::ErrorKind::InvalidFilename
+                    | std::io::ErrorKind::InvalidInput
+                    | std::io::ErrorKind::NotADirectory
+            );
             error!(
                 id = %item.id, repo = %item.repo, path = %owner_dir.display(), err = %e,
-                "cannot create the owner directory for a mirror; leaving the sync row pending"
+                permanent, "cannot create the owner directory for a mirror"
             );
+            if permanent {
+                let _ = db.mark_sync_failed(&item.id).await;
+            }
             continue;
         }
         match crate::git::repo_store::path_within_root(&local_path, &config.repos_dir) {
@@ -1491,11 +1504,17 @@ mod tests {
         let owner_dir = repos_dir.join("z6Mkfoo");
         std::fs::create_dir_all(&owner_dir).unwrap();
         std::fs::set_permissions(&owner_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
-        if std::fs::symlink_metadata(owner_dir.join("hello.git")).is_ok() {
-            // Running with enough privilege to ignore the mode bits (root).
+        // Probe by trying to CREATE inside the unreadable directory. Probing with
+        // symlink_metadata on a child that was never created returns Err for
+        // every user (ENOENT unprivileged, ENOENT as root), so that branch could
+        // never fire and the guard it looks like was not there at all.
+        if std::fs::create_dir(owner_dir.join("probe")).is_ok() {
             std::fs::set_permissions(&owner_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
-            eprintln!("skipping: permissions do not restrict this user");
-            return;
+            panic!(
+                "this test needs a user the mode bits actually restrict; it is the only \
+                 coverage for leaving the row pending on an I/O error, and passing it as \
+                 root would prove nothing. Run the suite unprivileged."
+            );
         }
 
         let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
@@ -1529,8 +1548,14 @@ mod tests {
         if std::fs::create_dir(repos_dir.join("probe")).is_ok() {
             std::fs::set_permissions(&repos_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
             std::fs::remove_dir(repos_dir.join("probe")).unwrap();
-            eprintln!("skipping: permissions do not restrict this user");
-            return;
+            // Fail rather than return: cargo swallows stderr for a passing test,
+            // so an early return here would report "ok" on a root runner while
+            // exercising nothing, and the pending-vs-failed contract would ship
+            // unverified from that point on.
+            panic!(
+                "this test needs a user the mode bits actually restrict; \
+                 run the suite unprivileged."
+            );
         }
 
         let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -222,17 +222,23 @@ async fn process_batch(
             }
         };
 
-        // Derive local disk path matching repo_disk_path convention:
-        // {repos_dir}/{owner_slug}/{name}.git
-        // item.repo is "{short_owner}/{name}" — split on first '/'
-        let (owner_short, repo_name) = match item.repo.split_once('/') {
-            Some(pair) => pair,
-            None => {
-                warn!(repo = %item.repo, "sync item repo has no '/' separator — skipping");
+        // Validate the slug before deriving any path from it. The row may have
+        // been queued before this check existed, or by the gossip/trigger
+        // writers, so the worker does not trust it (issue #272). This has to run
+        // ahead of the repos_dir join: PathBuf::join does not normalize, and an
+        // absolute second component discards the root entirely, which put a
+        // mirror outside repos_dir.
+        let (owner_short, repo_name) = match crate::git::repo_store::validate_repo_slug(&item.repo)
+        {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!(id = %item.id, repo = %item.repo, err = %e, "sync item has an invalid repo slug, skipping");
                 let _ = db.mark_sync_failed(&item.id).await;
                 continue;
             }
         };
+        // Local disk path matching the repo_disk_path convention:
+        // {repos_dir}/{owner_slug}/{name}.git
         let local_path = config
             .repos_dir
             .join(owner_short)
@@ -691,6 +697,7 @@ async fn fetch_repo(local_path: &Path, remote_url: &str, mode: MirrorMode) -> an
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlx::PgPool;
     use std::process::Command;
     use tempfile::TempDir;
 
@@ -1031,5 +1038,255 @@ mod tests {
     #[test]
     fn resolve_origin_url_returns_none_for_empty_peer_list() {
         assert_eq!(resolve_origin_url(&[], "did:key:a"), None);
+    }
+
+    // ── worker-side slug validation (issue #272) ─────────────────────────────
+
+    /// Build a rooted remote: one bare repo per entry in `rels`, each at
+    /// `root/{rel}`, and return the `file://` URL of `root` itself.
+    ///
+    /// `process_batch` composes the remote as `{peer_url}/{item.repo}`, so a
+    /// peer URL has to be a root under which the slug resolves to the bare
+    /// repo. `bare_remote` above returns a URL pointing straight at `bare.git`
+    /// and cannot serve as a peer URL as is.
+    ///
+    /// `root` sits two directories deep inside the tempdir so that a `rel`
+    /// carrying `..` (a hostile slug composed onto the root) still resolves
+    /// inside the tempdir instead of somewhere in the real filesystem.
+    fn rooted_remote(rels: &[&str]) -> (TempDir, String) {
+        let td = TempDir::new().unwrap();
+        let origin = td.path().join("origin");
+        std::fs::create_dir_all(&origin).unwrap();
+        std::fs::write(origin.join("a.txt"), b"hi\n").unwrap();
+        g(&["init", "-q"], &origin);
+        g(&["config", "user.email", "t@t"], &origin);
+        g(&["config", "user.name", "t"], &origin);
+        g(&["add", "."], &origin);
+        g(&["commit", "-qm", "init"], &origin);
+
+        let root = td.path().join("r1").join("r2").join("root");
+        std::fs::create_dir_all(&root).unwrap();
+        for rel in rels {
+            let bare = root.join(rel);
+            std::fs::create_dir_all(bare.parent().unwrap()).unwrap();
+            g(
+                &[
+                    "clone",
+                    "-q",
+                    "--bare",
+                    origin.to_str().unwrap(),
+                    bare.to_str().unwrap(),
+                ],
+                td.path(),
+            );
+        }
+        let url = format!("file://{}", root.display());
+        (td, url)
+    }
+
+    /// Insert a peer row directly.
+    ///
+    /// `Db::upsert_peer` runs the URL through `crate::api::peers::is_public_http_url`
+    /// and bails on anything that is not public http/https, which rules out both
+    /// `file://` and `http://127.0.0.1:PORT`. A worker test needs a locally
+    /// reachable origin, so the row goes in with the same column list
+    /// `upsert_peer` uses. Do not "fix" this back to the helper.
+    async fn seed_local_peer(pool: &PgPool, did: &str, http_url: &str) {
+        sqlx::query(
+            "INSERT INTO peers (did, http_url, last_seen, last_ping_ok, announced_at)
+             VALUES ($1, $2, $3, FALSE, $3)",
+        )
+        .bind(did)
+        .bind(http_url)
+        .bind(chrono::Utc::now().to_rfc3339())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn sync_status(pool: &PgPool, repo: &str) -> String {
+        let row: (String,) = sqlx::query_as("SELECT status FROM sync_queue WHERE repo = $1")
+            .bind(repo)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        row.0
+    }
+
+    async fn enqueue(db: &Db, repo: &str, did: &str) {
+        db.enqueue_sync(repo, did, "refs/heads/main", &"0".repeat(40), None)
+            .await
+            .unwrap();
+    }
+
+    fn dir_entries(dir: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// Run one `process_batch` against `repos_dir`, cloning the test config and
+    /// overriding only the repo root.
+    async fn run_batch(state: &crate::state::AppState, repos_dir: &Path) {
+        let mut cfg = (*state.config).clone();
+        cfg.repos_dir = repos_dir.to_path_buf();
+        process_batch(
+            &state.db,
+            &cfg,
+            &Keypair::generate(),
+            None,
+            &reqwest::Client::new(),
+        )
+        .await;
+    }
+
+    #[sqlx::test]
+    async fn process_batch_rejects_slug_escaping_repos_dir(pool: PgPool) {
+        // The verified escape from #272: `PathBuf::join` discards everything
+        // accumulated before an absolute component, so `repos_dir/a` joined with
+        // `/…/nest/escape.git` resolves to `/…/nest/escape.git`, outside the root.
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+
+        // `nest` does not exist yet, so both it and the mirror inside it are
+        // proof the write left repos_dir. git clone removes the destination it
+        // fails on but leaves the parent it created, so assert on both.
+        let outside = TempDir::new().unwrap();
+        let escape_dir = outside.path().join("nest");
+        let slug = format!("a/{}/escape", escape_dir.display());
+        let escape_target = escape_dir.join("escape.git");
+
+        // Serve the composed URL for real, so a run without the guard genuinely
+        // clones outside the root rather than merely failing at git.
+        let rel = format!("a{}/escape", escape_dir.display());
+        let (_remote, peer_url) = rooted_remote(&[&rel]);
+
+        let did = "did:key:z6MkAttacker";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, &slug, did).await;
+
+        run_batch(&state, &repos_dir).await;
+
+        assert!(
+            !escape_target.exists(),
+            "mirror written outside repos_dir at {}",
+            escape_target.display()
+        );
+        assert!(
+            !escape_dir.exists(),
+            "parent directory created outside repos_dir at {}",
+            escape_dir.display()
+        );
+        assert_eq!(sync_status(&pool, &slug).await, "failed");
+        assert!(
+            dir_entries(&repos_dir).is_empty(),
+            "repos_dir must stay empty"
+        );
+    }
+
+    #[sqlx::test]
+    async fn process_batch_rejects_malformed_slugs(pool: PgPool) {
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+
+        // Every slug's composed remote URL is served as a real bare repo, so a
+        // run without the guard actually writes the mirror instead of dying at
+        // git. `demo` has no separator and is caught by the pre-existing arm.
+        let slugs = ["../hello", "./hello", "../../etc/evil", "a/../../x", "demo"];
+        let (_remote, peer_url) = rooted_remote(&slugs);
+
+        let did = "did:key:z6MkAttacker";
+        seed_local_peer(&pool, did, &peer_url).await;
+        for slug in slugs {
+            enqueue(&state.db, slug, did).await;
+        }
+
+        run_batch(&state, &repos_dir).await;
+
+        for slug in slugs {
+            assert_eq!(sync_status(&pool, slug).await, "failed", "slug {slug}");
+        }
+        // `./hello` lands inside repos_dir; the other three land beside it.
+        assert!(
+            dir_entries(&repos_dir).is_empty(),
+            "repos_dir must stay empty"
+        );
+        assert_eq!(dir_entries(home.path()), vec!["repos".to_string()]);
+    }
+
+    #[sqlx::test]
+    async fn process_batch_still_fails_row_without_a_peer(pool: PgPool) {
+        // The pre-existing no-peer arm still fires first. Without a peer row a
+        // slug test would be green before the guard exists and prove nothing.
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+
+        enqueue(&state.db, "z6Mkfoo/hello", "did:key:z6MkNoPeer").await;
+
+        run_batch(&state, &repos_dir).await;
+
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "failed");
+        assert!(dir_entries(&repos_dir).is_empty());
+    }
+
+    #[sqlx::test]
+    async fn process_batch_mirrors_a_valid_slug(pool: PgPool) {
+        // Must-not-break, and the control that keeps the rejection tests above
+        // from passing vacuously: this harness can mirror successfully.
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+
+        let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkOrigin";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, "z6Mkfoo/hello", did).await;
+
+        run_batch(&state, &repos_dir).await;
+
+        let mirror = repos_dir.join("z6Mkfoo").join("hello.git");
+        assert!(mirror.is_dir(), "mirror missing at {}", mirror.display());
+        assert!(object_count(&mirror) > 0, "mirror has no objects");
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "done");
+
+        let disk: (String,) = sqlx::query_as("SELECT disk_path FROM repos WHERE id = $1")
+            .bind("z6Mkfoo/hello")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(disk.0, mirror.to_str().unwrap());
+    }
+
+    #[sqlx::test]
+    async fn process_batch_does_not_repick_a_failed_row(pool: PgPool) {
+        // `mark_sync_failed` is terminal: `dequeue_pending_syncs` selects only
+        // pending rows, so a rejected slug never becomes a poison item.
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+
+        let (_remote, peer_url) = rooted_remote(&["../hello"]);
+        let did = "did:key:z6MkAttacker";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, "../hello", did).await;
+
+        run_batch(&state, &repos_dir).await;
+        assert_eq!(sync_status(&pool, "../hello").await, "failed");
+        assert!(state.db.dequeue_pending_syncs(10).await.unwrap().is_empty());
+
+        run_batch(&state, &repos_dir).await;
+        assert_eq!(sync_status(&pool, "../hello").await, "failed");
+        assert_eq!(dir_entries(home.path()), vec!["repos".to_string()]);
     }
 }

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -1792,6 +1792,15 @@ mod tests {
         .await;
 
         run_batch(&state, &repos_dir).await;
+        // Pin the premise before the yield: the stuck rows must actually fill
+        // the first batch. Without this the test would still pass if the batch
+        // size ever grew past the stuck set, having quietly stopped exercising
+        // head-of-line yield at all.
+        assert_eq!(
+            sync_status(&pool, "z6Mkfoo/hello").await,
+            "pending",
+            "the first poll must be consumed by the stuck rows"
+        );
         run_batch(&state, &repos_dir).await;
 
         assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "done");
@@ -1836,11 +1845,22 @@ mod tests {
         )
         .await;
 
-        for _ in 0..3 {
-            run_batch(&state, &repos_dir).await;
-        }
+        // Two polls cannot reach it: 25 stuck rows are ahead of it and the
+        // batch is 10. Asserting that keeps the ceil(N/10) claim honest rather
+        // than just asserting it eventually lands.
+        run_batch(&state, &repos_dir).await;
+        run_batch(&state, &repos_dir).await;
+        assert_eq!(
+            sync_status(&pool, "z6Mkfoo/hello").await,
+            "pending",
+            "25 stuck rows must still be ahead of it after two polls"
+        );
+        run_batch(&state, &repos_dir).await;
 
         assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "done");
+        // Rotated, not retired: yielding the slot must not settle the row.
+        assert_eq!(sync_status(&pool, "z6Mkstuck/r0").await, "pending");
+        assert_eq!(sync_status(&pool, "z6Mkstuck/r24").await, "pending");
 
         unstick(&stuck);
     }

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -1570,4 +1570,110 @@ mod tests {
         assert_eq!(sync_status(&pool, "../hello").await, "failed");
         assert_eq!(dir_entries(home.path()), vec!["repos".to_string()]);
     }
+
+    // ── committed attack probes from the #272 investigation ──────────────────
+
+    #[sqlx::test]
+    async fn queued_escape_slug_cannot_plant_a_mirror_outside_repos_dir(pool: PgPool) {
+        // The worker half of #272, committed in its attack form. The row goes
+        // into sync_queue directly rather than through notify, because that is
+        // the case the boundary check cannot cover: rows queued before the fix
+        // existed, plus the gossip and trigger writers, which also enqueue a
+        // peer-controlled slug. `a/<abs>/gitlawb-probe` used to reach
+        // PathBuf::join, whose absolute second component discards repos_dir and
+        // puts the mirror at /<abs>/gitlawb-probe.git.
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+
+        let outside = TempDir::new().unwrap();
+        let escape_dir = outside.path().join("nest");
+        let slug = format!("a/{}/gitlawb-probe", escape_dir.display());
+        let escape_target = escape_dir.join("gitlawb-probe.git");
+
+        // Two things this fixture must get right or the test is green for the
+        // wrong reason. The peer row is mandatory: process_batch resolves the
+        // origin URL before it looks at the slug, so an unseeded row dies at the
+        // no-peer arm and would pass with the worker guard reverted. And the
+        // composed remote {peer_url}/{slug} is served as a real bare repo, so a
+        // run without the guard genuinely clones outside the root instead of
+        // just failing at git. Db::upsert_peer cannot seed this row: it gates on
+        // is_public_http_url, which rejects file://.
+        let rel = format!("a{}/gitlawb-probe", escape_dir.display());
+        let (_remote, peer_url) = rooted_remote(&[&rel]);
+        let did = "did:key:z6MkAttacker";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, &slug, did).await;
+
+        run_batch(&state, &repos_dir).await;
+
+        assert!(
+            !escape_target.exists(),
+            "mirror written outside repos_dir at {}",
+            escape_target.display()
+        );
+        // git clone removes the destination when the clone fails but leaves the
+        // parent it created, so the .git path alone can pass vacuously.
+        assert!(
+            !escape_dir.exists(),
+            "parent directory created outside repos_dir at {}",
+            escape_dir.display()
+        );
+        assert!(
+            dir_entries(&repos_dir).is_empty(),
+            "repos_dir must stay empty"
+        );
+        assert_eq!(sync_status(&pool, &slug).await, "failed");
+    }
+
+    #[sqlx::test]
+    async fn notify_to_mirror_still_works_end_to_end_for_a_valid_slug(pool: PgPool) {
+        // Positive control for the two #272 attack tests: the same unsigned
+        // notify route an attacker reaches still carries a well-formed slug all
+        // the way to a mirror on disk. Without it, both attack tests could be
+        // green because the chain is broken rather than because the guards hold.
+        use tower::ServiceExt as _;
+
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+
+        let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkOrigin";
+        // Direct insert for the same reason as above: upsert_peer rejects file://.
+        seed_local_peer(&pool, did, &peer_url).await;
+
+        let body = serde_json::json!({
+            "repo": "z6Mkfoo/hello",
+            "ref_name": "refs/heads/main",
+            "new_sha": "0".repeat(40),
+            "node_did": did,
+        })
+        .to_string();
+        let mut req = axum::http::Request::builder()
+            .method(axum::http::Method::POST)
+            .uri("/api/v1/sync/notify")
+            .header(axum::http::header::CONTENT_TYPE, "application/json")
+            .body(axum::body::Body::from(body))
+            .unwrap();
+        req.extensions_mut().insert(axum::extract::ConnectInfo(
+            "198.51.100.50:5000"
+                .parse::<std::net::SocketAddr>()
+                .unwrap(),
+        ));
+        let resp = crate::server::build_router(state.clone())
+            .oneshot(req)
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        run_batch(&state, &repos_dir).await;
+
+        let mirror = repos_dir.join("z6Mkfoo").join("hello.git");
+        assert!(mirror.is_dir(), "mirror missing at {}", mirror.display());
+        assert!(object_count(&mirror) > 0, "mirror has no objects");
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "done");
+    }
 }

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -256,8 +256,11 @@ async fn process_batch(
             // Split by whether retrying could ever change the answer. A
             // read-only or briefly unmounted repos_dir is transient, so the row
             // stays pending and is retried. A path that is simply not creatable
-            // is not going to become creatable on the next poll, and leaving it
-            // pending re-picks it forever.
+            // is not going to become creatable on the next poll, so leaving it
+            // pending would retry it forever for nothing. `dequeue_pending_syncs`
+            // stamps what it hands out, so such a row rotates rather than pins
+            // the batch, but a row that can never succeed still should not sit
+            // in the queue consuming a slot every rotation.
             //
             // AlreadyExists is in this set because create_dir_all only reports
             // it when something that is not a directory occupies the path — a
@@ -299,12 +302,19 @@ async fn process_batch(
                 continue;
             }
             crate::git::repo_store::Containment::IoError(e) => {
-                // Pending, so it is retried when the condition clears. There is
-                // deliberately no attempt cap: bounding it needs an attempts
-                // column on sync_queue, which is a migration and belongs in its
-                // own change. The metric is what makes a queue stalled on an
-                // operator condition (an unmounted repos_dir) distinguishable
-                // from an idle one, which is the gap that actually hurts.
+                // Pending, so it is retried when the condition clears. This is
+                // the deferral the error-kind split above cannot reach: an
+                // owner directory that exists but denies traversal lets
+                // create_dir_all succeed and fails here instead, and it is
+                // per-repo rather than a whole-repos_dir outage.
+                //
+                // No stamping is needed at this branch. `dequeue_pending_syncs`
+                // stamps every row it hands out, so this row already sorts to
+                // the back and cannot hold the batch against healthy repos.
+                // There is still deliberately no attempt cap: bounding retries
+                // needs an attempts column, which is its own change. The metric
+                // is what makes a queue stalled on an operator condition
+                // distinguishable from an idle one.
                 error!(
                     id = %item.id, repo = %item.repo, path = %local_path.display(), err = %e,
                     "cannot resolve the mirror path against repos_dir; leaving the sync row pending"
@@ -1701,6 +1711,138 @@ mod tests {
         assert!(owner_path.is_symlink());
         assert!(!home.path().join("no-such-target").exists());
         assert!(mirrors_under(home.path()).is_empty());
+    }
+
+    /// Enqueue a row and pin its `enqueued_at`, so batch ordering in the
+    /// starvation tests is fixed rather than dependent on how fast the loop
+    /// runs. Two rows enqueued in the same microsecond would otherwise order
+    /// arbitrarily.
+    async fn enqueue_at(db: &Db, pool: &PgPool, repo: &str, did: &str, enqueued_at: &str) {
+        enqueue(db, repo, did).await;
+        sqlx::query("UPDATE sync_queue SET enqueued_at = $1 WHERE repo = $2")
+            .bind(enqueued_at)
+            .bind(repo)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    /// An owner directory that exists but denies traversal. `create_dir_all`
+    /// returns Ok (mkdir gets EEXIST and `is_dir()` succeeds, since that stat
+    /// only needs +x on repos_dir), so this defers at `path_within_root`
+    /// instead — the stall path that survives the AlreadyExists
+    /// classification, which is what keeps the starvation tests load-bearing.
+    fn make_stuck_owner(repos_dir: &Path, owner: &str) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = repos_dir.join(owner);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::create_dir(dir.join("probe")).is_ok() {
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+            // Fail rather than return: cargo swallows stderr for a passing
+            // test, so an early return would report "ok" on a root runner while
+            // exercising nothing, and the head-of-line contract would ship
+            // unverified from that point on.
+            panic!(
+                "this test needs a user the mode bits actually restrict; it is the only \
+                 coverage for a stuck batch yielding to a healthy row, and passing it as \
+                 root would prove nothing. Run the suite unprivileged."
+            );
+        }
+        dir
+    }
+
+    fn unstick(dir: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    #[sqlx::test]
+    async fn a_full_batch_of_stuck_rows_does_not_starve_a_healthy_one(pool: PgPool) {
+        // Ten rows that defer forever, exactly filling the batch, with one
+        // healthy row queued behind them. Ordering by enqueued_at alone means
+        // the stuck ten are permanently the oldest and the healthy row is never
+        // dequeued at all, on any number of polls.
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+        let stuck = make_stuck_owner(&repos_dir, "z6Mkstuck");
+
+        let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkOrigin";
+        seed_local_peer(&pool, did, &peer_url).await;
+        for i in 0..10 {
+            enqueue_at(
+                &state.db,
+                &pool,
+                &format!("z6Mkstuck/r{i}"),
+                did,
+                &format!("2026-07-29T00:00:{i:02}Z"),
+            )
+            .await;
+        }
+        enqueue_at(
+            &state.db,
+            &pool,
+            "z6Mkfoo/hello",
+            did,
+            "2026-07-29T00:01:00Z",
+        )
+        .await;
+
+        run_batch(&state, &repos_dir).await;
+        run_batch(&state, &repos_dir).await;
+
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "done");
+        assert!(repos_dir.join("z6Mkfoo").join("hello.git").is_dir());
+        // The stuck rows yielded their slot; they did not get retired for it.
+        assert_eq!(sync_status(&pool, "z6Mkstuck/r0").await, "pending");
+
+        unstick(&stuck);
+    }
+
+    #[sqlx::test]
+    async fn a_stuck_set_larger_than_the_batch_still_yields(pool: PgPool) {
+        // 25 stuck rows against a batch size of 10. The healthy row lands
+        // within ceil(26/10) = 3 polls, which is the bound the PR claims;
+        // the batch-sized case above is the easiest one and would pass under a
+        // fix that only rotated a single full window.
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+        let stuck = make_stuck_owner(&repos_dir, "z6Mkstuck");
+
+        let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkOrigin";
+        seed_local_peer(&pool, did, &peer_url).await;
+        for i in 0..25 {
+            enqueue_at(
+                &state.db,
+                &pool,
+                &format!("z6Mkstuck/r{i}"),
+                did,
+                &format!("2026-07-29T00:00:{i:02}Z"),
+            )
+            .await;
+        }
+        enqueue_at(
+            &state.db,
+            &pool,
+            "z6Mkfoo/hello",
+            did,
+            "2026-07-29T00:01:00Z",
+        )
+        .await;
+
+        for _ in 0..3 {
+            run_batch(&state, &repos_dir).await;
+        }
+
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "done");
+
+        unstick(&stuck);
     }
 
     #[sqlx::test]

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -234,6 +234,7 @@ async fn process_batch(
             Err(e) => {
                 warn!(id = %item.id, repo = %item.repo, err = %e, "sync item has an invalid repo slug, skipping");
                 let _ = db.mark_sync_failed(&item.id).await;
+                crate::metrics::record_sync_processed("rejected");
                 continue;
             }
         };
@@ -271,6 +272,9 @@ async fn process_batch(
             );
             if permanent {
                 let _ = db.mark_sync_failed(&item.id).await;
+                crate::metrics::record_sync_processed("rejected");
+            } else {
+                crate::metrics::record_sync_processed("deferred");
             }
             continue;
         }
@@ -282,13 +286,21 @@ async fn process_batch(
                     "mirror path resolves outside repos_dir, skipping"
                 );
                 let _ = db.mark_sync_failed(&item.id).await;
+                crate::metrics::record_sync_processed("rejected");
                 continue;
             }
             crate::git::repo_store::Containment::IoError(e) => {
+                // Pending, so it is retried when the condition clears. There is
+                // deliberately no attempt cap: bounding it needs an attempts
+                // column on sync_queue, which is a migration and belongs in its
+                // own change. The metric is what makes a queue stalled on an
+                // operator condition (an unmounted repos_dir) distinguishable
+                // from an idle one, which is the gap that actually hurts.
                 error!(
                     id = %item.id, repo = %item.repo, path = %local_path.display(), err = %e,
                     "cannot resolve the mirror path against repos_dir; leaving the sync row pending"
                 );
+                crate::metrics::record_sync_processed("deferred");
                 continue;
             }
         }
@@ -1177,6 +1189,33 @@ mod tests {
         names
     }
 
+    /// Every `*.git` directory anywhere under `dir`.
+    ///
+    /// The property the escape tests actually protect is "no mirror was
+    /// planted", not "the tree is untouched". `process_batch` creates the owner
+    /// directory before it can canonicalize a parent for the containment check,
+    /// so an empty `repos_dir/<owner>` is expected debris on a rejected row and
+    /// asserting on it measures that side effect instead of the escape.
+    fn mirrors_under(dir: &Path) -> Vec<String> {
+        let mut found = Vec::new();
+        let mut stack = vec![dir.to_path_buf()];
+        while let Some(next) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&next) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_some_and(|e| e == "git") {
+                    found.push(path.to_string_lossy().into_owned());
+                } else if path.is_dir() && !path.is_symlink() {
+                    stack.push(path);
+                }
+            }
+        }
+        found.sort();
+        found
+    }
+
     /// Run one `process_batch` against `repos_dir`, cloning the test config and
     /// overriding only the repo root.
     async fn run_batch(state: &crate::state::AppState, repos_dir: &Path) {
@@ -1232,9 +1271,22 @@ mod tests {
             escape_dir.display()
         );
         assert_eq!(sync_status(&pool, &slug).await, "failed");
+        // What this test measures, verified by mutation rather than assumed: the
+        // slug rule and the containment check are each independently sufficient
+        // for this input, so removing either one alone leaves it green, and it
+        // goes red only when both are gone (observed: "mirror written outside
+        // repos_dir"). It is the end-to-end property, not a probe for one layer.
+        // Each layer has its own witness elsewhere: `./hello` in
+        // process_batch_rejects_malformed_slugs isolates the slug rule (it
+        // resolves back inside repos_dir, so containment approves it), and the
+        // two symlink tests isolate containment (no character rule can see a
+        // symlink). Assert on mirrors rather than on an empty repos_dir, because
+        // the owner directory is created before containment has a parent to
+        // canonicalize, so its presence is expected debris on a rejected row and
+        // asserting on it would make this flip on a side effect instead.
         assert!(
-            dir_entries(&repos_dir).is_empty(),
-            "repos_dir must stay empty"
+            mirrors_under(&repos_dir).is_empty(),
+            "no mirror may be planted inside repos_dir"
         );
     }
 
@@ -1645,9 +1697,19 @@ mod tests {
             "parent directory created outside repos_dir at {}",
             escape_dir.display()
         );
+        // Mirrors, not entries: the owner directory is created before the
+        // containment check has a parent to canonicalize, so it is expected
+        // debris on a rejected row. Asserting repos_dir is empty would make this
+        // flip on that side effect rather than on an escape.
+        //
+        // Like its sibling above, this is the end-to-end property. The slug rule
+        // and containment are each sufficient here, so it goes red only when
+        // both are removed; that was observed, with the mirror written outside
+        // repos_dir. Per-layer isolation lives in the `./hello` case and the two
+        // symlink tests.
         assert!(
-            dir_entries(&repos_dir).is_empty(),
-            "repos_dir must stay empty"
+            mirrors_under(&repos_dir).is_empty(),
+            "no mirror may be planted inside repos_dir"
         );
         assert_eq!(sync_status(&pool, &slug).await, "failed");
     }

--- a/crates/gitlawb-node/src/sync.rs
+++ b/crates/gitlawb-node/src/sync.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use gitlawb_core::identity::Keypair;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::config::Config;
 use crate::db::Db;
@@ -243,6 +243,42 @@ async fn process_batch(
             .repos_dir
             .join(owner_short)
             .join(format!("{repo_name}.git"));
+
+        // Third layer, after the slug's character rules and the component walk:
+        // prove the resolved mirror path really sits inside repos_dir. Only this
+        // sees a symlink standing between the root and the target, at either the
+        // owner directory or the mirror itself (#272). The owner directory is
+        // created first so the clone branch has a parent to canonicalize, and
+        // the check then covers clone and fetch alike.
+        let owner_dir = config.repos_dir.join(owner_short);
+        if let Err(e) = std::fs::create_dir_all(&owner_dir) {
+            // Leave the row pending: a read-only or briefly unmounted repos_dir
+            // is transient, and marking failed is terminal (dequeue_pending_syncs
+            // only ever selects pending rows).
+            error!(
+                id = %item.id, repo = %item.repo, path = %owner_dir.display(), err = %e,
+                "cannot create the owner directory for a mirror; leaving the sync row pending"
+            );
+            continue;
+        }
+        match crate::git::repo_store::path_within_root(&local_path, &config.repos_dir) {
+            crate::git::repo_store::Containment::Contained => {}
+            crate::git::repo_store::Containment::Outside => {
+                warn!(
+                    id = %item.id, repo = %item.repo, path = %local_path.display(),
+                    "mirror path resolves outside repos_dir, skipping"
+                );
+                let _ = db.mark_sync_failed(&item.id).await;
+                continue;
+            }
+            crate::git::repo_store::Containment::IoError(e) => {
+                error!(
+                    id = %item.id, repo = %item.repo, path = %local_path.display(), err = %e,
+                    "cannot resolve the mirror path against repos_dir; leaving the sync row pending"
+                );
+                continue;
+            }
+        }
 
         // Remote URL matches gitlawb-node git smart HTTP route: /{owner}/{repo}
         // (no .git suffix — the server routes don't include it)
@@ -1265,6 +1301,251 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(disk.0, mirror.to_str().unwrap());
+    }
+
+    // ── canonical containment before the git call (issue #272) ───────────────
+
+    /// Every ref in `repo`, as one string, for a before/after comparison.
+    fn refs_of(repo: &Path) -> String {
+        let out = Command::new("git")
+            .args(["-C", repo.to_str().unwrap(), "for-each-ref"])
+            .output()
+            .unwrap();
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+
+    async fn requeue(pool: &PgPool, repo: &str) {
+        sqlx::query("UPDATE sync_queue SET status = 'pending' WHERE repo = $1")
+            .bind(repo)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    #[sqlx::test]
+    async fn process_batch_rejects_a_symlinked_owner_directory(pool: PgPool) {
+        // The slug is textually valid, so U1's character rules pass it. The
+        // escape is on disk: repos_dir/z6Mkfoo is a symlink out of the root, so
+        // the clone would land outside repos_dir. Only canonical containment
+        // sees this.
+        use std::os::unix::fs::symlink;
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+
+        let outside = TempDir::new().unwrap();
+        let target = outside.path().join("owner");
+        std::fs::create_dir_all(&target).unwrap();
+        symlink(&target, repos_dir.join("z6Mkfoo")).unwrap();
+
+        let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkAttacker";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, "z6Mkfoo/hello", did).await;
+
+        run_batch(&state, &repos_dir).await;
+
+        assert!(
+            dir_entries(&target).is_empty(),
+            "wrote through the owner symlink into {}",
+            target.display()
+        );
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "failed");
+    }
+
+    #[sqlx::test]
+    async fn process_batch_rejects_a_symlinked_mirror_path(pool: PgPool) {
+        // The leaf case a parent-only canonicalize misses: the owner directory
+        // is real and canonicalizes clean, but the mirror itself is a symlink to
+        // a bare repo outside repos_dir. `local_path.exists()` follows the link,
+        // so the fetch branch would run `git -C <link>` and overwrite the linked
+        // repo's refs under the mirror refspec.
+        use std::os::unix::fs::symlink;
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        let owner_dir = repos_dir.join("z6Mkfoo");
+        std::fs::create_dir_all(&owner_dir).unwrap();
+
+        // The victim is a mirror clone, which is what this node's own mirrors
+        // are: `remote.origin.fetch = +refs/*:refs/*`, so a fetch through the
+        // link force-overwrites every ref. Its content differs from the peer's
+        // repo, so the overwrite is visible.
+        let (outside_td, outside_url) = bare_remote(&[("outside.txt", b"outside\n")]);
+        let outside_bare = outside_td.path().join("victim.git");
+        g(
+            &[
+                "clone",
+                "-q",
+                "--mirror",
+                &outside_url,
+                outside_bare.to_str().unwrap(),
+            ],
+            outside_td.path(),
+        );
+        let refs_before = refs_of(&outside_bare);
+        assert!(
+            !refs_before.is_empty(),
+            "outside repo has no refs to protect"
+        );
+        symlink(&outside_bare, owner_dir.join("hello.git")).unwrap();
+
+        let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkAttacker";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, "z6Mkfoo/hello", did).await;
+
+        run_batch(&state, &repos_dir).await;
+
+        // The ref is the property under protection, so assert it before status.
+        assert_eq!(
+            refs_of(&outside_bare),
+            refs_before,
+            "refs of the linked-to repo outside repos_dir were rewritten"
+        );
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "failed");
+    }
+
+    #[sqlx::test]
+    async fn process_batch_clones_when_the_owner_directory_is_missing(pool: PgPool) {
+        // Must-not-break, first clone: the mirror path does not exist yet, which
+        // is the case a candidate-only canonicalize would reject outright. That
+        // rejection is total loss of mirroring, so it gets its own test.
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+
+        let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkOrigin";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, "z6Mkfoo/hello", did).await;
+
+        assert!(
+            !repos_dir.join("z6Mkfoo").exists(),
+            "owner dir must be absent"
+        );
+
+        run_batch(&state, &repos_dir).await;
+
+        let mirror = repos_dir.join("z6Mkfoo").join("hello.git");
+        assert!(mirror.is_dir(), "mirror missing at {}", mirror.display());
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "done");
+    }
+
+    #[sqlx::test]
+    async fn process_batch_fetches_into_an_existing_mirror(pool: PgPool) {
+        // Must-not-break, fetch: the second sync of the same repo takes the
+        // exists() branch and must still pull new objects through it.
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+
+        let (remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkOrigin";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, "z6Mkfoo/hello", did).await;
+
+        run_batch(&state, &repos_dir).await;
+        let mirror = repos_dir.join("z6Mkfoo").join("hello.git");
+        assert!(mirror.is_dir(), "first sync did not clone");
+        let before = object_count(&mirror);
+
+        // Add a commit to the peer's bare repo so the fetch has work to do.
+        let origin = remote.path().join("origin");
+        let bare = remote
+            .path()
+            .join("r1")
+            .join("r2")
+            .join("root")
+            .join("z6Mkfoo")
+            .join("hello");
+        std::fs::write(origin.join("b.txt"), b"second\n").unwrap();
+        g(&["add", "."], &origin);
+        g(&["commit", "-qm", "second"], &origin);
+        g(&["push", "-q", bare.to_str().unwrap(), "HEAD"], &origin);
+
+        requeue(&pool, "z6Mkfoo/hello").await;
+        run_batch(&state, &repos_dir).await;
+
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "done");
+        assert!(
+            object_count(&mirror) > before,
+            "fetch pulled nothing into the existing mirror"
+        );
+    }
+
+    #[sqlx::test]
+    async fn process_batch_leaves_the_row_pending_when_the_mirror_cannot_be_inspected(
+        pool: PgPool,
+    ) {
+        // An I/O failure is transient, not hostile. `dequeue_pending_syncs`
+        // selects only pending rows, so marking failed here would permanently
+        // retire a legitimate repo over one EACCES.
+        use std::os::unix::fs::PermissionsExt;
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        let owner_dir = repos_dir.join("z6Mkfoo");
+        std::fs::create_dir_all(&owner_dir).unwrap();
+        std::fs::set_permissions(&owner_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::symlink_metadata(owner_dir.join("hello.git")).is_ok() {
+            // Running with enough privilege to ignore the mode bits (root).
+            std::fs::set_permissions(&owner_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+            eprintln!("skipping: permissions do not restrict this user");
+            return;
+        }
+
+        let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkOrigin";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, "z6Mkfoo/hello", did).await;
+
+        run_batch(&state, &repos_dir).await;
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "pending");
+
+        // The condition clears and the very same row syncs on the next pass.
+        std::fs::set_permissions(&owner_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        run_batch(&state, &repos_dir).await;
+
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "done");
+        assert!(owner_dir.join("hello.git").is_dir());
+    }
+
+    #[sqlx::test]
+    async fn process_batch_leaves_the_row_pending_when_the_owner_dir_cannot_be_created(
+        pool: PgPool,
+    ) {
+        // Same reasoning for the create_dir_all at the call site: a read-only
+        // repos_dir is an operator condition, not a hostile slug.
+        use std::os::unix::fs::PermissionsExt;
+        let state = crate::test_support::test_state(pool.clone()).await;
+        let home = TempDir::new().unwrap();
+        let repos_dir = home.path().join("repos");
+        std::fs::create_dir_all(&repos_dir).unwrap();
+        std::fs::set_permissions(&repos_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+        if std::fs::create_dir(repos_dir.join("probe")).is_ok() {
+            std::fs::set_permissions(&repos_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+            std::fs::remove_dir(repos_dir.join("probe")).unwrap();
+            eprintln!("skipping: permissions do not restrict this user");
+            return;
+        }
+
+        let (_remote, peer_url) = rooted_remote(&["z6Mkfoo/hello"]);
+        let did = "did:key:z6MkOrigin";
+        seed_local_peer(&pool, did, &peer_url).await;
+        enqueue(&state.db, "z6Mkfoo/hello", did).await;
+
+        run_batch(&state, &repos_dir).await;
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "pending");
+
+        std::fs::set_permissions(&repos_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        run_batch(&state, &repos_dir).await;
+
+        assert_eq!(sync_status(&pool, "z6Mkfoo/hello").await, "done");
+        assert!(repos_dir.join("z6Mkfoo").join("hello.git").is_dir());
     }
 
     #[sqlx::test]


### PR DESCRIPTION
Closes #272.

An unauthenticated caller could plant a git mirror at an arbitrary path on disk.

## The bug

`POST /api/v1/sync/notify` accepts unsigned callers by default: `require_signed_peer_writes` is false, so `server.rs` mounts the peer-write routes under `optional_signature` rather than the auth layers. Its only gate is that `node_did` appear in the peers table, and one unsigned announce of your own DID satisfies that. `req.repo` then reached `enqueue_sync` verbatim, and `process_batch` split it on the first `/` and joined both halves onto `repos_dir`. `PathBuf::join` does not normalize, and an absolute second component replaces the accumulated path, so `a//tmp/x` resolved to `/tmp/x.git`.

Reproduced end to end before any of this was written: unsigned announce 200, unsigned notify 200, then the worker cloned an attacker-controlled origin to `/tmp/gitlawb-escape-probe.git` with `repos_dir` left empty and the peer's `last_ping_ok` FALSE. The sync path never reads that flag, so nothing about peer reachability was in the way.

## The fix

Four layers, each catching something the others cannot:

| Layer | Where | What only it stops |
|---|---|---|
| slug validation | `repo_store::validate_repo_slug` | `./hello`, which canonicalizes back inside `repos_dir` and so passes containment |
| notify boundary | `api/peers.rs` | keeps the row out of `sync_queue` and out of `received_ref_updates` |
| worker re-check | `sync.rs` `process_batch` | rows queued before this landed, plus the gossip and trigger writers |
| canonical containment | `repo_store::path_within_root` | a symlink at the owner directory or at the `.git` leaf, which no character rule can see |

The validator reuses `validate_owner_did` and `validate_repo_name` rather than adding a second character rule to the crate. It adds two rules of its own: an owner half may not begin with `.` or `-` (those validators have no leading-character rule, and an owner of `.` puts a peer-controlled mirror at the `repos_dir` root), and the owner half is bounded by NAME_MAX at 255 rather than the DID column's 256.

`Containment` is three-valued rather than a bool, and that distinction is load-bearing. `Outside` is a deterministic verdict, so the row is retired. `IoError` means the filesystem could not answer, so the row stays pending and is retried, because marking it failed is terminal and a transient EACCES would otherwise permanently retire a legitimate repo. The predicate is pure; `create_dir_all` lives at the call site so the admin purge path in #196 can ask a containment question without mutating anything.

## Verification

549 tests, clippy clean under `-D warnings`, `cargo fmt --check` clean.

Every guard was mutation-tested: removed, observed red on a named case, restored. Worth stating plainly because five tests here were green before the guard they named existed, and were rewritten once that was found:

- `../hello` does not exercise the owner delegation; the leading-character rule catches it first. `a..b/hello` does.
- None of the three extra-separator cases isolate the separator count; each is caught by an earlier rule. `z6Mkfoo/hello/extra` does.
- The malformed-slug worker rows ended `failed` regardless when the remote was unreachable, because the clone simply failed. The fixture now serves every composed URL for real.
- The overlong-owner test asserted 257, one past the bound, so it passed for free. It now pins 256 rejected and 255 accepted.
- One root-skip probe used `symlink_metadata` on a path that was never created, which is `Err` for every user, so its guard could never fire.

The two escape tests assert the end-to-end property rather than isolating a layer: the slug rule and containment are each independently sufficient for that input, so removing either alone leaves them green and only removing both turns them red, with the mirror observed written outside `repos_dir`. Per-layer isolation lives in the `./hello` case and the two symlink tests. The comments say so.

An independent adversarial pass through a different model family returned no findings against the final state.

## Deliberately not in this PR

- Requiring `node_did` to be the repo's recorded origin. That needs an answer to what happens on the first sync of a repo this node has never seen, which depends on the DID key-binding decision in #273.
- Unifying the three path conventions (`RepoStore::local_path`, the `sync.rs` join, `repo_disk_path`). It relocates every existing mirror and orphans the `disk_path` already recorded on mirror rows, so it needs its own change with a migration.
- An attempt cap on the deferred arm. Bounding retries needs an `attempts` column on `sync_queue`, which is a migration. The new `deferred` and `rejected` metric labels are what make a stalled queue visible in the meantime.

## Known residuals

A well-formed slug naming a repo this node already mirrors still lets a known peer drive a fetch into it, repointing `remote.origin` and force-overwriting refs through the mirror refspec. That survives every guard here because the slug is well formed and the path stays inside `repos_dir`. It closes with the origin-ownership check above.

The window between the containment check and the git invocation is not atomic. Exploiting it needs local write access inside `repos_dir`, so it sits outside the unauthenticated threat model this addresses.

The gossip and trigger writers still reach `sync_queue` without an ingress check. The worker gate covers the path-write consequence; the ref-update feed remains poisonable with arbitrary strings, which is pre-existing.

Note for whoever rebases: `repo_store.rs` is also touched by #196, additively and in the same area. Whichever lands second resolves a small textual conflict there. Nothing else in this branch overlaps it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened sync/notify handling by rejecting malformed repository slugs and preventing traversal and symlink-based escape attempts.
  * Ensured invalid requests are neither queued nor recorded, while valid syncs continue to mirror correctly.
  * Improved mirror placement safety using stronger containment checks with safe handling of filesystem resolution issues.
* **New Features**
  * Added tracking for sync dequeue attempts to improve retry scheduling and ordering.
* **Documentation**
  * Updated sync metrics documentation to include newly documented `rejected` and `deferred` statuses.
* **Tests**
  * Expanded end-to-end and database tests covering slug validation, escape scenarios, and queue retry ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->