### PR TITLE
fix(node): reset a peer's reachability gate when an announce changes its http_url (#270)

### DIFF
--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -5681,3 +5681,114 @@ mod ref_update_db_tests {
         assert_eq!(all[0].new_sha, "gggg");
     }
 }
+
+#[cfg(test)]
+mod peer_reachability_tests {
+    use super::Db;
+    use sqlx::PgPool;
+
+    const VICTIM_DID: &str = "did:key:z6MkvictimPeerFixture";
+    const HONEST_URL: &str = "https://honest-peer.example.com";
+    const ATTACKER_URL: &str = "https://attacker.example.com";
+
+    async fn db(pool: PgPool) -> Db {
+        let db = Db::for_testing(pool);
+        db.run_migrations().await.unwrap();
+        db
+    }
+
+    /// Read the row back through `list_peers`, the same surface the federated
+    /// fan-out filters on, rather than issuing raw SQL from the test.
+    async fn peer(db: &Db, did: &str) -> (String, bool) {
+        let row = db
+            .list_peers()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|p| p.did == did)
+            .expect("seeded peer row is missing");
+        (row.http_url, row.last_ping_ok)
+    }
+
+    /// Seed a peer that has earned reachability, asserting the seed took so a
+    /// later case cannot pass vacuously on a row that was never written.
+    async fn seed_reachable(db: &Db) {
+        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+        db.mark_peer_ping(VICTIM_DID, true).await.unwrap();
+        assert_eq!(
+            peer(db, VICTIM_DID).await,
+            (HONEST_URL.to_string(), true),
+            "seed did not take"
+        );
+    }
+
+    /// Repointing an existing peer's URL must drop the reachability gate: the
+    /// new host has not been probed, so it cannot inherit the old host's
+    /// earned `last_ping_ok`.
+    #[sqlx::test]
+    async fn url_change_clears_reachability(pool: PgPool) {
+        let db = db(pool).await;
+        seed_reachable(&db).await;
+
+        db.upsert_peer(VICTIM_DID, ATTACKER_URL).await.unwrap();
+
+        let (url, reachable) = peer(&db, VICTIM_DID).await;
+        assert_eq!(url, ATTACKER_URL, "the URL should still be rewritten");
+        assert!(
+            !reachable,
+            "a repointed peer must re-earn reachability, not inherit it"
+        );
+    }
+
+    /// A plain liveness re-announce carries the same URL and must not cost an
+    /// honest peer its place in the federated fan-out. Guards against a fix
+    /// that clears the flag on every conflict instead of only on a change.
+    #[sqlx::test]
+    async fn same_url_reannounce_keeps_reachability(pool: PgPool) {
+        let db = db(pool).await;
+        seed_reachable(&db).await;
+
+        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+
+        let (url, reachable) = peer(&db, VICTIM_DID).await;
+        assert_eq!(url, HONEST_URL);
+        assert!(
+            reachable,
+            "an unchanged-URL re-announce must not drop the gate"
+        );
+    }
+
+    /// The must-not-grant direction. An unchanged URL preserves the flag as it
+    /// stands, which means FALSE stays FALSE: reachability is earned by a probe,
+    /// never by announcing. This is the only case that fails if the conditional
+    /// is flattened to `last_ping_ok = (peers.http_url IS NOT DISTINCT FROM $2)`,
+    /// which would let any unsigned same-URL re-announce set the flag TRUE.
+    #[sqlx::test]
+    async fn same_url_reannounce_does_not_grant_reachability(pool: PgPool) {
+        let db = db(pool).await;
+        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+        assert_eq!(peer(&db, VICTIM_DID).await, (HONEST_URL.to_string(), false));
+
+        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+
+        let (_, reachable) = peer(&db, VICTIM_DID).await;
+        assert!(
+            !reachable,
+            "announcing must never grant reachability without a probe"
+        );
+    }
+
+    /// A first insert stays out of the fan-out until a probe confirms it. Guards
+    /// against the conditional leaking into the INSERT branch.
+    #[sqlx::test]
+    async fn fresh_peer_inserts_unreachable(pool: PgPool) {
+        let db = db(pool).await;
+
+        db.upsert_peer("did:key:z6MkfreshPeerFixture", HONEST_URL)
+            .await
+            .unwrap();
+
+        let (_, reachable) = peer(&db, "did:key:z6MkfreshPeerFixture").await;
+        assert!(!reachable, "a never-probed peer must insert unreachable");
+    }
+}

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -2089,10 +2089,40 @@ impl Db {
             anyhow::bail!("refusing to register non-public peer http_url: {http_url}");
         }
         let now = Utc::now().to_rfc3339();
+        // A changed URL drops the reachability gate, so a repointed peer does
+        // not inherit a probe the previous host earned. In the DO UPDATE branch
+        // `peers.http_url` is the existing pre-update row (the proposed value is
+        // $2), and the comparison runs under the conflict row lock, so
+        // concurrent announces for one DID serialize instead of racing a
+        // read-then-write.
+        //
+        // Comparison is exact. http_url is stored as announced, so a cosmetic
+        // difference such as a trailing slash also clears the flag; the peer
+        // re-earns it on the next gossip round. Normalizing instead would mean
+        // canonicalizing the stored value, this comparison, and the existing
+        // trim_end_matches call sites.
+        //
+        // last_ping_ok is NOT a trust signal. An unauthenticated caller can
+        // clear it by announcing a different URL, and until #248 lands can also
+        // set it through the unauthenticated GET /api/v1/peers/{did}/ping, which
+        // writes mark_peer_ping from the stored URL's own probe response. Do not
+        // build a new consumer on this flag as if it were attacker-resistant.
+        //
+        // Four other http_url consumers never read the flag at all (sync.rs's
+        // origin resolve, the post-receive notify fan-out, trigger_sync, and the
+        // public resolve route), so this bounds the automatic inheritance rather
+        // than closing the rewrite. Binding a DID to its first-seen announcing
+        // key is what closes it: #273.
         sqlx::query(
             "INSERT INTO peers (did, http_url, last_seen, last_ping_ok, announced_at)
              VALUES ($1, $2, $3, FALSE, $3)
-             ON CONFLICT(did) DO UPDATE SET http_url = $2, last_seen = $3",
+             ON CONFLICT(did) DO UPDATE SET
+               http_url = $2,
+               last_seen = $3,
+               last_ping_ok = CASE
+                 WHEN peers.http_url IS DISTINCT FROM $2 THEN FALSE
+                 ELSE peers.last_ping_ok
+               END",
         )
         .bind(did)
         .bind(http_url)

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -2094,13 +2094,16 @@ impl Db {
         // `peers.http_url` is the existing pre-update row (the proposed value is
         // $2), and the comparison runs under the conflict row lock, so
         // concurrent announces for one DID serialize instead of racing a
-        // read-then-write.
+        // read-then-write. That orders announces against each other and nothing
+        // more: mark_peer_ping writes by DID with no http_url predicate, so a
+        // probe of the previous URL that lands after a reset can still re-grant
+        // the flag until the next round.
         //
         // Comparison is exact. http_url is stored as announced, so a cosmetic
         // difference such as a trailing slash also clears the flag; the peer
-        // re-earns it on the next gossip round. Normalizing instead would mean
-        // canonicalizing the stored value, this comparison, and the existing
-        // trim_end_matches call sites.
+        // re-earns it on a later gossip round, provided no further announce
+        // lands first. Normalizing instead would mean canonicalizing the stored
+        // value, this comparison, and the existing trim_end_matches call sites.
         //
         // last_ping_ok is NOT a trust signal. An unauthenticated caller can
         // clear it by announcing a different URL, and until #248 lands can also
@@ -2108,11 +2111,14 @@ impl Db {
         // writes mark_peer_ping from the stored URL's own probe response. Do not
         // build a new consumer on this flag as if it were attacker-resistant.
         //
-        // Four other http_url consumers never read the flag at all (sync.rs's
+        // Only the federated repo fan-out in api/repos.rs gates on this flag.
+        // Four consumers act on a repointed http_url regardless of it (sync.rs's
         // origin resolve, the post-receive notify fan-out, trigger_sync, and the
-        // public resolve route), so this bounds the automatic inheritance rather
-        // than closing the rewrite. Binding a DID to its first-seen announcing
-        // key is what closes it: #273.
+        // public resolve route), and two read surfaces republish it as
+        // `reachable` (api/resolve.rs, api/peers.rs), which is where a reset
+        // becomes externally visible. So this bounds the automatic inheritance
+        // rather than closing the rewrite. Binding a DID to its first-seen
+        // announcing key is what closes it: #273.
         sqlx::query(
             "INSERT INTO peers (did, http_url, last_seen, last_ping_ok, announced_at)
              VALUES ($1, $2, $3, FALSE, $3)
@@ -5740,6 +5746,21 @@ mod peer_reachability_tests {
         (row.http_url, row.last_ping_ok)
     }
 
+    /// Parsed rather than string-compared, so the ordering assertion does not
+    /// depend on the stored timestamp's textual precision.
+    async fn last_seen(db: &Db, did: &str) -> chrono::DateTime<chrono::Utc> {
+        let row = db
+            .list_peers()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|p| p.did == did)
+            .expect("seeded peer row is missing");
+        chrono::DateTime::parse_from_rfc3339(&row.last_seen.expect("last_seen is set by upsert"))
+            .expect("last_seen is rfc3339")
+            .with_timezone(&chrono::Utc)
+    }
+
     /// Seed a peer that has earned reachability, asserting the seed took so a
     /// later case cannot pass vacuously on a row that was never written.
     async fn seed_reachable(db: &Db) {
@@ -5820,5 +5841,46 @@ mod peer_reachability_tests {
 
         let (_, reachable) = peer(&db, "did:key:z6MkfreshPeerFixture").await;
         assert!(!reachable, "a never-probed peer must insert unreachable");
+    }
+
+    /// Comparison is exact, by decision: http_url is stored as announced and
+    /// nothing normalizes it, so a trailing slash is a different remote as far
+    /// as this row is concerned and clears the gate. Pins that decision against
+    /// a future normalizing comparison, which every other case here would pass
+    /// because they only ever compare identical or wholly different hosts.
+    #[sqlx::test]
+    async fn cosmetic_url_difference_counts_as_a_change(pool: PgPool) {
+        let db = db(pool).await;
+        seed_reachable(&db).await;
+
+        let with_slash = format!("{HONEST_URL}/");
+        db.upsert_peer(VICTIM_DID, &with_slash).await.unwrap();
+
+        let (url, reachable) = peer(&db, VICTIM_DID).await;
+        assert_eq!(url, with_slash);
+        assert!(
+            !reachable,
+            "comparison is exact, so a cosmetic difference clears the gate too"
+        );
+    }
+
+    /// The reset must ride the existing UPDATE, not gate it. Hoisting the
+    /// condition to a statement-level WHERE would leave every case above green
+    /// while silently skipping the whole update on a same-URL re-announce, so
+    /// liveness would stop advancing and the peer would age out on last_seen.
+    #[sqlx::test]
+    async fn same_url_reannounce_still_advances_last_seen(pool: PgPool) {
+        let db = db(pool).await;
+        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+        let first = last_seen(&db, VICTIM_DID).await;
+
+        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+
+        let second = last_seen(&db, VICTIM_DID).await;
+        assert!(
+            second > first,
+            "a same-URL re-announce is a liveness signal and must still \
+             advance last_seen: {first} then {second}"
+        );
     }
 }


### PR DESCRIPTION
`upsert_peer`'s `ON CONFLICT` branch rewrote `http_url` and said nothing about `last_ping_ok`, so an unsigned announce could repoint an existing peer's URL and inherit the `reachable = true` the previous host earned. The federated repo fan-out (`crates/gitlawb-node/src/api/repos.rs:1451`) filters on that flag and then stamps each entry from the peer's response body with that peer's DID, so the inheritance is what made the injection instant rather than probe-delayed. Reaching the branch needs no credential: `require_signed_peer_writes` defaults false (`config.rs:48`) and the announce handler's unsigned path only logs a warning.

## The change

One clause on the existing statement:

```sql
ON CONFLICT(did) DO UPDATE SET
  http_url = $2,
  last_seen = $3,
  last_ping_ok = CASE
    WHEN peers.http_url IS DISTINCT FROM $2 THEN FALSE
    ELSE peers.last_ping_ok
  END
```

In the `DO UPDATE` branch `peers.http_url` is the existing pre-update row and `$2` is the proposed value, so the comparison reads the stored URL, and it evaluates under the conflict row lock instead of a read-then-write that could lose an update. Both writers funnel through `upsert_peer` (the announce handler and the bootstrap announce-back in `main.rs`), so one clause covers both with no per-caller opt-out. No schema change, no migration.

## What this bounds, and what it does not

Worth being precise, since the flag is easy to over-trust:

Only the federated repo fan-out gates on `last_ping_ok`. Four consumers act on a repointed `http_url` regardless of it (`sync.rs`'s origin resolve, the post-receive notify fan-out, `trigger_sync`, and the public resolve route), and two read surfaces republish it as `reachable`. So this removes the automatic inheritance; it does not close the rewrite. Binding a DID to its first-seen announcing key is what closes it, which is #273 and a federation-model decision rather than a patch.

Until #248 lands, the reset is also bypassable in one unauthenticated request: `GET /api/v1/peers/{did}/ping` carries no auth layer and no IP brake, and writes `mark_peer_ping` from the stored URL's own probe response. #248 already deletes that write and is approved, so this branch deliberately leaves `ping_peer` alone rather than editing the same three lines.

Comparison is exact, which cuts both ways. A cosmetic difference such as a trailing slash also clears the flag, and an unauthenticated caller can use that to hold a legitimate peer out of the flag-gated fan-out at roughly 12 requests per hour per victim against the 600/hour/IP default brake. That cost is accepted here because the alternative is silent trust inheritance, and it goes away with #273. Normalizing instead would mean canonicalizing the stored value, this comparison, and the existing `trim_end_matches` call sites.

All of the above is recorded in a comment at the fix site so the next reader does not mistake the mitigation for a closure.

## Verification

Tests landed before the fix, in their own commit, and the failure was observed rather than assumed:

| | before the fix | after |
|---|---|---|
| `url_change_clears_reachability` | FAILED on the `last_ping_ok` assertion, with the `http_url` assertion passing | ok |
| the other five | ok | ok |

Three of the six are green in both directions by design. They are regression pins, and each one was confirmed load-bearing by applying the wrong implementation it targets and watching it go red:

| Wrong implementation | Caught only by |
|---|---|
| `CASE` clause removed | `url_change_clears_reachability` |
| `last_ping_ok = (peers.http_url IS NOT DISTINCT FROM $2)` | `same_url_reannounce_does_not_grant_reachability` |
| condition hoisted to a statement-level `WHERE` | `same_url_reannounce_still_advances_last_seen` |
| `rtrim(...)` normalizing comparison | `cosmetic_url_difference_counts_as_a_change` |

Each of those four passes at least three of the other tests, which is why the set is six and not one. The second would be the dangerous regression: it lets any unsigned same-URL re-announce set the flag TRUE with no probe at all, which is worse than the bug under repair. The third silently stops `last_seen` advancing on a liveness re-announce, so the peer ages out.

`cargo test -p gitlawb-node`: 516 passed, 0 failed, no pre-existing test flipped. `cargo clippy --all-targets -- -D warnings` clean workspace-wide. `cargo fmt --check` clean.

## Scope

Issue #270 was narrowed to this mitigation on 2026-07-28, with the rest split out: #272 (unvalidated `repo` slug on the same unsigned route, shipped as #274) and #273 (bind a DID to its first-seen key). Nothing here touches `sync.rs`, `api/repos.rs`, `api/resolve.rs`, `main.rs`, or `server.rs`.

Closes #270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer reachability tracking when a peer’s announced URL changes.
  * Preserved reachability status when peers re-announce the same URL.
  * Continued updating the last-seen timestamp for repeated announcements.
  * Correctly distinguishes URL changes based on exact string matching, including trailing-slash differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->