### PR TITLE
fix(release): bump icaptcha-client with the rest of the workspace

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -283,3 +283,35 @@ jobs:
 
       - name: Check gitlawb-core dependency allowlist
         run: bash scripts/check-gitlawb-core-deps.sh
+
+  # release-please only rewrites a crate's version when the line carries the
+  # `# x-release-please-version` annotation AND the manifest is listed under
+  # extra-files in release-please-config.json. Miss either half and the crate
+  # is skipped silently at release time, freezing at its creation version:
+  # icaptcha-client was added as a workspace member after the config was last
+  # written and sat at 0.4.0 through four releases before anyone noticed.
+  # Exhaustive-by-construction, like the allowlist gate above: the required set
+  # is derived from `cargo metadata`, so a newly added crate reds CI whether or
+  # not its author knew this gate existed.
+  release-versioning:
+    name: release versioning coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+        with:
+          key: release-versioning
+
+      - name: Check every workspace crate is release-managed
+        run: bash scripts/check-release-versioning.sh

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,8 @@
         { "type": "generic", "path": "crates/gitlawb-node/Cargo.toml" },
         { "type": "generic", "path": "crates/gl/Cargo.toml" },
         { "type": "generic", "path": "crates/git-remote-gitlawb/Cargo.toml" },
-        { "type": "generic", "path": "crates/gitlawb-attest/Cargo.toml" }
+        { "type": "generic", "path": "crates/gitlawb-attest/Cargo.toml" },
+        { "type": "generic", "path": "crates/icaptcha-client/Cargo.toml" }
       ]
     }
   }

--- a/scripts/check-release-versioning.sh
+++ b/scripts/check-release-versioning.sh
@@ -57,10 +57,19 @@ orphaned="$(comm -13 <(printf '%s\n' "$members") <(printf '%s\n' "$listed"))"
 
 # Second half of the invariant: being listed does nothing without the marker,
 # because the generic updater keys on the annotation to find the line.
+#
+# Scoped to the [package] table on purpose. A manifest-wide match is satisfied by
+# an annotated `version` under any other table, so a crate could leave the version
+# cargo actually reads unannotated, pass this gate, and still freeze at release
+# time while release-please rewrote the decoy line instead.
 unmarked=""
 while IFS= read -r manifest; do
   [ -n "$manifest" ] || continue
-  if ! grep -qE '^version = ".*" # x-release-please-version' "$ROOT/$manifest"; then
+  if ! awk '
+    /^[[:space:]]*\[/ { in_package = ($0 ~ /^[[:space:]]*\[package\][[:space:]]*$/); next }
+    in_package && /^version = ".*" # x-release-please-version/ { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "$ROOT/$manifest"; then
     unmarked="$unmarked$manifest"$'\n'
   fi
 done <<< "$members"

--- a/scripts/check-release-versioning.sh
+++ b/scripts/check-release-versioning.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Release-versioning coverage gate for the workspace crates.
+#
+# release-please owns every crate's version. It rewrites a version line only
+# when BOTH halves hold: the line carries an `# x-release-please-version`
+# annotation, and the crate's manifest is listed under `extra-files` in
+# release-please-config.json. A crate missing either half is silently skipped
+# at release time and freezes at whatever version it was created with, which
+# is exactly what happened to icaptcha-client (added as a workspace member
+# after the config was last written, so it sat at 0.4.0 while the rest of the
+# workspace walked to 0.7.1 across four releases).
+#
+# Exhaustive-by-construction: the required set is DERIVED from the workspace
+# member list via `cargo metadata`, never from a hand-maintained list here. A
+# newly added crate reds CI whether or not anyone remembered this gate exists,
+# which is the property a hand list cannot have.
+#
+# Hard-fail directions, all three release-silent:
+#   1. a workspace member absent from extra-files
+#   2. a workspace member whose version line lacks the annotation
+#   3. an extra-files entry pointing at a manifest that no longer exists
+#
+# Runnable from anywhere in the repo.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+CONFIG="$ROOT/release-please-config.json"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "ERROR: release-please config not found at $CONFIG" >&2
+  exit 1
+fi
+
+# Resolving can refresh Cargo.lock as a side effect, so snapshot and restore it:
+# this check must never leave the working tree dirty when run locally. Same
+# reasoning as scripts/check-gitlawb-core-deps.sh.
+lock_backup="$(mktemp)"
+cp "$ROOT/Cargo.lock" "$lock_backup"
+restore_lock() { cp "$lock_backup" "$ROOT/Cargo.lock"; rm -f "$lock_backup"; }
+trap restore_lock EXIT
+
+# Workspace members as repo-relative manifest paths, one per line. This is the
+# derived required set: whatever cargo considers a member must be release-managed.
+members="$(
+  cargo metadata --no-deps --format-version 1 --manifest-path "$ROOT/Cargo.toml" \
+    | jq -r '.packages[].manifest_path' \
+    | sed "s#^$ROOT/##" \
+    | sort -u
+)"
+
+# Manifest paths release-please is configured to rewrite.
+listed="$(jq -r '.packages["."]["extra-files"][] | .path' "$CONFIG" | sort -u)"
+
+unlisted="$(comm -23 <(printf '%s\n' "$members") <(printf '%s\n' "$listed"))"
+orphaned="$(comm -13 <(printf '%s\n' "$members") <(printf '%s\n' "$listed"))"
+
+# Second half of the invariant: being listed does nothing without the marker,
+# because the generic updater keys on the annotation to find the line.
+unmarked=""
+while IFS= read -r manifest; do
+  [ -n "$manifest" ] || continue
+  if ! grep -qE '^version = ".*" # x-release-please-version' "$ROOT/$manifest"; then
+    unmarked="$unmarked$manifest"$'\n'
+  fi
+done <<< "$members"
+
+failed=0
+
+if [ -n "$unlisted" ]; then
+  {
+    echo "ERROR: workspace members missing from extra-files in release-please-config.json:"
+    printf '  %s\n' $unlisted
+    echo
+    echo "release-please will never bump these crates, so they freeze at their"
+    echo "current version while the rest of the workspace moves. Add each one as"
+    echo '  { "type": "generic", "path": "<manifest path>" }'
+  } >&2
+  failed=1
+fi
+
+if [ -n "$unmarked" ]; then
+  {
+    echo "ERROR: workspace members whose version line lacks the release-please annotation:"
+    printf '  %s\n' $unmarked
+    echo
+    echo 'The generic updater finds the line by its trailing `# x-release-please-version`'
+    echo "comment. Without it the crate is listed but never rewritten."
+  } >&2
+  failed=1
+fi
+
+if [ -n "$orphaned" ]; then
+  {
+    echo "ERROR: extra-files entries pointing at manifests that are not workspace members:"
+    printf '  %s\n' $orphaned
+    echo
+    echo "release-please fails the release when an extra-file path does not exist."
+    echo "Drop the stale entry, or restore the crate to the workspace."
+  } >&2
+  failed=1
+fi
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi
+
+echo "release versioning coverage: OK ($(printf '%s\n' "$members" | wc -l | tr -d ' ') workspace members, all annotated and listed)."


### PR DESCRIPTION
`icaptcha-client` has been sitting at `0.4.0` since it was created, while the other five workspace crates walked to `0.7.1`. Surfaced while reviewing the 0.7.1 release PR, which bumped five of six annotated crates.

## Cause

release-please rewrites a crate's version line only when both halves hold: the line carries an `# x-release-please-version` annotation, and the manifest is listed under `extra-files` in `release-please-config.json`.

`release-please-config.json` was last written in #130, when the workspace had exactly the five crates it lists. #138 added `crates/icaptcha-client` as a sixth member with the annotation already on its version line, set to `0.4.0` (the workspace version that day), and did not touch the config. The config has been modified twice in the repo's history and never since #130. So every release since has rewritten five files and skipped the sixth.

## What this did and did not break

Nothing functional, which is worth stating plainly since the version has been wrong for four releases:

- Every intra-workspace path dependency is bare `{ path = "..." }` with no version requirement, so no resolution constraint could go unsatisfied.
- No crate is published to a registry. There is no `cargo publish` in any workflow or script.
- `icaptcha-client` is named in no workflow, script, or Dockerfile. It ships only compiled into `gl`.
- It reads no `CARGO_PKG_VERSION` of its own. The 11 uses across the workspace are all in `gl`, `git-remote-gitlawb`, and `gitlawb-node`, so the user-agent in `crates/gl/src/http.rs:28` correctly reports `gl`'s version.

The actual cost was `Cargo.toml:13-19`, which asserts that every crate's version line "carries an `# x-release-please-version` annotation and is listed under `extra-files`". That was false for one of six, and it is the comment the next person adding a crate reads and copies.

## Changes

Adding the missing `extra-files` entry makes that comment true again with no edit to it.

The gate is the part worth reviewing. `scripts/check-release-versioning.sh` derives its required set from `cargo metadata`, so a newly added crate reds CI whether or not its author knows the gate exists. This mirrors `check-gitlawb-core-deps.sh` and its exhaustive-by-construction property; a hand-maintained list would have the same blind spot that caused this. It covers all three release-silent shapes: a member absent from `extra-files`, a member whose version line lost the annotation, and an `extra-files` path that is no longer a member.

## Verification

Each arm was run in both directions:

| Arm | Injection | Result |
| --- | --- | --- |
| Member absent from `extra-files` | none, the live defect | exit 1, names `icaptcha-client` |
| Member missing the annotation | stripped from `gitlawb-attest` | exit 1, annotation message |
| `extra-files` path not a member | added `crates/deleted-crate` | exit 1, orphan message |
| Annotation outside `[package]` | decoy `version` under `[package.metadata.foo]`, real one unannotated | exit 1, annotation message |
| Must not fire | fix applied | exit 0, "6 workspace members" |
| Must not fire | annotated `[package]` plus a second annotated line | exit 0 |
| Must not fire | `[package]` not the first table | exit 0 |

The first arm is the one that matters: it went red against the real defect before the fix and green after, so it is load-bearing rather than vacuously passing. The `[package]` scoping arm was added in 251faf3 after review: a manifest-wide match for the annotation is satisfied by an annotated `version` under any other table, so a crate could leave the version cargo actually reads unannotated, pass this gate, and still freeze at release time. That arm was red before 251faf3 and green after, with the three must-not-fire rows holding in both directions. All injections were reverted. The script restores `Cargo.lock` on exit like its precedent, leaves the tree clean, and runs from repo subdirectories.

## One thing to decide

The next release will move `icaptcha-client` from `0.4.0` to the current workspace version in a single jump. Nothing reads that version, so it is cosmetic, but it will appear in a release diff and is better as a deliberate call than a surprise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated release-versioning checks to validate workspace package coverage and version annotations.
  * Updated release configuration to include the captcha client package.
  * Added safeguards that report missing, outdated, or invalid package entries during pull request checks.
  * Improved release readiness by preventing incomplete package version tracking from being merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
