### PR TITLE
fix(node): bind a peer row to its DID so only its keyholder can repoint it (#273)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ POST /api/v1/peers/announce
 POST /api/v1/sync/notify
 ```
 
-When `GITLAWB_REQUIRE_SIGNED_PEER_WRITES=false`, unsigned legacy peers are accepted on those two routes, but signed requests are verified when signature headers are present. Once all live peers upgrade, operators can set:
+When `GITLAWB_REQUIRE_SIGNED_PEER_WRITES=false`, unsigned legacy peers are accepted on those two routes, but signed requests are verified when signature headers are present. Staged rollout relaxes who may announce, not who owns a peer row. An unsigned announce may register a previously unseen peer, and it may refresh an existing row whose `http_url` is unchanged, but changing an existing peer's `http_url` requires an RFC 9421 signature from that peer's own DID and is refused with 403 otherwise. An unsigned announce can only register a `did:key`, since that is the only method whose verifying key can be resolved and therefore the only kind of row anyone could ever correct through the signed path; any other DID is refused with 400. Once all live peers upgrade, operators can set:
 
 ```bash
 GITLAWB_REQUIRE_SIGNED_PEER_WRITES=true

--- a/crates/gitlawb-core/src/did.rs
+++ b/crates/gitlawb-core/src/did.rs
@@ -80,6 +80,19 @@ impl Did {
             )));
         }
 
+        // Refuse an oversized id before decoding. base58 decoding is quadratic
+        // in its input, and both callers of this function take the string from
+        // an untrusted request: the unauthenticated peer-announce gate, and the
+        // HTTP-signature keyid. An ed25519 did:key method-id is a fixed 48
+        // characters, so this bound is slack rather than a behavior change, and
+        // it has to sit ahead of the decode to be worth anything.
+        const MAX_METHOD_ID_LEN: usize = 64;
+        if self.method_id().len() > MAX_METHOD_ID_LEN {
+            return Err(Error::InvalidDid(
+                "did:key method-specific id too long".to_string(),
+            ));
+        }
+
         let (_, bytes) =
             multibase::decode(self.method_id()).map_err(|e| Error::InvalidDid(e.to_string()))?;
 
@@ -307,5 +320,53 @@ mod tests {
     fn method_id_extraction() {
         assert_eq!(Did::web("example.com").method_id(), "example.com");
         assert_eq!(Did::gitlawb("z6MkSomeKey").method_id(), "z6MkSomeKey");
+    }
+
+    /// An oversized method-specific id is refused on its length, before the
+    /// base58 decode runs.
+    ///
+    /// base58 decoding is quadratic in the input, and `to_verifying_key` is
+    /// reached from two places that take an attacker-supplied string: the
+    /// unauthenticated peer-announce gate, and the HTTP-signature keyid. A
+    /// 64k-character DID measured 8s through the router without this guard
+    /// against 4.6ms with it, on a tokio worker with no spawn_blocking, so a
+    /// single caller could buy CPU-seconds by the thousand.
+    ///
+    /// Asserting the MESSAGE is what makes this load-bearing: an oversized id
+    /// errors either way, so a test that only checked `is_err()` would pass
+    /// with the guard removed, having merely paid the cost it exists to avoid.
+    #[test]
+    fn to_verifying_key_rejects_an_oversized_method_id_before_decoding() {
+        let oversized = format!("did:key:z{}", "z".repeat(64_000));
+        let did: Did = oversized.parse().expect("method is still `key`");
+
+        let start = std::time::Instant::now();
+        let err = did.to_verifying_key().expect_err("must be refused");
+        let elapsed = start.elapsed();
+
+        assert!(
+            err.to_string().contains("too long"),
+            "must be refused on length, not after the decode: {err}"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(1),
+            "refusal must not pay the quadratic decode: took {elapsed:?}"
+        );
+    }
+
+    /// The bound must not reject a real key. Every `did:key` this project
+    /// mints is a fixed 48 characters, so the limit is slack, not a behavior
+    /// change.
+    #[test]
+    fn to_verifying_key_still_accepts_a_real_did_key() {
+        use ed25519_dalek::SigningKey;
+        let signing = SigningKey::from_bytes(&[7u8; 32]);
+        let did = Did::from_verifying_key(&signing.verifying_key());
+        assert_eq!(
+            did.method_id().len(),
+            48,
+            "did:key method-id is fixed-width"
+        );
+        did.to_verifying_key().expect("a real did:key must resolve");
     }
 }

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -29,13 +29,19 @@ use crate::state::AppState;
 /// denial this gate exists to avoid. An authority refusal is 403; naming a DID
 /// method that can never authenticate, or a DID whose verifying key cannot be
 /// resolved, is a fact about the input's form, so both are the 400 validation
-/// class. The match stays exhaustive with no wildcard: the compile error a new
-/// denial causes here is what finds every mapping site.
+/// class, and the unresolvable one carries its own code so it reads the same to
+/// a client as the auth middleware's answer for an unresolvable keyid. The match
+/// stays exhaustive with no wildcard: the compile error a new denial causes here
+/// is what finds every mapping site.
 fn peer_write_error(err: anyhow::Error) -> AppError {
     match err.downcast::<PeerWriteDenied>() {
         Ok(denied) => match &denied {
-            PeerWriteDenied::UnsupportedDidMethod { .. }
-            | PeerWriteDenied::UnresolvableDid { .. } => AppError::BadRequest(denied.to_string()),
+            PeerWriteDenied::UnsupportedDidMethod { .. } => {
+                AppError::BadRequest(denied.to_string())
+            }
+            PeerWriteDenied::UnresolvableDid { .. } => {
+                AppError::UnresolvableDid(denied.to_string())
+            }
             PeerWriteDenied::UnprovenRepoint { .. } | PeerWriteDenied::ProofDidMismatch { .. } => {
                 AppError::Forbidden(denied.to_string())
             }
@@ -1659,7 +1665,12 @@ mod tests {
             StatusCode::BAD_REQUEST,
             "an unresolvable did:key is a validation failure: {message}"
         );
-        assert_eq!(code, "bad_request");
+        assert_eq!(
+            code, "unresolvable_did",
+            "the code must name the cause, the same way the signed path does for a keyid it \
+             cannot resolve; a client distinguishing this from the other 400s on this route \
+             must not have to substring-match the message: {message:?}"
+        );
         assert!(
             message.contains("cannot resolve DID"),
             "the rejection must report resolution, not method support, got {message:?}"

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -214,8 +214,15 @@ pub async fn announce(
     // auth/mod.rs resolves the verifying key FROM the keyid DID itself, so what
     // is carried through to the upsert boundary below is a proof, not a claim.
     let proven_did: Option<String> = if let Some(Extension(auth)) = auth {
+        // 403, not 400: this caller proved control of some DID and spent that
+        // proof on a different DID's row, which is a refusal of authority over
+        // the targeted row: the same denial as an unsigned repoint, and two
+        // callers denied for the same reason must not get different response
+        // classes. The 400 class stays for input-form failures: a malformed
+        // DID, a non-public URL, a self-announce, and a DID method that can
+        // never authenticate.
         if auth.0 != announced_did.to_string() {
-            return Err(AppError::BadRequest(
+            return Err(AppError::Forbidden(
                 "Signature keyid must match announced DID".into(),
             ));
         }
@@ -1359,6 +1366,560 @@ mod tests {
         assert!(
             !s.contains("push"),
             "a 429 on a sync route must not say 'push': {s:?}"
+        );
+    }
+
+    // ── #273: the announce authority contract ─────────────────────────────────
+    //
+    // U4 drives the handler mounted alone, because signed_request_as injects an
+    // AuthenticatedDid extension without a real signature and require_signature
+    // would reject that on the full router. U5 then proves the same properties
+    // through build_router with REAL RFC 9421 signatures, where a signature can
+    // be pointed at a row it does not own.
+
+    const OWNER_URL: &str = "https://owner-peer.example.com";
+    const MOVED_URL: &str = "https://moved-peer.example.com";
+    const HIJACK_URL: &str = "https://hijacker.example.com";
+    const WEB_DID: &str = "did:web:squatter.example.com";
+    const KEYID_MISMATCH: &str = "Signature keyid must match announced DID";
+
+    /// Every column a consumer sees, so a case that claims "unchanged" compares
+    /// the whole row rather than the one field it happened to think of.
+    type PeerSnapshot = (String, String, Option<String>, bool, String);
+
+    async fn snapshot(db: &crate::db::Db, did: &str) -> Option<PeerSnapshot> {
+        db.list_peers()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|p| p.did == did)
+            .map(|p| {
+                (
+                    p.did,
+                    p.http_url,
+                    p.last_seen,
+                    p.last_ping_ok,
+                    p.announced_at,
+                )
+            })
+    }
+
+    /// Seed a peer row and assert the seed took, so no case below can pass
+    /// vacuously against a row that was never written.
+    async fn seed_peer_row(state: &AppState, did: &str, url: &str) -> PeerSnapshot {
+        state
+            .db
+            .upsert_peer(did, url, crate::db::PeerWriteAuthority::Unproven)
+            .await
+            .expect("seed");
+        let seeded = snapshot(&state.db, did).await.expect("seed did not take");
+        assert_eq!(seeded.1, url, "seed did not take");
+        seeded
+    }
+
+    /// Status, error code, and message together, so a denial is asserted by its
+    /// exact class and stated reason rather than by "not 2xx".
+    async fn status_and_error(resp: axum::response::Response) -> (StatusCode, String, String) {
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_else(|_| {
+            panic!(
+                "error body must be JSON: {}",
+                String::from_utf8_lossy(&bytes)
+            )
+        });
+        let field = |k: &str| v[k].as_str().unwrap_or_default().to_string();
+        (status, field("error"), field("message"))
+    }
+
+    fn announce_body(did: &str, url: &str) -> String {
+        format!(r#"{{"did":"{did}","http_url":"{url}"}}"#)
+    }
+
+    fn announce_only(state: AppState) -> Router {
+        Router::new()
+            .route("/api/v1/peers/announce", post(super::announce))
+            .with_state(state)
+    }
+
+    fn announce_as(did: &str, body: &str) -> Request<Body> {
+        signed_request_as(
+            did,
+            Method::POST,
+            "/api/v1/peers/announce",
+            Body::from(body.to_string()),
+        )
+    }
+
+    /// U4 scenario 1, and the first test the keyid branch has ever had: a caller
+    /// who proved control of one DID must not announce another's. Kills
+    /// neutralizing the handler's keyid comparison, and kills demoting this
+    /// denial back to the 400 validation class where the unsigned repoint below
+    /// is a 403 for the same reason.
+    #[sqlx::test]
+    async fn announce_keyid_mismatch_is_a_403_denial(pool: PgPool) {
+        let state = test_state(pool).await;
+        let victim = Keypair::generate().did().to_string();
+        let hijacker = Keypair::generate().did().to_string();
+        let before = seed_peer_row(&state, &victim, OWNER_URL).await;
+
+        let resp = announce_only(state.clone())
+            .oneshot(announce_as(&hijacker, &announce_body(&victim, HIJACK_URL)))
+            .await
+            .unwrap();
+
+        let (status, code, message) = status_and_error(resp).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "a proof spent on another DID's row is an authority refusal: {message}"
+        );
+        assert_eq!(code, "forbidden", "denial body must name the 403 class");
+        assert!(
+            message.contains(KEYID_MISMATCH),
+            "the denial must name the keyid mismatch, got {message:?}"
+        );
+        assert_eq!(
+            snapshot(&state.db, &victim).await.expect("row vanished"),
+            before,
+            "the stored row must be byte-identical after a refused announce"
+        );
+    }
+
+    /// U4 scenario 2: the allowed signed case. A caller whose keyid IS the row
+    /// repoints it. Kills a gate that refuses proven writes too.
+    #[sqlx::test]
+    async fn announce_with_matching_keyid_repoints_its_own_row(pool: PgPool) {
+        let state = test_state(pool).await;
+        let owner = Keypair::generate().did().to_string();
+        seed_peer_row(&state, &owner, OWNER_URL).await;
+
+        let resp = announce_only(state.clone())
+            .oneshot(announce_as(&owner, &announce_body(&owner, MOVED_URL)))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let after = snapshot(&state.db, &owner).await.expect("row vanished");
+        assert_eq!(after.1, MOVED_URL, "a proven repoint must land");
+    }
+
+    /// U4 scenario 3: an unsigned caller cannot move an existing row, and the
+    /// refusal renders as a 403 with its reason, never as a 500 or as success.
+    #[sqlx::test]
+    async fn announce_unsigned_repoint_is_a_403_denial(pool: PgPool) {
+        let state = test_state(pool).await;
+        let victim = Keypair::generate().did().to_string();
+        let before = seed_peer_row(&state, &victim, OWNER_URL).await;
+
+        let resp = announce_only(state.clone())
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &announce_body(&victim, HIJACK_URL),
+                "203.0.113.90:5000",
+            ))
+            .await
+            .unwrap();
+
+        let (status, code, message) = status_and_error(resp).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "an unproven repoint is an authority refusal: {message}"
+        );
+        assert_eq!(code, "forbidden", "denial body must name the 403 class");
+        assert!(
+            message.contains("unproven announce cannot change an existing peer"),
+            "the denial must name the repoint refusal, got {message:?}"
+        );
+        assert_eq!(
+            snapshot(&state.db, &victim).await.expect("row vanished"),
+            before,
+            "the stored row must be byte-identical after a refused repoint"
+        );
+    }
+
+    /// U4 scenarios 4 and 5, the allowed unsigned class: discovery of an unseen
+    /// did:key still inserts, and an honest peer re-announcing the IDENTICAL URL
+    /// still refreshes liveness. The URL is reused byte for byte because the
+    /// comparison is exact, so a trailing slash would make this pass as a
+    /// repoint rejection instead. Kills a gate widened until it breaks
+    /// discovery or honest re-announces.
+    #[sqlx::test]
+    async fn announce_unsigned_insert_and_identical_url_reannounce_are_accepted(pool: PgPool) {
+        let state = test_state(pool).await;
+        let did = Keypair::generate().did().to_string();
+        let body = announce_body(&did, OWNER_URL);
+
+        let resp = announce_only(state.clone())
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &body,
+                "203.0.113.91:5000",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "discovery must stay open");
+        let before = snapshot(&state.db, &did).await.expect("row not inserted");
+        assert_eq!(before.1, OWNER_URL);
+        assert!(!before.3, "a never-probed peer inserts unreachable");
+
+        let resp = announce_only(state.clone())
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &body,
+                "203.0.113.92:5000",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "an identical-URL re-announce is a liveness signal, not a repoint"
+        );
+        let after = snapshot(&state.db, &did).await.expect("row vanished");
+        assert_eq!(after.1, OWNER_URL, "URL untouched");
+        assert_eq!(after.3, before.3, "reachability untouched");
+        assert_eq!(after.4, before.4, "announced_at untouched");
+        let parse = |s: &Option<String>| {
+            chrono::DateTime::parse_from_rfc3339(s.as_deref().expect("last_seen is set")).unwrap()
+        };
+        assert!(
+            parse(&after.2) > parse(&before.2),
+            "a same-URL re-announce must advance last_seen"
+        );
+    }
+
+    /// U4 scenario 6 (R8): a DID method that can never authenticate is refused
+    /// in the 400 validation class, with nothing written. This one IS about the
+    /// input's form, not the caller's authority, which is why it is not a 403.
+    #[sqlx::test]
+    async fn announce_of_a_did_web_is_a_400_validation_failure(pool: PgPool) {
+        let state = test_state(pool).await;
+
+        let resp = announce_only(state.clone())
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &announce_body(WEB_DID, OWNER_URL),
+                "203.0.113.93:5000",
+            ))
+            .await
+            .unwrap();
+
+        let (status, code, message) = status_and_error(resp).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "an unsupported DID method is a validation failure: {message}"
+        );
+        assert_eq!(code, "bad_request");
+        assert!(
+            message.contains("methodNotSupported"),
+            "the rejection must carry the methodNotSupported shape, got {message:?}"
+        );
+        assert!(
+            snapshot(&state.db, WEB_DID).await.is_none(),
+            "a rejected announce must leave no row behind"
+        );
+    }
+
+    // ── U5: the same matrix through the production router, real signatures ────
+
+    /// An announce carrying a REAL RFC 9421 signature, signed AS `kp` while the
+    /// body names whatever DID the caller chooses. That split is the point: it
+    /// is what lets a valid signature be pointed at a row it does not own,
+    /// which is the RUSTSEC-2022-0009 shape.
+    fn real_signed_announce(kp: &Keypair, body: &str, peer: &str) -> Request<Body> {
+        let path = "/api/v1/peers/announce";
+        let s = sign_request(kp, "POST", path, body.as_bytes());
+        let mut req = Request::builder()
+            .method(Method::POST)
+            .uri(path)
+            .header(header::CONTENT_TYPE, "application/json")
+            .header("content-digest", s.content_digest)
+            .header("signature-input", s.signature_input)
+            .header("signature", s.signature)
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        req.extensions_mut()
+            .insert(ConnectInfo(peer.parse::<SocketAddr>().unwrap()));
+        req
+    }
+
+    /// U5 scenario 1: the lowest-privilege caller there is, fully
+    /// unauthenticated, still seeds an unseen did:key row through the whole
+    /// production stack.
+    #[sqlx::test]
+    async fn router_unsigned_announce_inserts_an_unseen_did(pool: PgPool) {
+        let state = test_state(pool).await;
+        let did = Keypair::generate().did().to_string();
+        let db = state.db.clone();
+
+        let resp = crate::server::build_router(state)
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &announce_body(&did, OWNER_URL),
+                "203.0.113.94:5000",
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let row = snapshot(&db, &did).await.expect("row not inserted");
+        assert_eq!(row.1, OWNER_URL);
+    }
+
+    /// U5 scenario 2: the defect this change closes, driven end to end. An
+    /// unsigned repoint is refused with its reason and the row does not move.
+    /// Kills reverting the unproven arm to an unconditional DO UPDATE.
+    #[sqlx::test]
+    async fn router_unsigned_announce_cannot_repoint_an_existing_row(pool: PgPool) {
+        let state = test_state(pool).await;
+        let victim = Keypair::generate().did().to_string();
+        let before = seed_peer_row(&state, &victim, OWNER_URL).await;
+        let db = state.db.clone();
+
+        let resp = crate::server::build_router(state)
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &announce_body(&victim, HIJACK_URL),
+                "203.0.113.95:5000",
+            ))
+            .await
+            .unwrap();
+
+        // The row assertion leads: the property is that the row does not move.
+        // A response-class regression is a second, separate failure below.
+        let (status, code, message) = status_and_error(resp).await;
+        assert_eq!(
+            snapshot(&db, &victim).await.expect("row vanished"),
+            before,
+            "the stored row must be byte-identical after a refused unsigned repoint \
+             (observed status {status})"
+        );
+        assert_eq!(status, StatusCode::FORBIDDEN, "observed body: {message}");
+        assert_eq!(code, "forbidden");
+    }
+
+    /// U5 scenario 3: the allowed signed case through the real verification
+    /// middleware. The row was seeded under this keypair's own did:key, so the
+    /// signature names the row it moves.
+    #[sqlx::test]
+    async fn router_signature_from_the_rows_own_did_repoints_it(pool: PgPool) {
+        let state = test_state(pool).await;
+        let owner = Keypair::generate();
+        let owner_did = owner.did().to_string();
+        seed_peer_row(&state, &owner_did, OWNER_URL).await;
+        let db = state.db.clone();
+
+        let resp = crate::server::build_router(state)
+            .oneshot(real_signed_announce(
+                &owner,
+                &announce_body(&owner_did, MOVED_URL),
+                "203.0.113.96:5000",
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "a real signature from the row's own DID must be admitted"
+        );
+        let row = snapshot(&db, &owner_did).await.expect("row vanished");
+        assert_eq!(row.1, MOVED_URL, "a proven repoint must land");
+        assert!(
+            !row.3,
+            "a repointed peer must re-earn reachability even when the repoint is signed"
+        );
+    }
+
+    /// U5 scenario 4, the RUSTSEC-2022-0009 shape: a signature that verifies
+    /// perfectly, spent on a row it does not own. The key must be bound to the
+    /// ROW, not to anything the request carries. The assertion names the keyid
+    /// denial specifically, because the boundary's own DID comparison would
+    /// also refuse this write, so a status-only assertion would stay green with
+    /// the handler branch neutralized.
+    #[sqlx::test]
+    async fn router_signature_from_another_did_cannot_repoint_this_row(pool: PgPool) {
+        let state = test_state(pool).await;
+        let victim = Keypair::generate().did().to_string();
+        let hijacker = Keypair::generate();
+        let before = seed_peer_row(&state, &victim, OWNER_URL).await;
+        let db = state.db.clone();
+
+        let resp = crate::server::build_router(state)
+            .oneshot(real_signed_announce(
+                &hijacker,
+                &announce_body(&victim, HIJACK_URL),
+                "203.0.113.97:5000",
+            ))
+            .await
+            .unwrap();
+
+        let (status, code, message) = status_and_error(resp).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "a valid signature over another DID's row must be refused: {message}"
+        );
+        assert_eq!(code, "forbidden");
+        assert!(
+            message.contains(KEYID_MISMATCH),
+            "the denial must name the keyid mismatch, got {message:?}"
+        );
+        assert_eq!(
+            snapshot(&db, &victim).await.expect("row vanished"),
+            before,
+            "the stored row must be byte-identical after a mismatched signature"
+        );
+    }
+
+    /// U5 scenario 5: an honest unsigned peer re-announcing the identical URL
+    /// through the full stack refreshes last_seen and moves nothing else. The
+    /// seeded string is reused byte for byte, since the comparison is exact.
+    #[sqlx::test]
+    async fn router_unsigned_identical_url_reannounce_refreshes_last_seen(pool: PgPool) {
+        let state = test_state(pool).await;
+        let did = Keypair::generate().did().to_string();
+        let before = seed_peer_row(&state, &did, OWNER_URL).await;
+        let db = state.db.clone();
+
+        let resp = crate::server::build_router(state)
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &announce_body(&did, OWNER_URL),
+                "203.0.113.98:5000",
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let after = snapshot(&db, &did).await.expect("row vanished");
+        assert_eq!(after.1, OWNER_URL, "URL untouched");
+        assert_eq!(after.3, before.3, "reachability untouched");
+        assert_eq!(after.4, before.4, "announced_at untouched");
+        let parse = |s: &Option<String>| {
+            chrono::DateTime::parse_from_rfc3339(s.as_deref().expect("last_seen is set")).unwrap()
+        };
+        assert!(
+            parse(&after.2) > parse(&before.2),
+            "a same-URL re-announce must advance last_seen"
+        );
+    }
+
+    /// U5 scenario 6 (R8) through the full stack: a did:web announce is refused
+    /// in the validation class and writes nothing. Such a row could never be
+    /// corrected by anyone, since only a did:key can ever satisfy the proven
+    /// path. Kills neutralizing the method gate on the unproven arm.
+    #[sqlx::test]
+    async fn router_unsigned_announce_of_a_did_web_is_refused(pool: PgPool) {
+        let state = test_state(pool).await;
+        let db = state.db.clone();
+
+        let resp = crate::server::build_router(state)
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &announce_body(WEB_DID, OWNER_URL),
+                "203.0.113.99:5000",
+            ))
+            .await
+            .unwrap();
+
+        let (status, code, message) = status_and_error(resp).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "an unsupported DID method must be refused: {message}"
+        );
+        assert_eq!(code, "bad_request");
+        assert!(
+            message.contains("methodNotSupported"),
+            "the rejection must carry the methodNotSupported shape, got {message:?}"
+        );
+        assert!(
+            snapshot(&db, WEB_DID).await.is_none(),
+            "a rejected announce must leave no row behind"
+        );
+    }
+
+    /// U5, flag-on mode: with require_signed_peer_writes the write group moves
+    /// under add_auth_layers, so the unsigned caller dies at the auth layer with
+    /// a 401 instead of reaching the handler's 403. The authority rules
+    /// themselves do not change: a signature over another DID's row is still
+    /// refused, and the row's own key still moves it. The flag is applied BEFORE
+    /// build_router, which reads it at build time.
+    #[sqlx::test]
+    async fn announce_authority_matrix_in_signed_writes_mode(pool: PgPool) {
+        let mut state = test_state(pool).await;
+        require_signed_peer_writes(&mut state);
+        let owner = Keypair::generate();
+        let owner_did = owner.did().to_string();
+        let hijacker = Keypair::generate();
+        let before = seed_peer_row(&state, &owner_did, OWNER_URL).await;
+        let db = state.db.clone();
+        let router = crate::server::build_router(state);
+
+        let resp = router
+            .clone()
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &announce_body(&owner_did, HIJACK_URL),
+                "203.0.113.100:5000",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "with the flag on, an unsigned announce dies at the auth layer"
+        );
+        assert_eq!(
+            snapshot(&db, &owner_did).await.expect("row vanished"),
+            before,
+            "the row must be byte-identical after the 401"
+        );
+
+        let resp = router
+            .clone()
+            .oneshot(real_signed_announce(
+                &hijacker,
+                &announce_body(&owner_did, HIJACK_URL),
+                "203.0.113.101:5000",
+            ))
+            .await
+            .unwrap();
+        let (status, _, message) = status_and_error(resp).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "a signature over another DID's row is still refused: {message}"
+        );
+        assert!(message.contains(KEYID_MISMATCH), "got {message:?}");
+        assert_eq!(
+            snapshot(&db, &owner_did).await.expect("row vanished"),
+            before,
+            "the row must be byte-identical after the mismatched signature"
+        );
+
+        let resp = router
+            .oneshot(real_signed_announce(
+                &owner,
+                &announce_body(&owner_did, MOVED_URL),
+                "203.0.113.102:5000",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "the row's own key still moves it with the flag on"
+        );
+        assert_eq!(
+            snapshot(&db, &owner_did).await.expect("row vanished").1,
+            MOVED_URL
         );
     }
 }

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -1404,16 +1404,24 @@ mod tests {
             })
     }
 
-    /// Seed a peer row and assert the seed took, so no case below can pass
-    /// vacuously against a row that was never written.
+    /// Seed a peer row that has EARNED reachability, asserting the seed took,
+    /// so no case below can pass vacuously against a row that was never written
+    /// or against a flag that was already false. Without the granted ping a
+    /// "must be unreachable after this" assertion compares false to false and
+    /// stays green with the production code that clears the flag removed.
     async fn seed_peer_row(state: &AppState, did: &str, url: &str) -> PeerSnapshot {
         state
             .db
             .upsert_peer(did, url, crate::db::PeerWriteAuthority::Unproven)
             .await
             .expect("seed");
+        state.db.mark_peer_ping(did, true).await.expect("seed ping");
         let seeded = snapshot(&state.db, did).await.expect("seed did not take");
         assert_eq!(seeded.1, url, "seed did not take");
+        assert!(
+            seeded.3,
+            "the seeded row must start reachable, or a later unreachable assertion is vacuous"
+        );
         seeded
     }
 

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -27,14 +27,15 @@ use crate::state::AppState;
 /// back out the way `From<anyhow::Error> for AppError` already recovers sqlx
 /// errors. Without this a refusal renders as a 500, which is the mis-rendered
 /// denial this gate exists to avoid. An authority refusal is 403; naming a DID
-/// method that can never authenticate is a fact about the input's form, so it
-/// is the 400 validation class.
+/// method that can never authenticate, or a DID whose verifying key cannot be
+/// resolved, is a fact about the input's form, so both are the 400 validation
+/// class. The match stays exhaustive with no wildcard: the compile error a new
+/// denial causes here is what finds every mapping site.
 fn peer_write_error(err: anyhow::Error) -> AppError {
     match err.downcast::<PeerWriteDenied>() {
         Ok(denied) => match &denied {
-            PeerWriteDenied::UnsupportedDidMethod { .. } => {
-                AppError::BadRequest(denied.to_string())
-            }
+            PeerWriteDenied::UnsupportedDidMethod { .. }
+            | PeerWriteDenied::UnresolvableDid { .. } => AppError::BadRequest(denied.to_string()),
             PeerWriteDenied::UnprovenRepoint { .. } | PeerWriteDenied::ProofDidMismatch { .. } => {
                 AppError::Forbidden(denied.to_string())
             }
@@ -1629,6 +1630,42 @@ mod tests {
         );
         assert!(
             snapshot(&state.db, WEB_DID).await.is_none(),
+            "a rejected announce must leave no row behind"
+        );
+    }
+
+    /// The sibling of the case above, and the one it must not swallow: the
+    /// method IS did:key, so methodNotSupported would be a false statement
+    /// about the input. The value is the W3C secp256k1 did:key test vector,
+    /// which decodes cleanly and is simply not an ed25519 key. Still the 400
+    /// validation class, still nothing written.
+    #[sqlx::test]
+    async fn announce_of_an_unresolvable_did_key_is_a_400_with_the_cause(pool: PgPool) {
+        let state = test_state(pool).await;
+        let did = "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme";
+
+        let resp = announce_only(state.clone())
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &announce_body(did, OWNER_URL),
+                "203.0.113.99:5000",
+            ))
+            .await
+            .unwrap();
+
+        let (status, code, message) = status_and_error(resp).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "an unresolvable did:key is a validation failure: {message}"
+        );
+        assert_eq!(code, "bad_request");
+        assert!(
+            message.contains("cannot resolve DID"),
+            "the rejection must report resolution, not method support, got {message:?}"
+        );
+        assert!(
+            snapshot(&state.db, did).await.is_none(),
             "a rejected announce must leave no row behind"
         );
     }

--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -17,8 +17,31 @@ use gitlawb_core::did::Did;
 use serde::{Deserialize, Serialize};
 
 use crate::auth::AuthenticatedDid;
+use crate::db::{PeerWriteAuthority, PeerWriteDenied};
 use crate::error::{AppError, Result};
 use crate::state::AppState;
+
+/// Map an `upsert_peer` failure onto its response class.
+///
+/// The boundary's denials arrive inside an anyhow chain, so they are downcast
+/// back out the way `From<anyhow::Error> for AppError` already recovers sqlx
+/// errors. Without this a refusal renders as a 500, which is the mis-rendered
+/// denial this gate exists to avoid. An authority refusal is 403; naming a DID
+/// method that can never authenticate is a fact about the input's form, so it
+/// is the 400 validation class.
+fn peer_write_error(err: anyhow::Error) -> AppError {
+    match err.downcast::<PeerWriteDenied>() {
+        Ok(denied) => match &denied {
+            PeerWriteDenied::UnsupportedDidMethod { .. } => {
+                AppError::BadRequest(denied.to_string())
+            }
+            PeerWriteDenied::UnprovenRepoint { .. } | PeerWriteDenied::ProofDidMismatch { .. } => {
+                AppError::Forbidden(denied.to_string())
+            }
+        },
+        Err(other) => AppError::from(other),
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct AnnounceRequest {
@@ -187,18 +210,23 @@ pub async fn announce(
         .did
         .parse()
         .map_err(|e: gitlawb_core::Error| AppError::BadRequest(e.to_string()))?;
-    if let Some(Extension(auth)) = auth {
+    // The extension's DID is cryptographically derived, never body-supplied:
+    // auth/mod.rs resolves the verifying key FROM the keyid DID itself, so what
+    // is carried through to the upsert boundary below is a proof, not a claim.
+    let proven_did: Option<String> = if let Some(Extension(auth)) = auth {
         if auth.0 != announced_did.to_string() {
             return Err(AppError::BadRequest(
                 "Signature keyid must match announced DID".into(),
             ));
         }
+        Some(auth.0)
     } else {
         tracing::warn!(
             did = %announced_did,
             "accepted unsigned peer announce; set GITLAWB_REQUIRE_SIGNED_PEER_WRITES=true after all peers upgrade"
         );
-    }
+        None
+    };
 
     // Validate the URL is a public http(s) endpoint. The announce route is
     // reachable unauthenticated (until all peers sign), so without this an
@@ -228,7 +256,20 @@ pub async fn announce(
         ));
     }
 
-    state.db.upsert_peer(&req.did, &req.http_url).await?;
+    // The authority declaration, not a re-statement of the check above: the
+    // boundary carries the proven DID and re-checks it against the row itself,
+    // so the keyid comparison above is an early rejection rather than the only
+    // gate. The other writer (the bootstrap announce-back in main.rs) never
+    // reaches this handler at all.
+    let authority = match proven_did.as_deref() {
+        Some(did) => PeerWriteAuthority::Proven(did),
+        None => PeerWriteAuthority::Unproven,
+    };
+    state
+        .db
+        .upsert_peer(&req.did, &req.http_url, authority)
+        .await
+        .map_err(peer_write_error)?;
 
     tracing::info!(did = %req.did, url = %req.http_url, "peer announced");
 
@@ -770,7 +811,11 @@ mod tests {
         let did = Keypair::generate().did().to_string();
         state
             .db
-            .upsert_peer(&did, "https://peer.example.com")
+            .upsert_peer(
+                &did,
+                "https://peer.example.com",
+                crate::db::PeerWriteAuthority::Unproven,
+            )
             .await
             .unwrap();
         did
@@ -1153,6 +1198,57 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// U1 (#273). An unsigned announce must not repoint an existing peer's row.
+    ///
+    /// Kills the unconditional `ON CONFLICT(did) DO UPDATE SET http_url = $2` in
+    /// `Db::upsert_peer`. The failure message carries BOTH observed values,
+    /// because the gate is the observed rewrite (2xx AND the attacker URL
+    /// stored), not merely a failing assertion: a 429 from the peer-write brake,
+    /// a fixture URL `is_public_http_url` rejects, or a DB error would all read
+    /// as "assertion failed" while proving nothing about this defect.
+    #[sqlx::test]
+    async fn unsigned_announce_cannot_repoint_an_existing_peer(pool: PgPool) {
+        const HONEST: &str = "https://honest-peer.example.com";
+        const ATTACKER: &str = "https://attacker.example.com";
+
+        let state = test_state(pool).await;
+        let did = Keypair::generate().did().to_string();
+        state
+            .db
+            .upsert_peer(&did, HONEST, crate::db::PeerWriteAuthority::Unproven)
+            .await
+            .unwrap();
+
+        let stored_url = |peers: Vec<crate::db::PeerRecord>| {
+            peers.into_iter().find(|p| p.did == did).map(|p| p.http_url)
+        };
+        assert_eq!(
+            stored_url(state.db.list_peers().await.unwrap()).as_deref(),
+            Some(HONEST),
+            "seed did not take; the case below would pass vacuously"
+        );
+
+        // Clone before build_router consumes state, so the row can be read back.
+        let db = state.db.clone();
+        let body = format!(r#"{{"did":"{did}","http_url":"{ATTACKER}"}}"#);
+        let resp = crate::server::build_router(state)
+            .oneshot(unsigned_post(
+                "/api/v1/peers/announce",
+                &body,
+                "203.0.113.77:5000",
+            ))
+            .await
+            .unwrap();
+        let status = resp.status();
+        let stored = stored_url(db.list_peers().await.unwrap())
+            .expect("peer row vanished; neither the allowed nor the denied outcome");
+
+        assert_eq!(
+            stored, HONEST,
+            "unsigned announce repointed an existing peer (observed status {status}, stored http_url {stored})"
+        );
     }
 
     // Build a request carrying a REAL RFC 9421 signature (not just an injected

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -6959,6 +6959,72 @@ mod peers_table_writer_guard {
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
 
+    /// The per-file scan, split out so the multi-line-SQL property can be
+    /// asserted against a synthetic source rather than only against the real
+    /// tree, which happens to contain no multi-line peers write today. A guard
+    /// whose blind spot is invisible because the tree does not currently
+    /// exercise it is one that fails the moment somebody writes normal code.
+    fn scan_source(src: &str) -> BTreeMap<String, usize> {
+        let needles: Vec<String> = needles().iter().map(|n| n.to_lowercase()).collect();
+        let mut found: BTreeMap<String, usize> = BTreeMap::new();
+        // Normalize the WHOLE file before matching, not each line on its
+        // own. Per-line `contains` is whitespace- and case-sensitive, so
+        // `sqlx::query(r#"UPDATE\n  peers SET ..."#)` walked straight past
+        // it, and that multi-line form is how the longer queries in this
+        // file are already written. Verified both ways: the single-line
+        // bypass went RED, the identical statement split across lines
+        // stayed GREEN. Offsets are mapped back to line numbers so each
+        // statement is still attributed to the function that issues it.
+        let mut flat = String::with_capacity(src.len());
+        let mut starts: Vec<(usize, usize)> = Vec::new(); // (offset, line index)
+        for (idx, line) in src.lines().enumerate() {
+            starts.push((flat.len(), idx));
+            flat.push_str(&line.trim().to_lowercase());
+            flat.push(' ');
+        }
+        let flat = flat.split_whitespace().collect::<Vec<_>>().join(" ");
+
+        // Re-derive offsets against the collapsed text by walking it once.
+        let mut collapsed = String::with_capacity(flat.len());
+        let mut owners: Vec<usize> = Vec::new(); // line index per byte
+        for (idx, line) in src.lines().enumerate() {
+            for tok in line.trim().to_lowercase().split_whitespace() {
+                if !collapsed.is_empty() {
+                    collapsed.push(' ');
+                    owners.push(idx);
+                }
+                for _ in 0..tok.len() {
+                    owners.push(idx);
+                }
+                collapsed.push_str(tok);
+            }
+        }
+
+        let fn_at: Vec<&str> = {
+            let mut current = "<module level>";
+            src.lines()
+                .map(|line| {
+                    if let Some(name) = declared_fn(line) {
+                        current = name;
+                    }
+                    current
+                })
+                .collect()
+        };
+
+        for needle in &needles {
+            let mut from = 0usize;
+            while let Some(rel) = collapsed[from..].find(needle.as_str()) {
+                let at = from + rel;
+                let line_idx = owners.get(at).copied().unwrap_or(0);
+                let owner = fn_at.get(line_idx).copied().unwrap_or("<module level>");
+                *found.entry(owner.to_string()).or_default() += 1;
+                from = at + needle.len();
+            }
+        }
+        found
+    }
+
     /// Each dispositioned writer and the number of statements it issues against
     /// the table. Bidirectional: an undispositioned hit fails, and so does a
     /// listed function that no longer has one.
@@ -7012,6 +7078,43 @@ mod peers_table_writer_guard {
     /// The backstop the authority parameter cannot provide: a new raw write
     /// against the table from outside `upsert_peer` is invisible to the type
     /// system, so it is caught here or not at all.
+    /// The blind spot this guard shipped with: matching a verb-plus-table needle
+    /// per line is whitespace- and case-sensitive, so the identical statement split
+    /// across lines walked past it. That form is how the longer queries in this
+    /// file are already written, so it is the shape a future writer most likely
+    /// takes. Both directions asserted, plus lowercase.
+    ///
+    /// The fixtures are DERIVED from `needles()` at runtime for the same reason
+    /// the needles themselves are: a literal here would be found by the scan of
+    /// this very file and counted against this test function. Deriving them
+    /// also means the test follows if the needle set ever changes.
+    #[test]
+    fn the_scan_sees_a_write_whose_verb_and_table_are_on_different_lines() {
+        for needle in needles() {
+            let (verb, table) = needle.rsplit_once(' ').expect("a needle is '<VERB> peers'");
+            let cases = [
+                ("single-line", format!("{verb} {table} SET x = $1")),
+                (
+                    "split across lines",
+                    format!("{verb}\n             {table}\n             SET x = $1"),
+                ),
+                (
+                    "lowercase, double-spaced",
+                    format!("{}  {} set x = $1", verb.to_lowercase(), table),
+                ),
+            ];
+            for (label, sql) in cases {
+                let src = format!("fn sneaky() {{\n    sqlx::query(\"{sql}\");\n}}\n");
+                let found = scan_source(&src);
+                assert_eq!(
+                    found.get("sneaky").copied(),
+                    Some(1),
+                    "the scan missed a peers write written {label} with needle {needle:?}: {found:?}"
+                );
+            }
+        }
+    }
+
     #[test]
     fn every_peers_table_write_is_dispositioned() {
         let mut files = Vec::new();
@@ -7026,18 +7129,12 @@ mod peers_table_writer_guard {
             files.len()
         );
 
-        let needles = needles();
         let mut found: BTreeMap<String, usize> = BTreeMap::new();
         for file in &files {
             let src = std::fs::read_to_string(file).expect("source file must be readable");
-            let mut current = "<module level>";
-            for line in src.lines() {
-                if let Some(name) = declared_fn(line) {
-                    current = name;
-                }
-                if needles.iter().any(|n| line.contains(n.as_str())) {
-                    *found.entry(current.to_string()).or_default() += 1;
-                }
+
+            for (owner, n) in scan_source(&src) {
+                *found.entry(owner).or_default() += n;
             }
         }
 

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -2186,6 +2186,16 @@ pub enum PeerWriteDenied {
         "methodNotSupported: only did:key peers can be registered without a proof of control: {did}"
     )]
     UnsupportedDidMethod { did: String },
+
+    /// The value is a did:key (or never parsed as a DID at all), but no
+    /// verifying key can be resolved from it. Distinct from
+    /// `UnsupportedDidMethod`, which is a true statement about a foreign
+    /// method; this one carries the underlying resolution failure instead of
+    /// claiming did:key is unsupported. The wording mirrors the signed path in
+    /// auth/mod.rs, so the two surfaces that judge the same input say the same
+    /// sentence.
+    #[error("cannot resolve DID '{did}': {reason}")]
+    UnresolvableDid { did: String, reason: String },
 }
 
 impl Db {
@@ -2236,17 +2246,37 @@ impl Db {
             // is_did_key() and creates exactly the permanently uncorrectable
             // row this gate exists to prevent. to_verifying_key() is the same
             // resolution auth/mod.rs performs on the keyid.
-            PeerWriteAuthority::Unproven
-                if !did
-                    .parse::<gitlawb_core::did::Did>()
-                    .map(|d| d.to_verifying_key().is_ok())
-                    .unwrap_or(false) =>
-            {
-                return Err(PeerWriteDenied::UnsupportedDidMethod {
-                    did: did.to_string(),
+            //
+            // The refusal is split by cause, because methodNotSupported is only
+            // a true statement about a foreign method: a did:key whose key
+            // material does not resolve gets the resolution failure instead.
+            PeerWriteAuthority::Unproven => match did.parse::<gitlawb_core::did::Did>() {
+                // Only reachable from the bootstrap announce-back in main.rs,
+                // which passes the contacted peer's raw JSON string; the
+                // announce handler parses req.did before calling here.
+                Err(e) => {
+                    return Err(PeerWriteDenied::UnresolvableDid {
+                        did: did.to_string(),
+                        reason: e.to_string(),
+                    }
+                    .into());
                 }
-                .into());
-            }
+                Ok(d) if !d.is_did_key() => {
+                    return Err(PeerWriteDenied::UnsupportedDidMethod {
+                        did: did.to_string(),
+                    }
+                    .into());
+                }
+                Ok(d) => {
+                    if let Err(e) = d.to_verifying_key() {
+                        return Err(PeerWriteDenied::UnresolvableDid {
+                            did: did.to_string(),
+                            reason: e.to_string(),
+                        }
+                        .into());
+                    }
+                }
+            },
             _ => {}
         }
         let now = Utc::now().to_rfc3339();
@@ -6652,27 +6682,163 @@ mod peer_authority_tests {
         assert!(!reachable, "a never-probed peer must insert unreachable");
     }
 
-    /// R8. Only a DID whose verifying key can be derived can ever authenticate,
-    /// so an unproven insert of anything else would create a row no one could
-    /// ever correct through the proven path. Rejected in the validation class,
-    /// with nothing written. Kills a method gate applied only to the update
-    /// path, and kills a gate that checks the method LABEL rather than the key
-    /// material: `did:key:notarealkey` carries the right method and no
-    /// derivable key, so the row it would create is the permanently
-    /// uncorrectable one this gate exists to prevent.
+    /// R8. A DID whose method can never authenticate is refused in the
+    /// validation class, with nothing written. Kills a method gate applied only
+    /// to the update path. This case is about the METHOD LABEL alone, which is
+    /// the one thing methodNotSupported can truthfully say; a did:key whose key
+    /// material does not resolve is a different refusal and is covered by the
+    /// unresolvable tests below, so it is deliberately not in this loop.
     #[sqlx::test]
     async fn unproven_insert_of_a_non_did_key_is_rejected(pool: PgPool) {
         let db = db(pool).await;
 
-        for did in [WEB_DID, "did:gitlawb:z6MkSomeKey", "did:key:notarealkey"] {
+        for did in [WEB_DID, "did:gitlawb:z6MkSomeKey"] {
             let err = db
                 .upsert_peer(did, HONEST_URL, PeerWriteAuthority::Unproven)
                 .await
                 .expect_err("a DID method that can never authenticate must not be insertable");
 
+            let denied = denial(err);
             assert!(
-                matches!(denial(err), PeerWriteDenied::UnsupportedDidMethod { .. }),
+                matches!(denied, PeerWriteDenied::UnsupportedDidMethod { .. }),
+                "the denial must be the typed method refusal: {did}"
+            );
+            assert!(
+                denied
+                    .to_string()
+                    .contains("methodNotSupported: only did:key peers"),
                 "the denial must name the unsupported method"
+            );
+            assert!(
+                row(&db, did).await.is_none(),
+                "a rejected announce must leave no row behind: {did}"
+            );
+        }
+    }
+
+    /// The oversized method-id is refused ahead of the quadratic base58 decode,
+    /// and the caller is told THAT, not that did:key is unsupported. Kills
+    /// folding the key-resolution failure back into the method class.
+    #[sqlx::test]
+    async fn unproven_insert_of_an_oversized_did_key_reports_the_cause(pool: PgPool) {
+        let db = db(pool).await;
+        let did = format!("did:key:z{}", "a".repeat(70));
+
+        let err = db
+            .upsert_peer(&did, HONEST_URL, PeerWriteAuthority::Unproven)
+            .await
+            .expect_err("a did:key whose key cannot be resolved must not be insertable");
+
+        let denied = denial(err);
+        assert!(
+            matches!(denied, PeerWriteDenied::UnresolvableDid { .. }),
+            "the denial must be the typed resolution refusal"
+        );
+        let denied = denied.to_string();
+        assert!(
+            denied.contains("cannot resolve DID"),
+            "an unresolvable did:key must report resolution, not method support, got {denied:?}"
+        );
+        assert!(
+            denied.contains("method-specific id too long"),
+            "the denial must carry the underlying cause, got {denied:?}"
+        );
+        assert!(
+            row(&db, &did).await.is_none(),
+            "a rejected announce must leave no row behind: {did}"
+        );
+    }
+
+    /// The remaining resolution failures, one input class per entry, each
+    /// pinned to its own cause. The multibase entry asserts only the class
+    /// message: its sub-reason is multibase's own Display and a dependency bump
+    /// can reword it.
+    #[sqlx::test]
+    async fn unproven_insert_of_an_unresolvable_did_key_reports_the_cause(pool: PgPool) {
+        let db = db(pool).await;
+
+        // "0" is not in the base58btc alphabet, so the decode itself fails.
+        // "notarealkey" carries the right method label and no decodable key,
+        // which is the permanently uncorrectable row this gate prevents.
+        // The secp256k1 vector is the W3C did:key test vector: it decodes
+        // cleanly and is simply not an ed25519 key.
+        // The wrong-length vector is base58btc(0xed 0x01 || sixteen bytes
+        // 0x00..0x0f) with the multibase 'z' prefix: the right multicodec, half
+        // the key.
+        for (did, cause) in [
+            ("did:key:z0", None),
+            ("did:key:notarealkey", None),
+            (
+                "did:key:zQ3shokFTS3brHcDQrn82RUDfCZESWL1ZdCEJwekUDPQiYBme",
+                Some("not an ed25519 multicodec key"),
+            ),
+            (
+                "did:key:zAq9r99PUfP1Xyitb5n8V9sxht",
+                Some("ed25519 key must be 32 bytes"),
+            ),
+        ] {
+            let err = db
+                .upsert_peer(did, HONEST_URL, PeerWriteAuthority::Unproven)
+                .await
+                .expect_err("a did:key whose key cannot be resolved must not be insertable");
+
+            let denied = denial(err);
+            assert!(
+                matches!(denied, PeerWriteDenied::UnresolvableDid { .. }),
+                "the denial must be the typed resolution refusal: {did}"
+            );
+            let denied = denied.to_string();
+            assert!(
+                denied.contains("cannot resolve DID"),
+                "an unresolvable did:key must report resolution, not method support: \
+                 {did} got {denied:?}"
+            );
+            if let Some(cause) = cause {
+                assert!(
+                    denied.contains(cause),
+                    "the denial must carry the underlying cause {cause:?}: {did} got {denied:?}"
+                );
+            }
+            assert!(
+                row(&db, did).await.is_none(),
+                "a rejected announce must leave no row behind: {did}"
+            );
+        }
+    }
+
+    /// The bootstrap announce-back in main.rs hands this boundary the contacted
+    /// peer's raw JSON string, so a value that never parses as a DID reaches
+    /// here; the announce handler cannot produce it, since it parses req.did
+    /// first. The parse error is what an operator reading that loop's warning
+    /// needs, and methodNotSupported would be a false claim about a string that
+    /// names no method at all.
+    #[sqlx::test]
+    async fn unproven_insert_of_an_unparseable_string_reports_the_parse_failure(pool: PgPool) {
+        let db = db(pool).await;
+
+        for (did, cause) in [
+            ("not-a-did", "does not start with 'did:'"),
+            ("did:foo:x", "unsupported DID method: foo"),
+        ] {
+            let err = db
+                .upsert_peer(did, HONEST_URL, PeerWriteAuthority::Unproven)
+                .await
+                .expect_err("a string that is not a DID must not be insertable");
+
+            let denied = denial(err);
+            assert!(
+                matches!(denied, PeerWriteDenied::UnresolvableDid { .. }),
+                "the denial must be the typed resolution refusal: {did}"
+            );
+            let denied = denied.to_string();
+            assert!(
+                denied.contains("cannot resolve DID"),
+                "an unparseable DID must report resolution, not method support: \
+                 {did} got {denied:?}"
+            );
+            assert!(
+                denied.contains(cause),
+                "the denial must carry the parse failure {cause:?}: {did} got {denied:?}"
             );
             assert!(
                 row(&db, did).await.is_none(),

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -2192,8 +2192,9 @@ pub enum PeerWriteDenied {
     /// `UnsupportedDidMethod`, which is a true statement about a foreign
     /// method; this one carries the underlying resolution failure instead of
     /// claiming did:key is unsupported. The wording mirrors the signed path in
-    /// auth/mod.rs, so the two surfaces that judge the same input say the same
-    /// sentence.
+    /// auth/mod.rs, and peer_write_error maps it to the same `unresolvable_did`
+    /// code that path returns, so the two surfaces that judge the same input
+    /// answer with the same sentence under the same name.
     #[error("cannot resolve DID '{did}': {reason}")]
     UnresolvableDid { did: String, reason: String },
 }

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -2133,8 +2133,74 @@ impl Db {
 
 // ── Peers ─────────────────────────────────────────────────────────────────────
 
+/// What a caller of [`Db::upsert_peer`] can prove about the DID it is writing.
+///
+/// An enum rather than a bool, and the proven variant carries a payload rather
+/// than being a bare unit, for two separate reasons.
+///
+/// It is not a bool because a bool at a call site reads as `true`/`false` with
+/// nothing at the call site saying what was proven, and because the default a
+/// bool invites (`false` meaning "no proof") is exactly the permissive value
+/// this gate exists to withhold. Passed as a real parameter with no default, so
+/// a new writer of the peers table cannot reach the update path by omission.
+///
+/// It carries the DID because "something was proven" is not the question. The
+/// boundary needs to know WHICH DID was proven, and compare it against the row
+/// being written. A bare proven/unproven flag leaves that comparison in the
+/// handler, which is the shape of RUSTSEC-2022-0009 (libp2p-core accepted a
+/// valid signature without checking it derived the claimed peer id) and leaves
+/// the second writer, the bootstrap announce-back in main.rs, outside the gate
+/// entirely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerWriteAuthority<'a> {
+    /// The caller has no proof of control over the DID it is writing. May
+    /// insert an unseen `did:key` row; may never change an existing row's
+    /// `http_url`.
+    Unproven,
+    /// The caller verified a signature, and the DID carried here is the one
+    /// that signature proved control of. `upsert_peer` checks it against the
+    /// row being written; a mismatch is a denial, not a warning.
+    Proven(&'a str),
+}
+
+/// A write refused by [`Db::upsert_peer`]'s authority gate.
+///
+/// A distinct type rather than a bare `anyhow::bail!` because `upsert_peer`
+/// returns `anyhow::Result` and `From<anyhow::Error> for AppError` routes
+/// anything it cannot downcast to `AppError::Internal`, so an untyped rejection
+/// would reach the client as a 500. The announce handler downcasts this out of
+/// the anyhow chain the same way the error module already recovers sqlx errors.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum PeerWriteDenied {
+    /// An unproven write tried to change an existing row's `http_url`.
+    #[error("unproven announce cannot change an existing peer's http_url: {did}")]
+    UnprovenRepoint { did: String },
+
+    /// The signature proved control of one DID and the write targeted another.
+    #[error("signature proves control of {proven}, but the write targets {target}")]
+    ProofDidMismatch { proven: String, target: String },
+
+    /// An unproven write named a DID method that can never authenticate, so the
+    /// row it would create could never be corrected by anyone.
+    #[error(
+        "methodNotSupported: only did:key peers can be registered without a proof of control: {did}"
+    )]
+    UnsupportedDidMethod { did: String },
+}
+
 impl Db {
-    pub async fn upsert_peer(&self, did: &str, http_url: &str) -> Result<()> {
+    /// Insert or refresh a peer row, bounded by what the caller can prove.
+    ///
+    /// See [`PeerWriteAuthority`] for why the authority is a parameter with no
+    /// default. The rule: an unproven caller may INSERT an unseen `did:key`
+    /// row, but may never UPDATE an existing row's `http_url`. Changing an
+    /// existing row requires a verified signature from that row's own DID.
+    pub async fn upsert_peer(
+        &self,
+        did: &str,
+        http_url: &str,
+        authority: PeerWriteAuthority<'_>,
+    ) -> Result<()> {
         // Defense-in-depth at the DB boundary: both writers funnel through here
         // — the announce handler and the bootstrap announce-back in main.rs.
         // The latter has no announce-time check, so validating here is what
@@ -2142,6 +2208,38 @@ impl Db {
         // right after prune_non_public_peers cleaned it.
         if !crate::api::peers::is_public_http_url(http_url) {
             anyhow::bail!("refusing to register non-public peer http_url: {http_url}");
+        }
+        match authority {
+            // The proof has to name the row being written. Checking it here and
+            // not only in the announce handler is the whole point of putting
+            // the gate at this boundary: a caller could otherwise hold a valid
+            // signature for its own DID and spend it on someone else's row,
+            // which is RUSTSEC-2022-0009 exactly.
+            PeerWriteAuthority::Proven(proven) if proven != did => {
+                return Err(PeerWriteDenied::ProofDidMismatch {
+                    proven: proven.to_string(),
+                    target: did.to_string(),
+                }
+                .into());
+            }
+            // Only did:key can ever authenticate: auth/mod.rs resolves the
+            // verifying key from the keyid DID itself and rejects every other
+            // method. A did:web or did:gitlawb row seeded here would therefore
+            // be unwritable by anyone forever, since no proof could ever
+            // satisfy the branch above, while still steering the sync origin
+            // resolve, the notify fan-out, and the public resolve route.
+            PeerWriteAuthority::Unproven
+                if !did
+                    .parse::<gitlawb_core::did::Did>()
+                    .map(|d| d.is_did_key())
+                    .unwrap_or(false) =>
+            {
+                return Err(PeerWriteDenied::UnsupportedDidMethod {
+                    did: did.to_string(),
+                }
+                .into());
+            }
+            _ => {}
         }
         let now = Utc::now().to_rfc3339();
         // A changed URL drops the reachability gate, so a repointed peer does
@@ -2174,22 +2272,61 @@ impl Db {
         // becomes externally visible. So this bounds the automatic inheritance
         // rather than closing the rewrite. Binding a DID to its first-seen
         // announcing key is what closes it: #273.
-        sqlx::query(
-            "INSERT INTO peers (did, http_url, last_seen, last_ping_ok, announced_at)
-             VALUES ($1, $2, $3, FALSE, $3)
-             ON CONFLICT(did) DO UPDATE SET
-               http_url = $2,
-               last_seen = $3,
-               last_ping_ok = CASE
-                 WHEN peers.http_url IS DISTINCT FROM $2 THEN FALSE
-                 ELSE peers.last_ping_ok
-               END",
-        )
-        .bind(did)
-        .bind(http_url)
-        .bind(&now)
-        .execute(&self.pool)
-        .await?;
+        //
+        // The two statements below differ only in what the conflict branch may
+        // touch. The proven one keeps the form above verbatim. The unproven one
+        // never assigns http_url at all and guards the whole DO UPDATE on the
+        // stored URL being byte-identical, so an unproven caller can refresh
+        // liveness and nothing else. last_ping_ok needs no CASE there, because
+        // the guard already restricts the branch to the URL-unchanged case the
+        // CASE would have preserved.
+        match authority {
+            PeerWriteAuthority::Proven(_) => {
+                sqlx::query(
+                    "INSERT INTO peers (did, http_url, last_seen, last_ping_ok, announced_at)
+                     VALUES ($1, $2, $3, FALSE, $3)
+                     ON CONFLICT(did) DO UPDATE SET
+                       http_url = $2,
+                       last_seen = $3,
+                       last_ping_ok = CASE
+                         WHEN peers.http_url IS DISTINCT FROM $2 THEN FALSE
+                         ELSE peers.last_ping_ok
+                       END",
+                )
+                .bind(did)
+                .bind(http_url)
+                .bind(&now)
+                .execute(&self.pool)
+                .await?;
+            }
+            PeerWriteAuthority::Unproven => {
+                let rows = sqlx::query(
+                    "INSERT INTO peers (did, http_url, last_seen, last_ping_ok, announced_at)
+                     VALUES ($1, $2, $3, FALSE, $3)
+                     ON CONFLICT(did) DO UPDATE SET
+                       last_seen = $3
+                     WHERE peers.http_url IS NOT DISTINCT FROM $2",
+                )
+                .bind(did)
+                .bind(http_url)
+                .bind(&now)
+                .execute(&self.pool)
+                .await?;
+                // A guarded ON CONFLICT DO UPDATE whose WHERE fails reports
+                // zero rows affected; it does NOT raise. So the refusal has to
+                // be derived from rows_affected, or the "an unproven repoint is
+                // an error, not a silent no-op" decision quietly becomes the
+                // no-op it was chosen to avoid. Zero rows here means exactly
+                // one thing, since the insert branch always affects a row: the
+                // DID exists and the announced URL is not the stored one.
+                if rows.rows_affected() == 0 {
+                    return Err(PeerWriteDenied::UnprovenRepoint {
+                        did: did.to_string(),
+                    }
+                    .into());
+                }
+            }
+        }
         Ok(())
     }
 
@@ -6111,7 +6248,7 @@ mod ref_update_db_tests {
 
 #[cfg(test)]
 mod peer_reachability_tests {
-    use super::Db;
+    use super::{Db, PeerWriteAuthority};
     use sqlx::PgPool;
 
     const VICTIM_DID: &str = "did:key:z6MkvictimPeerFixture";
@@ -6155,7 +6292,9 @@ mod peer_reachability_tests {
     /// Seed a peer that has earned reachability, asserting the seed took so a
     /// later case cannot pass vacuously on a row that was never written.
     async fn seed_reachable(db: &Db) {
-        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+        db.upsert_peer(VICTIM_DID, HONEST_URL, PeerWriteAuthority::Unproven)
+            .await
+            .unwrap();
         db.mark_peer_ping(VICTIM_DID, true).await.unwrap();
         assert_eq!(
             peer(db, VICTIM_DID).await,
@@ -6172,7 +6311,16 @@ mod peer_reachability_tests {
         let db = db(pool).await;
         seed_reachable(&db).await;
 
-        db.upsert_peer(VICTIM_DID, ATTACKER_URL).await.unwrap();
+        // Proven: the repoint is the row's own key announcing a new host, which
+        // is the case #270's reset is about. An unproven repoint is refused
+        // outright now, so it cannot express this property.
+        db.upsert_peer(
+            VICTIM_DID,
+            ATTACKER_URL,
+            PeerWriteAuthority::Proven(VICTIM_DID),
+        )
+        .await
+        .unwrap();
 
         let (url, reachable) = peer(&db, VICTIM_DID).await;
         assert_eq!(url, ATTACKER_URL, "the URL should still be rewritten");
@@ -6190,7 +6338,9 @@ mod peer_reachability_tests {
         let db = db(pool).await;
         seed_reachable(&db).await;
 
-        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+        db.upsert_peer(VICTIM_DID, HONEST_URL, PeerWriteAuthority::Unproven)
+            .await
+            .unwrap();
 
         let (url, reachable) = peer(&db, VICTIM_DID).await;
         assert_eq!(url, HONEST_URL);
@@ -6208,10 +6358,14 @@ mod peer_reachability_tests {
     #[sqlx::test]
     async fn same_url_reannounce_does_not_grant_reachability(pool: PgPool) {
         let db = db(pool).await;
-        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+        db.upsert_peer(VICTIM_DID, HONEST_URL, PeerWriteAuthority::Unproven)
+            .await
+            .unwrap();
         assert_eq!(peer(&db, VICTIM_DID).await, (HONEST_URL.to_string(), false));
 
-        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+        db.upsert_peer(VICTIM_DID, HONEST_URL, PeerWriteAuthority::Unproven)
+            .await
+            .unwrap();
 
         let (_, reachable) = peer(&db, VICTIM_DID).await;
         assert!(
@@ -6226,9 +6380,13 @@ mod peer_reachability_tests {
     async fn fresh_peer_inserts_unreachable(pool: PgPool) {
         let db = db(pool).await;
 
-        db.upsert_peer("did:key:z6MkfreshPeerFixture", HONEST_URL)
-            .await
-            .unwrap();
+        db.upsert_peer(
+            "did:key:z6MkfreshPeerFixture",
+            HONEST_URL,
+            PeerWriteAuthority::Unproven,
+        )
+        .await
+        .unwrap();
 
         let (_, reachable) = peer(&db, "did:key:z6MkfreshPeerFixture").await;
         assert!(!reachable, "a never-probed peer must insert unreachable");
@@ -6245,7 +6403,13 @@ mod peer_reachability_tests {
         seed_reachable(&db).await;
 
         let with_slash = format!("{HONEST_URL}/");
-        db.upsert_peer(VICTIM_DID, &with_slash).await.unwrap();
+        db.upsert_peer(
+            VICTIM_DID,
+            &with_slash,
+            PeerWriteAuthority::Proven(VICTIM_DID),
+        )
+        .await
+        .unwrap();
 
         let (url, reachable) = peer(&db, VICTIM_DID).await;
         assert_eq!(url, with_slash);
@@ -6262,10 +6426,14 @@ mod peer_reachability_tests {
     #[sqlx::test]
     async fn same_url_reannounce_still_advances_last_seen(pool: PgPool) {
         let db = db(pool).await;
-        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+        db.upsert_peer(VICTIM_DID, HONEST_URL, PeerWriteAuthority::Unproven)
+            .await
+            .unwrap();
         let first = last_seen(&db, VICTIM_DID).await;
 
-        db.upsert_peer(VICTIM_DID, HONEST_URL).await.unwrap();
+        db.upsert_peer(VICTIM_DID, HONEST_URL, PeerWriteAuthority::Unproven)
+            .await
+            .unwrap();
 
         let second = last_seen(&db, VICTIM_DID).await;
         assert!(
@@ -6273,5 +6441,223 @@ mod peer_reachability_tests {
             "a same-URL re-announce is a liveness signal and must still \
              advance last_seen: {first} then {second}"
         );
+    }
+}
+
+#[cfg(test)]
+mod peer_authority_tests {
+    use super::{Db, PeerWriteAuthority, PeerWriteDenied};
+    use sqlx::PgPool;
+
+    const VICTIM_DID: &str = "did:key:z6MkvictimAuthorityFixture";
+    const OTHER_DID: &str = "did:key:z6MkotherAuthorityFixture";
+    const WEB_DID: &str = "did:web:squatter.example.com";
+    const HONEST_URL: &str = "https://honest-peer.example.com";
+    const ATTACKER_URL: &str = "https://attacker.example.com";
+
+    async fn db(pool: PgPool) -> Db {
+        let db = Db::for_testing(pool);
+        db.run_migrations().await.unwrap();
+        db
+    }
+
+    /// The whole row, read back through `list_peers` rather than raw SQL, so a
+    /// case that claims "unchanged" is comparing every column a consumer sees.
+    async fn row(db: &Db, did: &str) -> Option<(String, String, Option<String>, bool, String)> {
+        db.list_peers()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|p| p.did == did)
+            .map(|p| {
+                (
+                    p.did,
+                    p.http_url,
+                    p.last_seen,
+                    p.last_ping_ok,
+                    p.announced_at,
+                )
+            })
+    }
+
+    /// Seed a row and assert the seed took, so no case below can pass
+    /// vacuously against a row that was never written.
+    async fn seed(db: &Db) -> (String, String, Option<String>, bool, String) {
+        db.upsert_peer(VICTIM_DID, HONEST_URL, PeerWriteAuthority::Unproven)
+            .await
+            .unwrap();
+        db.mark_peer_ping(VICTIM_DID, true).await.unwrap();
+        let seeded = row(db, VICTIM_DID).await.expect("seed did not take");
+        assert_eq!(seeded.1, HONEST_URL, "seed did not take");
+        assert!(seeded.3, "seed did not earn reachability");
+        seeded
+    }
+
+    fn denial(err: anyhow::Error) -> PeerWriteDenied {
+        err.downcast::<PeerWriteDenied>()
+            .expect("rejection must be the typed denial, or the handler renders it as a 500")
+    }
+
+    /// Discovery stays open: an unproven caller may still seed an unseen
+    /// did:key row. Kills a gate widened until it rejects inserts too.
+    #[sqlx::test]
+    async fn unproven_insert_of_an_unseen_did_key_is_allowed(pool: PgPool) {
+        let db = db(pool).await;
+
+        db.upsert_peer(VICTIM_DID, HONEST_URL, PeerWriteAuthority::Unproven)
+            .await
+            .unwrap();
+
+        let (_, url, last_seen, reachable, _) = row(&db, VICTIM_DID).await.expect("row missing");
+        assert_eq!(url, HONEST_URL);
+        assert!(last_seen.is_some());
+        assert!(!reachable, "a never-probed peer must insert unreachable");
+    }
+
+    /// The defect this change exists to close. Kills the unconditional
+    /// `ON CONFLICT(did) DO UPDATE SET http_url = $2`.
+    #[sqlx::test]
+    async fn unproven_repoint_of_an_existing_row_is_rejected(pool: PgPool) {
+        let db = db(pool).await;
+        let before = seed(&db).await;
+
+        let err = db
+            .upsert_peer(VICTIM_DID, ATTACKER_URL, PeerWriteAuthority::Unproven)
+            .await
+            .expect_err("an unproven repoint must be an error, never a silent no-op");
+
+        assert!(
+            matches!(denial(err), PeerWriteDenied::UnprovenRepoint { .. }),
+            "the denial must be the typed repoint refusal"
+        );
+        assert_eq!(
+            row(&db, VICTIM_DID).await.expect("row vanished"),
+            before,
+            "the stored row must be byte-identical after a refused repoint"
+        );
+    }
+
+    /// Honest peers re-announce, so the identical-URL case is a liveness
+    /// refresh, not a denial. The URL string is reused byte for byte: the
+    /// comparison inherited from #270 is exact, so a trailing slash would make
+    /// this pass as a repoint rejection instead. Kills a too-wide gate.
+    #[sqlx::test]
+    async fn unproven_reannounce_of_the_identical_url_refreshes_last_seen(pool: PgPool) {
+        let db = db(pool).await;
+        let before = seed(&db).await;
+
+        db.upsert_peer(VICTIM_DID, HONEST_URL, PeerWriteAuthority::Unproven)
+            .await
+            .expect("an identical-URL re-announce cannot change the URL, so it is allowed");
+
+        let after = row(&db, VICTIM_DID).await.expect("row vanished");
+        assert_eq!(after.1, HONEST_URL, "URL untouched");
+        assert_eq!(after.3, before.3, "reachability untouched");
+        assert_eq!(after.4, before.4, "announced_at untouched");
+        let parse = |s: &Option<String>| {
+            chrono::DateTime::parse_from_rfc3339(s.as_deref().expect("last_seen is set")).unwrap()
+        };
+        assert!(
+            parse(&after.2) > parse(&before.2),
+            "a same-URL re-announce is a liveness signal and must advance last_seen"
+        );
+    }
+
+    /// A signed repoint from the row's own key is the allowed case, and it must
+    /// still clear reachability per #270: a proven repoint is still an unprobed
+    /// URL. Kills a gate that rejects proven writes, and kills dropping the
+    /// #270 CASE.
+    #[sqlx::test]
+    async fn proven_repoint_by_the_rows_own_did_updates_and_clears_reachability(pool: PgPool) {
+        let db = db(pool).await;
+        seed(&db).await;
+
+        db.upsert_peer(
+            VICTIM_DID,
+            ATTACKER_URL,
+            PeerWriteAuthority::Proven(VICTIM_DID),
+        )
+        .await
+        .unwrap();
+
+        let (_, url, _, reachable, _) = row(&db, VICTIM_DID).await.expect("row missing");
+        assert_eq!(url, ATTACKER_URL, "a proven repoint must land");
+        assert!(
+            !reachable,
+            "a repointed peer must re-earn reachability, even when the repoint is signed"
+        );
+    }
+
+    /// The RUSTSEC-2022-0009 shape at the boundary: a valid proof of control
+    /// over one DID must not authorize a write to a different DID's row. Kills
+    /// a bare proven/unproven flag that never checks WHICH DID was proven, and
+    /// kills neutralizing the boundary's comparison.
+    #[sqlx::test]
+    async fn proof_of_another_did_cannot_write_this_row(pool: PgPool) {
+        let db = db(pool).await;
+        let before = seed(&db).await;
+
+        let err = db
+            .upsert_peer(
+                VICTIM_DID,
+                ATTACKER_URL,
+                PeerWriteAuthority::Proven(OTHER_DID),
+            )
+            .await
+            .expect_err("a proof naming another DID must not authorize this row");
+
+        assert!(
+            matches!(denial(err), PeerWriteDenied::ProofDidMismatch { .. }),
+            "the denial must name the proof/target mismatch"
+        );
+        assert_eq!(
+            row(&db, VICTIM_DID).await.expect("row vanished"),
+            before,
+            "the stored row must be byte-identical after a mismatched proof"
+        );
+    }
+
+    /// Signed first contact must not regress: a proven write for an unseen DID
+    /// still inserts.
+    #[sqlx::test]
+    async fn proven_insert_of_an_unseen_did_is_allowed(pool: PgPool) {
+        let db = db(pool).await;
+
+        db.upsert_peer(
+            VICTIM_DID,
+            HONEST_URL,
+            PeerWriteAuthority::Proven(VICTIM_DID),
+        )
+        .await
+        .unwrap();
+
+        let (_, url, _, reachable, _) = row(&db, VICTIM_DID).await.expect("row missing");
+        assert_eq!(url, HONEST_URL);
+        assert!(!reachable, "a never-probed peer must insert unreachable");
+    }
+
+    /// R8. Only did:key can ever authenticate, so an unproven insert of any
+    /// other method would create a row no one could ever correct through the
+    /// proven path. Rejected in the validation class, with nothing written.
+    /// Kills a method gate applied only to the update path.
+    #[sqlx::test]
+    async fn unproven_insert_of_a_non_did_key_is_rejected(pool: PgPool) {
+        let db = db(pool).await;
+
+        for did in [WEB_DID, "did:gitlawb:z6MkSomeKey"] {
+            let err = db
+                .upsert_peer(did, HONEST_URL, PeerWriteAuthority::Unproven)
+                .await
+                .expect_err("a DID method that can never authenticate must not be insertable");
+
+            assert!(
+                matches!(denial(err), PeerWriteDenied::UnsupportedDidMethod { .. }),
+                "the denial must name the unsupported method"
+            );
+            assert!(
+                row(&db, did).await.is_none(),
+                "a rejected announce must leave no row behind: {did}"
+            );
+        }
     }
 }

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -2251,33 +2251,56 @@ impl Db {
             // The refusal is split by cause, because methodNotSupported is only
             // a true statement about a foreign method: a did:key whose key
             // material does not resolve gets the resolution failure instead.
-            PeerWriteAuthority::Unproven => match did.parse::<gitlawb_core::did::Did>() {
-                // Only reachable from the bootstrap announce-back in main.rs,
-                // which passes the contacted peer's raw JSON string; the
-                // announce handler parses req.did before calling here.
-                Err(e) => {
-                    return Err(PeerWriteDenied::UnresolvableDid {
-                        did: did.to_string(),
-                        reason: e.to_string(),
-                    }
-                    .into());
-                }
-                Ok(d) if !d.is_did_key() => {
-                    return Err(PeerWriteDenied::UnsupportedDidMethod {
-                        did: did.to_string(),
-                    }
-                    .into());
-                }
-                Ok(d) => {
-                    if let Err(e) = d.to_verifying_key() {
+            // Scoped to the INSERT, not to the DID. The check exists to stop a
+            // permanently uncorrectable row being CREATED; applied to a row that
+            // already exists it prevents nothing and freezes it instead. Before
+            // this gate, upsert_peer validated nothing and the handler accepted
+            // any parseable DID, so deployed tables hold did:web rows and
+            // did:key rows whose key never resolved. Judging the DID first made
+            // every one of those permanently unrefreshable: the unsigned
+            // announce is refused, and a signed one cannot exist because no key
+            // resolves. The row stays and keeps steering fan-out either way.
+            //
+            // The read-then-write race is benign: if a row appears in between,
+            // this write becomes an UPDATE and the UnprovenRepoint guard below
+            // still refuses any http_url change.
+            PeerWriteAuthority::Unproven
+                if !sqlx::query_scalar::<_, bool>(
+                    "SELECT EXISTS(SELECT 1 FROM peers WHERE did = $1)",
+                )
+                .bind(did)
+                .fetch_one(&self.pool)
+                .await
+                .unwrap_or(false) =>
+            {
+                match did.parse::<gitlawb_core::did::Did>() {
+                    // Only reachable from the bootstrap announce-back in main.rs,
+                    // which passes the contacted peer's raw JSON string; the
+                    // announce handler parses req.did before calling here.
+                    Err(e) => {
                         return Err(PeerWriteDenied::UnresolvableDid {
                             did: did.to_string(),
                             reason: e.to_string(),
                         }
                         .into());
                     }
+                    Ok(d) if !d.is_did_key() => {
+                        return Err(PeerWriteDenied::UnsupportedDidMethod {
+                            did: did.to_string(),
+                        }
+                        .into());
+                    }
+                    Ok(d) => {
+                        if let Err(e) = d.to_verifying_key() {
+                            return Err(PeerWriteDenied::UnresolvableDid {
+                                did: did.to_string(),
+                                reason: e.to_string(),
+                            }
+                            .into());
+                        }
+                    }
                 }
-            },
+            }
             _ => {}
         }
         let now = Utc::now().to_rfc3339();
@@ -6545,6 +6568,56 @@ mod peer_authority_tests {
             .expect("rejection must be the typed denial, or the handler renders it as a 500")
     }
 
+    /// A row a deployed database ALREADY holds must keep refreshing its
+    /// liveness. Before this gate existed `upsert_peer` did no DID validation
+    /// at all and the handler accepted any parseable DID, so live peer tables
+    /// carry did:web rows and did:key rows whose key never resolved. Judging
+    /// the DID before looking at whether the row exists freezes those forever:
+    /// the unsigned refresh is refused, and a signed one is impossible because
+    /// no key resolves. Nothing is protected by that, since the row is already
+    /// there and an identical-URL refresh changes no authority. Kills a gate
+    /// scoped to the DID instead of to the INSERT.
+    #[sqlx::test]
+    async fn a_legacy_row_can_still_refresh_its_liveness(pool: PgPool) {
+        let db = db(pool).await;
+
+        for legacy in [WEB_DID, "did:key:znotarealkeymaterial"] {
+            sqlx::query(
+                "INSERT INTO peers (did, http_url, last_seen, announced_at) \
+                 VALUES ($1, $2, $3, $3)",
+            )
+            .bind(legacy)
+            .bind(HONEST_URL)
+            .bind(chrono::Utc::now().to_rfc3339())
+            .execute(&db.pool)
+            .await
+            .expect("seeding a pre-gate row must succeed");
+
+            db.upsert_peer(legacy, HONEST_URL, PeerWriteAuthority::Unproven)
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("a legacy row must keep refreshing its liveness: {legacy} -> {e}")
+                });
+        }
+    }
+
+    /// The other half: the gate still refuses to CREATE such a row. Without
+    /// this, scoping the check to the insert path could be satisfied by
+    /// dropping the check altogether.
+    #[sqlx::test]
+    async fn a_legacy_did_still_cannot_be_created_fresh(pool: PgPool) {
+        let db = db(pool).await;
+
+        let err = db
+            .upsert_peer(WEB_DID, HONEST_URL, PeerWriteAuthority::Unproven)
+            .await
+            .expect_err("an unseen non-did:key must still be refused at insert");
+        assert!(
+            matches!(denial(err), PeerWriteDenied::UnsupportedDidMethod { .. }),
+            "the insert refusal must survive the insert-scoping"
+        );
+    }
+
     /// Discovery stays open: an unproven caller may still seed an unseen
     /// did:key row. Kills a gate widened until it rejects inserts too.
     #[sqlx::test]
@@ -6871,6 +6944,7 @@ mod peer_authority_tests {
 /// | `prune_self_peers` (db/mod.rs) | a delete keyed on `http_url`; cannot repoint; boot-only caller in main.rs |
 /// | `prune_non_public_peers` (db/mod.rs) | a delete keyed on a computed bad-DID array; cannot repoint; boot-only caller in main.rs |
 /// | `seed_local_peer` (sync.rs) | excluded by test-module location: a deliberate `upsert_peer` bypass for `file://` fixtures, which the public-URL gate rejects |
+/// | `a_legacy_row_can_still_refresh_its_liveness` (db/mod.rs) | test-only. Seeds a PRE-GATE row by raw SQL on purpose: `upsert_peer` cannot create one, since the gate it is testing refuses exactly that DID. The fixture models what a deployed table already holds |
 ///
 /// And the `upsert_peer` CALL-SITE authority table, which the ledger above
 /// structurally cannot hold, because the bootstrap site issues no SQL of its own
@@ -6889,6 +6963,7 @@ mod peers_table_writer_guard {
     /// the table. Bidirectional: an undispositioned hit fails, and so does a
     /// listed function that no longer has one.
     const LEDGER: &[(&str, usize)] = &[
+        ("a_legacy_row_can_still_refresh_its_liveness", 1),
         ("mark_peer_ping", 1),
         ("prune_non_public_peers", 1),
         ("prune_self_peers", 1),

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -6661,3 +6661,131 @@ mod peer_authority_tests {
         }
     }
 }
+
+/// #273 completeness ledger: every writer of the `peers` table.
+///
+/// The required set is derived from the authority that DEFINES membership, the
+/// write statements themselves, not from the set of `upsert_peer` callers. A
+/// caller scan is structurally blind to a future writer that issues its own SQL
+/// and bypasses `upsert_peer`, which is precisely the case the type system
+/// cannot see.
+///
+/// The type system carries the real weight: `upsert_peer`'s authority parameter
+/// has no default, so a new caller cannot omit its declaration, compile-enforced
+/// and exhaustive by construction. This scan is the backstop for the bypass case
+/// alone, which is why it is one equality assertion rather than a framework.
+///
+/// The ledger, one row per function that writes the table:
+///
+/// | Writer | Disposition |
+/// | --- | --- |
+/// | `upsert_peer` (db/mod.rs) | guarded by the authority parameter |
+/// | `mark_peer_ping` (db/mod.rs) | benign for `http_url`: it writes only `last_seen` and `last_ping_ok`. It IS the table's other production writer, and its unauthenticated reachability is tracked separately as issue #269 |
+/// | `prune_self_peers` (db/mod.rs) | a delete keyed on `http_url`; cannot repoint; boot-only caller in main.rs |
+/// | `prune_non_public_peers` (db/mod.rs) | a delete keyed on a computed bad-DID array; cannot repoint; boot-only caller in main.rs |
+/// | `seed_local_peer` (sync.rs) | excluded by test-module location: a deliberate `upsert_peer` bypass for `file://` fixtures, which the public-URL gate rejects |
+///
+/// And the `upsert_peer` CALL-SITE authority table, which the ledger above
+/// structurally cannot hold, because the bootstrap site issues no SQL of its own
+/// and therefore can never appear in a scan of write statements:
+///
+/// | Call site | Authority declared |
+/// | --- | --- |
+/// | api/peers.rs (announce) | proven if and only if the `AuthenticatedDid` extension is present, carrying that extension's DID |
+/// | main.rs (bootstrap announce-back) | unproven, unconditionally. Reasoned-not-run: no runtime test reaches that site in this change |
+#[cfg(test)]
+mod peers_table_writer_guard {
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+
+    /// Each dispositioned writer and the number of statements it issues against
+    /// the table. Bidirectional: an undispositioned hit fails, and so does a
+    /// listed function that no longer has one.
+    const LEDGER: &[(&str, usize)] = &[
+        ("mark_peer_ping", 1),
+        ("prune_non_public_peers", 1),
+        ("prune_self_peers", 1),
+        ("seed_local_peer", 1),
+        ("upsert_peer", 2),
+    ];
+
+    /// Assembled at runtime rather than written as literals, so this module's
+    /// own source does not match the scan it performs.
+    fn needles() -> Vec<String> {
+        ["INSERT INTO ", "UPDATE ", "DELETE FROM "]
+            .iter()
+            .map(|verb| format!("{verb}peers"))
+            .collect()
+    }
+
+    fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).expect("the crate source tree must be readable") {
+            let path = entry.expect("directory entry").path();
+            if path.is_dir() {
+                rust_sources(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    /// The function a line declares, if it declares one.
+    fn declared_fn(line: &str) -> Option<&str> {
+        let trimmed = line.trim_start();
+        let rest = [
+            "pub(crate) async fn ",
+            "pub(crate) fn ",
+            "pub async fn ",
+            "pub fn ",
+            "async fn ",
+            "fn ",
+        ]
+        .iter()
+        .find_map(|p| trimmed.strip_prefix(p))?;
+        rest.split(|c: char| !(c.is_alphanumeric() || c == '_'))
+            .next()
+            .filter(|name| !name.is_empty())
+    }
+
+    /// The backstop the authority parameter cannot provide: a new raw write
+    /// against the table from outside `upsert_peer` is invisible to the type
+    /// system, so it is caught here or not at all.
+    #[test]
+    fn every_peers_table_write_is_dispositioned() {
+        let mut files = Vec::new();
+        rust_sources(
+            &PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src"),
+            &mut files,
+        );
+        // Anti-vacuity: a scrape that walked nothing would report a clean tree.
+        assert!(
+            files.len() > 10,
+            "the scan found only {} source files, so a clean result proves nothing",
+            files.len()
+        );
+
+        let needles = needles();
+        let mut found: BTreeMap<String, usize> = BTreeMap::new();
+        for file in &files {
+            let src = std::fs::read_to_string(file).expect("source file must be readable");
+            let mut current = "<module level>";
+            for line in src.lines() {
+                if let Some(name) = declared_fn(line) {
+                    current = name;
+                }
+                if needles.iter().any(|n| line.contains(n.as_str())) {
+                    *found.entry(current.to_string()).or_default() += 1;
+                }
+            }
+        }
+
+        let expected: BTreeMap<String, usize> =
+            LEDGER.iter().map(|(f, n)| ((*f).to_string(), *n)).collect();
+        assert_eq!(
+            found, expected,
+            "the peers-table writers no longer match the ledger. A new writer must \
+             be dispositioned in the table above (and gated), and a removed one \
+             dropped from LEDGER"
+        );
+    }
+}

--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -2222,16 +2222,24 @@ impl Db {
                 }
                 .into());
             }
-            // Only did:key can ever authenticate: auth/mod.rs resolves the
-            // verifying key from the keyid DID itself and rejects every other
-            // method. A did:web or did:gitlawb row seeded here would therefore
-            // be unwritable by anyone forever, since no proof could ever
-            // satisfy the branch above, while still steering the sync origin
-            // resolve, the notify fan-out, and the public resolve route.
+            // Only a DID whose verifying key resolves can ever authenticate:
+            // auth/mod.rs resolves the key from the keyid DID itself and
+            // rejects everything else. A row seeded here that cannot yield a
+            // key would therefore be unwritable by anyone forever, since no
+            // proof could ever satisfy the branch above, while still steering
+            // the sync origin resolve, the notify fan-out, and the public
+            // resolve route.
+            //
+            // The check is key derivability, NOT the method label. `Did`'s
+            // FromStr only runs validate(), which accepts key/web/gitlawb and
+            // never looks at the key material, so `did:key:notarealkey` passes
+            // is_did_key() and creates exactly the permanently uncorrectable
+            // row this gate exists to prevent. to_verifying_key() is the same
+            // resolution auth/mod.rs performs on the keyid.
             PeerWriteAuthority::Unproven
                 if !did
                     .parse::<gitlawb_core::did::Did>()
-                    .map(|d| d.is_did_key())
+                    .map(|d| d.to_verifying_key().is_ok())
                     .unwrap_or(false) =>
             {
                 return Err(PeerWriteDenied::UnsupportedDidMethod {
@@ -6251,7 +6259,9 @@ mod peer_reachability_tests {
     use super::{Db, PeerWriteAuthority};
     use sqlx::PgPool;
 
-    const VICTIM_DID: &str = "did:key:z6MkvictimPeerFixture";
+    // Real derivable did:key fixtures. The unproven arm resolves the verifying
+    // key, so a made-up method-id is refused before any SQL runs.
+    const VICTIM_DID: &str = "did:key:z6Mkrmsd28nDTPBjk55EJCSjtJLVJDZffyczjBEHvywhutM4";
     const HONEST_URL: &str = "https://honest-peer.example.com";
     const ATTACKER_URL: &str = "https://attacker.example.com";
 
@@ -6381,14 +6391,18 @@ mod peer_reachability_tests {
         let db = db(pool).await;
 
         db.upsert_peer(
-            "did:key:z6MkfreshPeerFixture",
+            "did:key:z6MkfGVENKztfeXa631WYVqyAGaXeP8AnN6nTkfogHn9vaaQ",
             HONEST_URL,
             PeerWriteAuthority::Unproven,
         )
         .await
         .unwrap();
 
-        let (_, reachable) = peer(&db, "did:key:z6MkfreshPeerFixture").await;
+        let (_, reachable) = peer(
+            &db,
+            "did:key:z6MkfGVENKztfeXa631WYVqyAGaXeP8AnN6nTkfogHn9vaaQ",
+        )
+        .await;
         assert!(!reachable, "a never-probed peer must insert unreachable");
     }
 
@@ -6449,8 +6463,10 @@ mod peer_authority_tests {
     use super::{Db, PeerWriteAuthority, PeerWriteDenied};
     use sqlx::PgPool;
 
-    const VICTIM_DID: &str = "did:key:z6MkvictimAuthorityFixture";
-    const OTHER_DID: &str = "did:key:z6MkotherAuthorityFixture";
+    // Real derivable did:key fixtures. The unproven arm resolves the verifying
+    // key, so a made-up method-id is refused before any SQL runs.
+    const VICTIM_DID: &str = "did:key:z6MkuMqUm4i228K9qXidJ57zqSWAcQLgrcbMxB8RKVLuqitj";
+    const OTHER_DID: &str = "did:key:z6MkuzEVwHSWSCLq6xAkgTAJxHMa24KuBtgozce77TEihnWD";
     const WEB_DID: &str = "did:web:squatter.example.com";
     const HONEST_URL: &str = "https://honest-peer.example.com";
     const ATTACKER_URL: &str = "https://attacker.example.com";
@@ -6636,15 +6652,19 @@ mod peer_authority_tests {
         assert!(!reachable, "a never-probed peer must insert unreachable");
     }
 
-    /// R8. Only did:key can ever authenticate, so an unproven insert of any
-    /// other method would create a row no one could ever correct through the
-    /// proven path. Rejected in the validation class, with nothing written.
-    /// Kills a method gate applied only to the update path.
+    /// R8. Only a DID whose verifying key can be derived can ever authenticate,
+    /// so an unproven insert of anything else would create a row no one could
+    /// ever correct through the proven path. Rejected in the validation class,
+    /// with nothing written. Kills a method gate applied only to the update
+    /// path, and kills a gate that checks the method LABEL rather than the key
+    /// material: `did:key:notarealkey` carries the right method and no
+    /// derivable key, so the row it would create is the permanently
+    /// uncorrectable one this gate exists to prevent.
     #[sqlx::test]
     async fn unproven_insert_of_a_non_did_key_is_rejected(pool: PgPool) {
         let db = db(pool).await;
 
-        for did in [WEB_DID, "did:gitlawb:z6MkSomeKey"] {
+        for did in [WEB_DID, "did:gitlawb:z6MkSomeKey", "did:key:notarealkey"] {
             let err = db
                 .upsert_peer(did, HONEST_URL, PeerWriteAuthority::Unproven)
                 .await

--- a/crates/gitlawb-node/src/error.rs
+++ b/crates/gitlawb-node/src/error.rs
@@ -35,6 +35,15 @@ pub enum AppError {
     #[error("invalid request: {0}")]
     BadRequest(String),
 
+    /// A DID was well-formed enough to carry to a resolver but no verifying key
+    /// could be derived from it. Its own code rather than plain `bad_request`
+    /// because the auth middleware already answers `unresolvable_did` for the
+    /// same failure on a request's keyid, and a client should not have to
+    /// substring-match a message to tell this apart from the other validation
+    /// failures on the same route.
+    #[error("unresolvable did: {0}")]
+    UnresolvableDid(String),
+
     #[error("too many requests: {0}")]
     TooManyRequests(String),
 
@@ -132,6 +141,9 @@ impl IntoResponse for AppError {
             // IcaptchaProofRequired is handled above (it carries extra headers/fields).
             AppError::IcaptchaProofRequired { .. } => unreachable!("handled before this match"),
             AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, "bad_request", msg.clone()),
+            AppError::UnresolvableDid(msg) => {
+                (StatusCode::BAD_REQUEST, "unresolvable_did", msg.clone())
+            }
             AppError::TooManyRequests(msg) => {
                 (StatusCode::TOO_MANY_REQUESTS, "rate_limited", msg.clone())
             }

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -921,8 +921,33 @@ async fn gossip_task(
                             json.get("node_url").and_then(|v| v.as_str()),
                         ) {
                             if !their_url.is_empty() {
-                                let _ = state.db.upsert_peer(their_did, their_url).await;
-                                tracing::info!(did = %their_did, url = %their_url, "bootstrap peer added");
+                                // Unproven, unconditionally: their_did and
+                                // their_url come straight out of the contacted
+                                // peer's JSON response body, with no signature
+                                // and no proof the claimed DID belongs to the
+                                // peer we reached. This path therefore seeds
+                                // new peers and can never repoint an existing
+                                // row. The upsert's result is matched rather
+                                // than discarded, because "bootstrap peer
+                                // added" printed over a refused write is a
+                                // denial rendering as success. Non-fatal to the
+                                // loop either way.
+                                match state
+                                    .db
+                                    .upsert_peer(
+                                        their_did,
+                                        their_url,
+                                        db::PeerWriteAuthority::Unproven,
+                                    )
+                                    .await
+                                {
+                                    Ok(()) => {
+                                        tracing::info!(did = %their_did, url = %their_url, "bootstrap peer added")
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(did = %their_did, url = %their_url, err = %e, "bootstrap peer announce-back rejected")
+                                    }
+                                }
                             }
                         }
                     }

--- a/crates/gl/src/http.rs
+++ b/crates/gl/src/http.rs
@@ -203,6 +203,39 @@ async fn obtain_proof(cfg: IcaptchaCfg) -> Result<String> {
         .context("iCaptcha solver task panicked")?
 }
 
+/// Read at most `cap` bytes of a response body. Bounds the allocation from a
+/// hostile or broken node returning a huge error body — the display is capped
+/// separately, but the read itself must not be unbounded (INV-6, read half).
+pub(crate) async fn read_body_capped(mut resp: reqwest::Response, cap: usize) -> String {
+    let mut buf: Vec<u8> = Vec::new();
+    while buf.len() < cap {
+        match resp.chunk().await {
+            Ok(Some(chunk)) => {
+                let take = (cap - buf.len()).min(chunk.len());
+                buf.extend_from_slice(&chunk[..take]);
+                if take < chunk.len() {
+                    break; // hit the cap mid-chunk
+                }
+            }
+            _ => break, // end of body or read error — return what we have
+        }
+    }
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+/// Strip terminal-dangerous characters from (and cap the length of) a
+/// node-supplied error string before surfacing it. The node a caller talks to
+/// could be hostile and embed escape sequences in its error body; those must not
+/// reach the terminal verbatim (INV-6). We drop the C0/C1 control bytes (which
+/// defangs ANSI/OSC escapes) AND the Unicode bidi/format controls (which
+/// `char::is_control` does not cover — they can reorder the displayed line).
+pub(crate) fn sanitize_node_msg(s: &str) -> String {
+    s.chars()
+        .filter(|c| !c.is_control() && !gitlawb_core::sanitize::is_bidi_format(*c))
+        .take(200)
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -586,5 +619,36 @@ mod tests {
         n.assert();
         ic.challenge.assert();
         ic.answer.assert();
+    }
+
+    #[test]
+    fn sanitize_strips_controls_bidi_and_caps_length() {
+        // C0 (ESC/BEL) and the Cf bidi override (U+202E) are both removed; the
+        // printable text survives. (Note: a stripped ESC leaves any following
+        // "[31m" as inert literal text — that is the point, so the input here
+        // avoids that residue to keep the expectation unambiguous.)
+        let out = sanitize_node_msg("a\u{1b}\u{07}b\u{202e}c");
+        assert!(
+            !out.chars().any(|c| c.is_control()),
+            "control char leaked: {out:?}"
+        );
+        assert!(
+            !out.contains('\u{202e}'),
+            "RLO bidi override leaked: {out:?}"
+        );
+        assert_eq!(out, "abc");
+        // Length is capped at 200 chars regardless of input size.
+        let long = "x".repeat(250);
+        assert_eq!(sanitize_node_msg(&long).chars().count(), 200);
+    }
+
+    #[test]
+    fn sanitize_preserves_legitimate_and_rtl_text() {
+        // Must not over-strip: a plain word, a genuine RTL SCRIPT letter (Arabic
+        // U+0627, category Lo — NOT a format char), and ZWJ (U+200D, a legitimate
+        // Cf char, e.g. emoji sequences) all survive. Guards the shared predicate
+        // against being widened into a blanket Cf stripper.
+        let out = sanitize_node_msg("ok \u{0627}\u{200D}b");
+        assert_eq!(out, "ok \u{0627}\u{200D}b");
     }
 }

--- a/crates/gl/src/peer.rs
+++ b/crates/gl/src/peer.rs
@@ -251,17 +251,35 @@ mod tests {
     /// The node's 403 for repointing an existing peer must surface, not print
     /// as a completed add. Without the status check the command prints "Added
     /// to local peer list." over a refusal.
+    ///
+    /// The fixture body is the real wire shape, not an invented one: the
+    /// message is the Display of `PeerWriteDenied::UnprovenRepoint`, declared
+    /// in `crates/gitlawb-node/src/db/mod.rs`. The executable detector for a
+    /// wording change is the node-side pin
+    /// `announce_unsigned_repoint_is_a_403_denial` in
+    /// `crates/gitlawb-node/src/api/peers.rs`, which asserts this same
+    /// substring against a response driven through the real router, so
+    /// rewording the Display turns that test red and the grep for the old
+    /// phrase lands here.
+    ///
+    /// The assertion bites rather than echoing its own input because the
+    /// substring is reachable only through the helper's `body["message"]`
+    /// extraction; the fixture's `error` field carries a different string, so
+    /// reading `body["error"]` instead fails this test.
     #[test]
     fn a_refused_local_add_warns_with_the_node_reason() {
         let warning = local_add_refusal(
             StatusCode::FORBIDDEN,
-            &json!({ "error": "forbidden", "message": "peer http_url change requires a signature from that peer" }),
+            &json!({
+                "error": "forbidden",
+                "message": "unproven announce cannot change an existing peer's http_url: did:key:z6MkuMqUm4i228K9qXidJ57zqSWAcQLgrcbMxB8RKVLuqitj"
+            }),
         )
         .expect("a refusal must not render as success");
 
         assert!(warning.contains("403"), "must name the status: {warning}");
         assert!(
-            warning.contains("requires a signature"),
+            warning.contains("unproven announce cannot change an existing peer"),
             "must carry the node's own reason: {warning}"
         );
     }

--- a/crates/gl/src/peer.rs
+++ b/crates/gl/src/peer.rs
@@ -7,7 +7,7 @@ use clap::{Args, Subcommand};
 use serde_json::Value;
 use std::path::PathBuf;
 
-use crate::http::NodeClient;
+use crate::http::{read_body_capped, sanitize_node_msg, NodeClient};
 use crate::identity::load_keypair_from_dir;
 
 #[derive(Args)]
@@ -107,10 +107,26 @@ fn local_add_refusal(status: reqwest::StatusCode, body: &Value) -> Option<String
     if status.is_success() {
         return None;
     }
-    let msg = body["message"].as_str().unwrap_or("unknown error");
+    // The message is the node's, not ours, so it is defanged before it reaches
+    // the terminal. Only the message: the status and the prose are ours.
+    let msg = sanitize_node_msg(body["message"].as_str().unwrap_or("unknown error"));
     Some(format!(
         "warning: local peer list not updated ({status}): {msg}"
     ))
+}
+
+/// The block printed after a peer accepts our announce. Split out so the
+/// defanging is assertable: the DID and URL are the remote peer's own strings,
+/// and `peer_url` is caller-chosen, so this is the least trusted body the
+/// command handles. Only the display is sanitized; the values sent on to our
+/// local node stay verbatim, since that is data rather than terminal output and
+/// the node runs its own validation on them.
+fn announced_peer_summary(their_did: &str, their_url: &str, peer_count: u64) -> String {
+    format!(
+        "Announced to peer node:\n  DID:        {}\n  URL:        {}\n  Their peers: {peer_count}\n",
+        sanitize_node_msg(their_did),
+        sanitize_node_msg(their_url),
+    )
 }
 
 async fn cmd_add(peer_url: String, node: String, dir: Option<PathBuf>) -> Result<()> {
@@ -143,10 +159,15 @@ async fn cmd_add(peer_url: String, node: String, dir: Option<PathBuf>) -> Result
         .await
         .context("failed to connect to peer")?;
     let status = resp.status();
-    let result: Value = resp.json().await.context("invalid JSON response")?;
+    // `peer_url` is fully caller-chosen, so this body is the least trusted one
+    // in the command: bound the read, and defang the message before it reaches
+    // the terminal through the error return. An announce reply is a DID, a URL
+    // and a count, so 8 KiB is well past what the shape needs.
+    let raw = read_body_capped(resp, 8 * 1024).await;
+    let result: Value = serde_json::from_str(&raw).context("invalid JSON response")?;
 
     if !status.is_success() {
-        let msg = result["message"].as_str().unwrap_or("unknown error");
+        let msg = sanitize_node_msg(result["message"].as_str().unwrap_or("unknown error"));
         anyhow::bail!("announce failed ({status}): {msg}");
     }
 
@@ -154,10 +175,10 @@ async fn cmd_add(peer_url: String, node: String, dir: Option<PathBuf>) -> Result
     let their_url = result["node_url"].as_str().unwrap_or("?");
     let peer_count = result["peer_count"].as_u64().unwrap_or(0);
 
-    println!("Announced to peer node:");
-    println!("  DID:        {their_did}");
-    println!("  URL:        {their_url}");
-    println!("  Their peers: {peer_count}");
+    print!(
+        "{}",
+        announced_peer_summary(their_did, their_url, peer_count)
+    );
 
     // Also add their info to our local node's peer list
     // (the peer's /announce response includes their did + url)
@@ -176,7 +197,12 @@ async fn cmd_add(peer_url: String, node: String, dir: Option<PathBuf>) -> Result
         match local_client.post("/api/v1/peers/announce", &add_body).await {
             Ok(resp) => {
                 let status = resp.status();
-                let result: Value = resp.json().await.unwrap_or(Value::Null);
+                // Same bound as the remote announce above: a compromised local
+                // node (or a MITM on plain http) must not force an unbounded
+                // read. A body that does not parse stays `Null`, which still
+                // routes a non-success status to the warning.
+                let raw = read_body_capped(resp, 8 * 1024).await;
+                let result: Value = serde_json::from_str(&raw).unwrap_or(Value::Null);
                 match local_add_refusal(status, &result) {
                     Some(warning) => eprintln!("{warning}"),
                     None => println!("  Added to local peer list."),
@@ -244,7 +270,7 @@ async fn cmd_resolve(did: String, node: String) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::local_add_refusal;
+    use super::{announced_peer_summary, local_add_refusal};
     use reqwest::StatusCode;
     use serde_json::json;
 
@@ -296,5 +322,100 @@ mod tests {
     #[test]
     fn an_accepted_local_add_produces_no_warning() {
         assert!(local_add_refusal(StatusCode::OK, &json!({ "peer_count": 3 })).is_none());
+    }
+
+    /// The warning is printed straight to a terminal, so a node-supplied message
+    /// carrying an OSC title-rewrite plus a C0 escape must reach it defanged.
+    #[test]
+    fn a_refusal_message_cannot_carry_terminal_escapes() {
+        let warning = local_add_refusal(
+            StatusCode::FORBIDDEN,
+            &json!({ "message": "\u{1b}]2;pwned\u{7}legit-looking text" }),
+        )
+        .expect("a refusal must not render as success");
+
+        assert!(
+            !warning.chars().any(|c| c.is_control()),
+            "control char leaked to the terminal: {warning:?}"
+        );
+        assert!(
+            warning.contains("legit-looking text"),
+            "printable text dropped: {warning:?}"
+        );
+    }
+
+    /// Bidi format chars are not `char::is_control`, yet they reorder the
+    /// displayed line, so a refusal must not carry them either.
+    #[test]
+    fn a_refusal_message_cannot_carry_bidi_overrides() {
+        let warning = local_add_refusal(
+            StatusCode::FORBIDDEN,
+            &json!({ "message": "peer \u{202e}refused\u{202c} here" }),
+        )
+        .expect("a refusal must not render as success");
+
+        assert!(
+            !warning.chars().any(gitlawb_core::sanitize::is_bidi_format),
+            "bidi format char leaked to the terminal: {warning:?}"
+        );
+    }
+
+    /// A hostile node must not be able to dump an arbitrary amount of text into
+    /// the user's scrollback through the warning line.
+    #[test]
+    fn a_refusal_message_is_length_bounded() {
+        let warning = local_add_refusal(
+            StatusCode::FORBIDDEN,
+            &json!({ "message": "x".repeat(5000) }),
+        )
+        .expect("a refusal must not render as success");
+
+        assert!(
+            warning.chars().count() < 500,
+            "warning not bounded: {} chars",
+            warning.chars().count()
+        );
+    }
+
+    /// The accepted-announce block prints the remote peer's own DID and URL, so
+    /// a hostile peer answering 200 must not get escapes onto the terminal that
+    /// way either. The refusal path is not the only sink in this command.
+    #[test]
+    fn an_accepted_announce_summary_cannot_carry_terminal_escapes() {
+        let summary = announced_peer_summary(
+            "did:key:z6Mk\u{1b}]2;pwned\u{7}abc",
+            "https://peer.example\u{202e}moc.live//:sptth",
+            3,
+        );
+
+        assert!(
+            !summary.chars().any(|c| c.is_control() && c != '\n'),
+            "control char leaked to the terminal: {summary:?}"
+        );
+        assert!(
+            !summary.chars().any(gitlawb_core::sanitize::is_bidi_format),
+            "bidi format char leaked to the terminal: {summary:?}"
+        );
+        assert!(
+            summary.contains("did:key:z6Mk") && summary.contains("Their peers: 3"),
+            "printable content dropped: {summary:?}"
+        );
+    }
+
+    /// The counterweight to the stripping tests: a legitimate message with RTL
+    /// script letters and a ZWJ must survive intact, so the sanitizer is not
+    /// proven by over-stripping.
+    #[test]
+    fn a_legitimate_refusal_message_survives_intact() {
+        let warning = local_add_refusal(
+            StatusCode::FORBIDDEN,
+            &json!({ "message": "peer refused \u{0627}\u{200D}b" }),
+        )
+        .expect("a refusal must not render as success");
+
+        assert!(
+            warning.contains("peer refused \u{0627}\u{200D}b"),
+            "legitimate text mangled: {warning:?}"
+        );
     }
 }

--- a/crates/gl/src/peer.rs
+++ b/crates/gl/src/peer.rs
@@ -115,6 +115,27 @@ fn local_add_refusal(status: reqwest::StatusCode, body: &Value) -> Option<String
     ))
 }
 
+/// The error text for a remote announce reply, or `None` when the peer accepted
+/// it.
+///
+/// Split out so the ordering is assertable: the status has to reach the caller
+/// even when the body does not parse. That case is reachable rather than
+/// theoretical, because the read above is capped, so a peer answering with a
+/// body past the cap leaves truncated JSON behind, and `peer_url` is whatever
+/// the caller passed, so a non-JSON error page is just as easy. Parsing first
+/// and failing on the parse would swallow the status the user needs.
+fn remote_announce_failure(status: reqwest::StatusCode, raw: &str) -> Option<String> {
+    if status.is_success() {
+        return None;
+    }
+    // Falls back to the body itself when there is no `message` field, which is
+    // what a truncated or non-JSON reply leaves. Sanitized either way: it is the
+    // peer's text and it is headed for the terminal.
+    let parsed: Value = serde_json::from_str(raw).unwrap_or(Value::Null);
+    let msg = sanitize_node_msg(parsed["message"].as_str().unwrap_or(raw));
+    Some(format!("announce failed ({status}): {msg}"))
+}
+
 /// The block printed after a peer accepts our announce. Split out so the
 /// defanging is assertable: the DID and URL are the remote peer's own strings,
 /// and `peer_url` is caller-chosen, so this is the least trusted body the
@@ -164,12 +185,12 @@ async fn cmd_add(peer_url: String, node: String, dir: Option<PathBuf>) -> Result
     // the terminal through the error return. An announce reply is a DID, a URL
     // and a count, so 8 KiB is well past what the shape needs.
     let raw = read_body_capped(resp, 8 * 1024).await;
-    let result: Value = serde_json::from_str(&raw).context("invalid JSON response")?;
 
-    if !status.is_success() {
-        let msg = sanitize_node_msg(result["message"].as_str().unwrap_or("unknown error"));
-        anyhow::bail!("announce failed ({status}): {msg}");
+    if let Some(failure) = remote_announce_failure(status, &raw) {
+        anyhow::bail!("{failure}");
     }
+
+    let result: Value = serde_json::from_str(&raw).context("invalid JSON response")?;
 
     let their_did = result["node_did"].as_str().unwrap_or("?");
     let their_url = result["node_url"].as_str().unwrap_or("?");
@@ -270,7 +291,7 @@ async fn cmd_resolve(did: String, node: String) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{announced_peer_summary, local_add_refusal};
+    use super::{announced_peer_summary, cmd_add, local_add_refusal, remote_announce_failure};
     use reqwest::StatusCode;
     use serde_json::json;
 
@@ -375,6 +396,116 @@ mod tests {
             "warning not bounded: {} chars",
             warning.chars().count()
         );
+    }
+
+    /// The status is the part the user can act on, so it must survive a body
+    /// that does not parse. The read is capped, so a peer answering past the cap
+    /// leaves exactly this: a valid status and truncated JSON.
+    #[test]
+    fn a_remote_announce_failure_keeps_the_status_when_the_body_does_not_parse() {
+        let truncated = r#"{"error":"service_unavailable","message":"backend is do"#;
+        let failure = remote_announce_failure(StatusCode::SERVICE_UNAVAILABLE, truncated)
+            .expect("a non-success status must produce a failure");
+
+        assert!(
+            failure.contains("503"),
+            "the status must survive an unparseable body: {failure:?}"
+        );
+    }
+
+    /// A parseable error body still reports the peer's own message.
+    #[test]
+    fn a_remote_announce_failure_carries_the_peers_message() {
+        let failure = remote_announce_failure(
+            StatusCode::FORBIDDEN,
+            r#"{"error":"forbidden","message":"unproven announce cannot change an existing peer"}"#,
+        )
+        .expect("a non-success status must produce a failure");
+
+        assert!(
+            failure.contains("403")
+                && failure.contains("unproven announce cannot change an existing peer"),
+            "status and reason must both survive: {failure:?}"
+        );
+    }
+
+    /// The fallback path prints the raw body, so it is defanged like every other
+    /// peer-supplied string headed for the terminal.
+    #[test]
+    fn a_remote_announce_failure_defangs_an_unparseable_body() {
+        let failure = remote_announce_failure(
+            StatusCode::BAD_GATEWAY,
+            "\u{1b}]2;pwned\u{7}<html>gateway error</html>",
+        )
+        .expect("a non-success status must produce a failure");
+
+        assert!(
+            !failure.chars().any(|c| c.is_control()),
+            "control char leaked to the terminal: {failure:?}"
+        );
+        assert!(failure.contains("502"), "status dropped: {failure:?}");
+        assert!(
+            failure.contains("gateway error"),
+            "the body is all the user gets when there is no message field: {failure:?}"
+        );
+    }
+
+    /// The unit tests above bind the helper. This one binds the CALL SITE: the
+    /// failure check has to run before the parse, or a body past the read cap
+    /// turns a 503 into "invalid JSON response" and the status the user needs is
+    /// gone. Reordering the two statements in `cmd_add` compiles and passes every
+    /// other test in this file, so only driving the command catches it.
+    #[tokio::test]
+    async fn a_peer_failure_past_the_read_cap_still_reports_its_status() {
+        let mut peer = mockito::Server::new_async().await;
+        let mut local = mockito::Server::new_async().await;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let kp = gitlawb_core::identity::Keypair::generate();
+        std::fs::write(
+            dir.path().join("identity.pem"),
+            kp.to_pem().unwrap().as_bytes(),
+        )
+        .unwrap();
+
+        let _local_info = local
+            .mock("GET", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"public_url":"https://me.example"}"#)
+            .create_async()
+            .await;
+
+        // Valid JSON, but past the 8 KiB read cap, so what survives the read is
+        // truncated and unparseable. This is the shape the cap itself creates.
+        let oversized = format!(r#"{{"message":"{}"}}"#, "x".repeat(16 * 1024));
+        let _peer_refusal = peer
+            .mock("POST", "/api/v1/peers/announce")
+            .with_status(503)
+            .with_header("content-type", "application/json")
+            .with_body(oversized)
+            .create_async()
+            .await;
+
+        let err = cmd_add(peer.url(), local.url(), Some(dir.path().to_path_buf()))
+            .await
+            .expect_err("a 503 from the peer must fail the command");
+
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("503"),
+            "the status must survive a body past the read cap: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains("invalid JSON response"),
+            "the parse failure must not stand in for the status: {rendered:?}"
+        );
+    }
+
+    /// An accepted announce produces no error, so the caller proceeds to parse.
+    #[test]
+    fn an_accepted_remote_announce_produces_no_failure() {
+        assert!(remote_announce_failure(StatusCode::OK, r#"{"peer_count":3}"#).is_none());
     }
 
     /// The accepted-announce block prints the remote peer's own DID and URL, so

--- a/crates/gl/src/peer.rs
+++ b/crates/gl/src/peer.rs
@@ -136,6 +136,21 @@ fn remote_announce_failure(status: reqwest::StatusCode, raw: &str) -> Option<Str
     Some(format!("announce failed ({status}): {msg}"))
 }
 
+/// Which line the local peer-add prints, and whether it is a warning.
+///
+/// Split out because the SELECTION is what the fix is: `local_add_refusal` was
+/// already unit-tested six ways, and replacing this whole match with an
+/// unconditional "Added to local peer list." still left 312 tests green. The
+/// helper was pinned; the wiring was not, which is the shape
+/// `unit-test-on-helper-does-not-prove-handler-wiring` names. With the choice
+/// extracted, the call site is a two-line dispatch carrying no logic.
+fn local_add_report(status: reqwest::StatusCode, body: &Value) -> (bool, String) {
+    match local_add_refusal(status, body) {
+        Some(warning) => (true, warning),
+        None => (false, "  Added to local peer list.".to_string()),
+    }
+}
+
 /// The block printed after a peer accepts our announce. Split out so the
 /// defanging is assertable: the DID and URL are the remote peer's own strings,
 /// and `peer_url` is caller-chosen, so this is the least trusted body the
@@ -224,9 +239,11 @@ async fn cmd_add(peer_url: String, node: String, dir: Option<PathBuf>) -> Result
                 // routes a non-success status to the warning.
                 let raw = read_body_capped(resp, 8 * 1024).await;
                 let result: Value = serde_json::from_str(&raw).unwrap_or(Value::Null);
-                match local_add_refusal(status, &result) {
-                    Some(warning) => eprintln!("{warning}"),
-                    None => println!("  Added to local peer list."),
+                let (is_warning, line) = local_add_report(status, &result);
+                if is_warning {
+                    eprintln!("{line}");
+                } else {
+                    println!("{line}");
                 }
             }
             Err(e) => eprintln!("warning: local peer list not updated: {e}"),
@@ -291,7 +308,10 @@ async fn cmd_resolve(did: String, node: String) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{announced_peer_summary, cmd_add, local_add_refusal, remote_announce_failure};
+    use super::{
+        announced_peer_summary, cmd_add, local_add_refusal, local_add_report,
+        remote_announce_failure,
+    };
     use reqwest::StatusCode;
     use serde_json::json;
 
@@ -506,6 +526,40 @@ mod tests {
     #[test]
     fn an_accepted_remote_announce_produces_no_failure() {
         assert!(remote_announce_failure(StatusCode::OK, r#"{"peer_count":3}"#).is_none());
+    }
+
+    /// The selection, not the helper. A refusal must never yield the success
+    /// line, and the success line must never carry the warning prefix. This is
+    /// what stayed green when the entire match was replaced with an
+    /// unconditional "Added to local peer list."
+    #[test]
+    fn a_local_add_refusal_never_selects_the_success_line() {
+        let (is_warning, line) = local_add_report(
+            StatusCode::FORBIDDEN,
+            &json!({ "message": "unproven announce cannot change an existing peer's http_url: did:key:zAbc" }),
+        );
+
+        assert!(is_warning, "a 403 must select the warning stream: {line:?}");
+        assert!(
+            !line.contains("Added to local peer list"),
+            "a refusal rendered as the success line: {line:?}"
+        );
+        assert!(
+            line.contains("unproven announce cannot change an existing peer"),
+            "the node's reason must reach the user: {line:?}"
+        );
+    }
+
+    /// The other direction, so the fix cannot be satisfied by always warning.
+    #[test]
+    fn an_accepted_local_add_selects_the_success_line() {
+        let (is_warning, line) = local_add_report(StatusCode::OK, &json!({ "peer_count": 3 }));
+
+        assert!(!is_warning, "a 200 must not select the warning stream");
+        assert!(
+            line.contains("Added to local peer list"),
+            "the success line must still print: {line:?}"
+        );
     }
 
     /// The accepted-announce block prints the remote peer's own DID and URL, so

--- a/crates/gl/src/peer.rs
+++ b/crates/gl/src/peer.rs
@@ -97,6 +97,22 @@ async fn cmd_list(node: String) -> Result<()> {
     Ok(())
 }
 
+/// The warning text for a local peer-add reply, or `None` when the node
+/// accepted it.
+///
+/// Split out so the refusal path is assertable. The node now answers 403 when
+/// an unproven caller tries to repoint an existing peer's `http_url`, so a
+/// reply that arrived and refused must not reach the success line.
+fn local_add_refusal(status: reqwest::StatusCode, body: &Value) -> Option<String> {
+    if status.is_success() {
+        return None;
+    }
+    let msg = body["message"].as_str().unwrap_or("unknown error");
+    Some(format!(
+        "warning: local peer list not updated ({status}): {msg}"
+    ))
+}
+
 async fn cmd_add(peer_url: String, node: String, dir: Option<PathBuf>) -> Result<()> {
     let keypair = load_keypair_from_dir(dir.as_deref())?;
     let my_did = keypair.did().to_string();
@@ -150,9 +166,24 @@ async fn cmd_add(peer_url: String, node: String, dir: Option<PathBuf>) -> Result
             "did": their_did,
             "http_url": their_url,
         }))?;
-        // This requires the local node to be running; ignore errors here
-        let _ = local_client.post("/api/v1/peers/announce", &add_body).await;
-        println!("  Added to local peer list.");
+        // This requires the local node to be running, so a transport failure
+        // stays a warning rather than failing the command. A reply that
+        // ARRIVED and refused is different: the announce route answers 403
+        // when an unproven caller tries to repoint an existing peer, and
+        // printing the success line over that reports a completed add that
+        // never happened. Same status handling as the remote announce above,
+        // except best effort.
+        match local_client.post("/api/v1/peers/announce", &add_body).await {
+            Ok(resp) => {
+                let status = resp.status();
+                let result: Value = resp.json().await.unwrap_or(Value::Null);
+                match local_add_refusal(status, &result) {
+                    Some(warning) => eprintln!("{warning}"),
+                    None => println!("  Added to local peer list."),
+                }
+            }
+            Err(e) => eprintln!("warning: local peer list not updated: {e}"),
+        }
     }
 
     Ok(())
@@ -209,4 +240,43 @@ async fn cmd_resolve(did: String, node: String) -> Result<()> {
         println!("  Note: {err}");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::local_add_refusal;
+    use reqwest::StatusCode;
+    use serde_json::json;
+
+    /// The node's 403 for repointing an existing peer must surface, not print
+    /// as a completed add. Without the status check the command prints "Added
+    /// to local peer list." over a refusal.
+    #[test]
+    fn a_refused_local_add_warns_with_the_node_reason() {
+        let warning = local_add_refusal(
+            StatusCode::FORBIDDEN,
+            &json!({ "error": "forbidden", "message": "peer http_url change requires a signature from that peer" }),
+        )
+        .expect("a refusal must not render as success");
+
+        assert!(warning.contains("403"), "must name the status: {warning}");
+        assert!(
+            warning.contains("requires a signature"),
+            "must carry the node's own reason: {warning}"
+        );
+    }
+
+    /// A refusal with no message body still warns rather than passing silently.
+    #[test]
+    fn a_refusal_without_a_message_still_warns() {
+        let warning = local_add_refusal(StatusCode::BAD_REQUEST, &serde_json::Value::Null)
+            .expect("a refusal must not render as success");
+        assert!(warning.contains("400"), "must name the status: {warning}");
+    }
+
+    /// The accepted case stays quiet, so the success line still prints.
+    #[test]
+    fn an_accepted_local_add_produces_no_warning() {
+        assert!(local_add_refusal(StatusCode::OK, &json!({ "peer_count": 3 })).is_none());
+    }
 }

--- a/crates/gl/src/sync.rs
+++ b/crates/gl/src/sync.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 use std::path::PathBuf;
 
-use crate::http::NodeClient;
+use crate::http::{read_body_capped, sanitize_node_msg, NodeClient};
 use crate::identity::load_keypair_from_dir;
 
 #[derive(Args)]
@@ -102,39 +102,6 @@ fn trigger_counts(resp: &serde_json::Value) -> (u64, u64) {
         resp["peers_reached"].as_u64().unwrap_or(0),
         resp["repos_enqueued"].as_u64().unwrap_or(0),
     )
-}
-
-/// Read at most `cap` bytes of a response body. Bounds the allocation from a
-/// hostile or broken node returning a huge error body — the display is capped
-/// separately, but the read itself must not be unbounded (INV-6, read half).
-async fn read_body_capped(mut resp: reqwest::Response, cap: usize) -> String {
-    let mut buf: Vec<u8> = Vec::new();
-    while buf.len() < cap {
-        match resp.chunk().await {
-            Ok(Some(chunk)) => {
-                let take = (cap - buf.len()).min(chunk.len());
-                buf.extend_from_slice(&chunk[..take]);
-                if take < chunk.len() {
-                    break; // hit the cap mid-chunk
-                }
-            }
-            _ => break, // end of body or read error — return what we have
-        }
-    }
-    String::from_utf8_lossy(&buf).into_owned()
-}
-
-/// Strip terminal-dangerous characters from (and cap the length of) a
-/// node-supplied error string before surfacing it. The node a caller talks to
-/// could be hostile and embed escape sequences in its error body; those must not
-/// reach the terminal verbatim (INV-6). We drop the C0/C1 control bytes (which
-/// defangs ANSI/OSC escapes) AND the Unicode bidi/format controls (which
-/// `char::is_control` does not cover — they can reorder the displayed line).
-fn sanitize_node_msg(s: &str) -> String {
-    s.chars()
-        .filter(|c| !c.is_control() && !gitlawb_core::sanitize::is_bidi_format(*c))
-        .take(200)
-        .collect()
 }
 
 #[cfg(test)]
@@ -258,37 +225,6 @@ mod tests {
             .await;
         let (args, _dir) = trigger_args(server.url());
         run(args).await.unwrap();
-    }
-
-    #[test]
-    fn sanitize_strips_controls_bidi_and_caps_length() {
-        // C0 (ESC/BEL) and the Cf bidi override (U+202E) are both removed; the
-        // printable text survives. (Note: a stripped ESC leaves any following
-        // "[31m" as inert literal text — that is the point, so the input here
-        // avoids that residue to keep the expectation unambiguous.)
-        let out = sanitize_node_msg("a\u{1b}\u{07}b\u{202e}c");
-        assert!(
-            !out.chars().any(|c| c.is_control()),
-            "control char leaked: {out:?}"
-        );
-        assert!(
-            !out.contains('\u{202e}'),
-            "RLO bidi override leaked: {out:?}"
-        );
-        assert_eq!(out, "abc");
-        // Length is capped at 200 chars regardless of input size.
-        let long = "x".repeat(250);
-        assert_eq!(sanitize_node_msg(&long).chars().count(), 200);
-    }
-
-    #[test]
-    fn sanitize_preserves_legitimate_and_rtl_text() {
-        // Must not over-strip: a plain word, a genuine RTL SCRIPT letter (Arabic
-        // U+0627, category Lo — NOT a format char), and ZWJ (U+200D, a legitimate
-        // Cf char, e.g. emoji sequences) all survive. Guards the shared predicate
-        // against being widened into a blanket Cf stripper.
-        let out = sanitize_node_msg("ok \u{0627}\u{200D}b");
-        assert_eq!(out, "ok \u{0627}\u{200D}b");
     }
 
     #[tokio::test]


### PR DESCRIPTION
`upsert_peer` ended in an unconditional `ON CONFLICT DO UPDATE SET http_url`, so any unauthenticated caller could repoint any peer. A repointed row steers the sync worker's git remote, the post-receive notify fan-out, `trigger_sync`, and the public `GET /api/v1/resolve/{did}`, none of which consult the reachability flag that #270's stopgap resets.

An unsigned write may now insert an unseen DID but may never change an existing row's `http_url`. Changing one requires a verified signature from that row's own DID.

**The gate sits at the db boundary, not in the announce handler, because there is a second writer.** The bootstrap announce-back in `main.rs` reads a peer's own JSON response with no proof of anything. It now declares itself unproven, which makes it insert-only by construction rather than by remembering.

**The proven variant carries the DID it proves**, and `upsert_peer` compares it against the row being written. A bare proven/unproven flag would say that something was proven without saying which DID, leaving the real check in the handler. That is the RUSTSEC-2022-0009 shape, where `libp2p-core` accepted a valid signature without checking it derived the claimed identity.

**#273 proposed recording the announcing key in a new column, which turns out to be unnecessary.** Only `did:key` can authenticate here (`auth/mod.rs` resolves the verifying key from the keyid), and a `did:key` is the ed25519 public key, so `peers.did` already is the first-seen key. No migration.

An unproven insert is therefore restricted to keys that actually resolve. Checking the method label was not enough: `did:key:notarealkey` passes a label check and creates a row nobody can ever correct. Resolving the key put a quadratic base58 decode on an anonymous route, so there is a length bound ahead of it, which also covers the signature keyid path since both reach the same function.

`gl peer add` discarded the local node's reply and printed success unconditionally, so the new refusal would have been reported as a completed add. It now surfaces the node's message.

## What this does not close

Squatting. An attacker who announces an unseen DID before its owner is indistinguishable from that owner, which is the standard trust-on-first-use residual (RFC 4251 section 4.1, RFC 7435 section 3). The rule stops them holding the row, since only the real keyholder can produce the signature, but the window is real: peer DIDs are enumerable through the unauthenticated peer list, and the announce is one-shot at boot. A repair path is a follow-up rather than part of this change.

## Verification

The defect was re-observed at the merge base before any fix was written: an unsigned announce naming an existing peer returned 200 OK and left the attacker's URL stored.

Eight guard mutations were run, each turning a specific named test red on its expected message. Three of those runs are worth noting because they were not clean the first time: one scored INCONCLUSIVE because the injected mutation did not compile, and one scored RED-WRONG-REASON because the test reddened on a different assertion than expected. Both would have read as passing without checking the failure text.

One call site has no runtime test here. The bootstrap announce-back is held by the compile-enforced parameter and the writer ledger, and is recorded as reasoned-not-run rather than counted as covered.

## Known gaps

- No monotonic `seq` replay guard. Deferred to the HTTP-signature nonce ledger, which is off by default, so this gap is open today.
- No key-rotation path. A `did:key` cannot rotate, so building one would bypass the gate: a peer that loses its key announces under a new DID.
- `require_signed_peer_writes` is not flipped.
- Two of #270's reachability tests now drive the proven path. Under this rule an unproven repoint is refused, so they can no longer express a URL change through it. They assert the same behavior as before.

Closes #273.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened peer announcement authorization to prevent unsigned updates from redirecting existing peers.
  * Rejected excessively long, unsupported, malformed, or unresolvable DID identifiers.
  * Sanitized and limited remote messages before displaying them in the terminal.

* **Bug Fixes**
  * Corrected HTTP error responses for rejected or mismatched peer updates.
  * Prevented refused peer changes from altering stored peer information.
  * Improved handling of refused or failed peer-list announcements.
  * Preserved HTTP status details when remote responses are malformed or truncated.

* **Documentation**
  * Clarified staged rollout behavior for signed and unsigned peer announcements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->