### PR TITLE
fix(node): disposition #248's two peers-table test writers in the ledger

### DIFF
--- a/crates/gitlawb-node/src/db/mod.rs
+++ b/crates/gitlawb-node/src/db/mod.rs
@@ -6945,6 +6945,8 @@ mod peer_authority_tests {
 /// | `prune_non_public_peers` (db/mod.rs) | a delete keyed on a computed bad-DID array; cannot repoint; boot-only caller in main.rs |
 /// | `seed_local_peer` (sync.rs) | excluded by test-module location: a deliberate `upsert_peer` bypass for `file://` fixtures, which the public-URL gate rejects |
 /// | `a_legacy_row_can_still_refresh_its_liveness` (db/mod.rs) | test-only. Seeds a PRE-GATE row by raw SQL on purpose: `upsert_peer` cannot create one, since the gate it is testing refuses exactly that DID. The fixture models what a deployed table already holds |
+/// | `gossip_ping_round_requires_two_failures_before_persisting_unreachable` (main.rs) | test-only (#248). Seeds a reachable row pointing at a mockito server so the ping round has a peer to probe. `upsert_peer` cannot create it: mockito binds 127.0.0.1, and the `is_public_http_url` gate refuses loopback |
+/// | `manual_ping_uses_readiness_without_mutating_federation_gate` (api/peers.rs) | test-only (#248). Same fixture shape and the same reason: a loopback mockito URL that `upsert_peer` would refuse |
 ///
 /// And the `upsert_peer` CALL-SITE authority table, which the ledger above
 /// structurally cannot hold, because the bootstrap site issues no SQL of its own
@@ -7030,6 +7032,14 @@ mod peers_table_writer_guard {
     /// listed function that no longer has one.
     const LEDGER: &[(&str, usize)] = &[
         ("a_legacy_row_can_still_refresh_its_liveness", 1),
+        (
+            "gossip_ping_round_requires_two_failures_before_persisting_unreachable",
+            1,
+        ),
+        (
+            "manual_ping_uses_readiness_without_mutating_federation_gate",
+            1,
+        ),
         ("mark_peer_ping", 1),
         ("prune_non_public_peers", 1),
         ("prune_self_peers", 1),


### PR DESCRIPTION
`main` is red at 225644a3. This is the failure #310 reports; that issue closes itself when a run on main's tip goes green, so I have not added a closing keyword here. `every_peers_table_write_is_dispositioned` fails because two test fixtures introduced by #248 write the `peers` table directly, and neither is in the #273 completeness ledger:

```
gossip_ping_round_requires_two_failures_before_persisting_unreachable  (main.rs)
manual_ping_uses_readiness_without_mutating_federation_gate            (api/peers.rs)
```

Neither PR could have caught this on its own. The ledger landed in #290, after #248 was last tested, and #248's writers did not exist when the ledger was written. Both were green individually and merged cleanly because they touch different files, so the conflict was semantic rather than textual and only appeared once both were on main. The guard did its job on first contact.

Both new writers are test-only fixtures seeding a peer row that points at a mockito server, and neither can go through `upsert_peer`: mockito binds 127.0.0.1, and `upsert_peer` bails on `!is_public_http_url(..)`, which rejects loopback. That is the disposition already recorded for `seed_local_peer` (file:// fixtures) and `a_legacy_row_can_still_refresh_its_liveness` (a pre-gate DID), so this adds two rows to an existing category rather than a new kind of exemption.

Verified by execution: the guard is RED on this tree before the change and GREEN after, and the full workspace suite passes locally with the fix where it fails without it. The two new rows are load-bearing, not decorative, checked by injecting three defects and confirming each goes RED on the ledger's own message: drop the gossip entry, drop the manual-ping entry, and claim the wrong statement count for one of them. The count mutation matters because it shows the ledger binds how many statements each writer issues, not just the name.

Worth a separate look: the merge-queue grouping trusts each PR's own last CI run, so a guard that lands after a PR was last tested cannot bind that PR before it merges. This is the second instance tonight of work merging against a base it was never tested on.

Note on the red Windows lane here: that is not this change. `real_git_withheld_shaped_first_post` and `real_git_multi_round_fetch_completes` both abort with `os error 10053`, a race in the test shim that reached main with #192 and is fixed in #312. This PR touches one file in `gitlawb-node` and that lane builds only `gl` and `git-remote-gitlawb`, so it cannot reach them. The lane is non-blocking; the 16 gating checks are green.
