### PR TITLE
fix(git-remote): normalize the shim's accepted socket to blocking

### DIFF
--- a/crates/git-remote-gitlawb/tests/real_git_fetch.rs
+++ b/crates/git-remote-gitlawb/tests/real_git_fetch.rs
@@ -788,21 +788,22 @@ fn build_divergent_repos(shared_commits: usize) -> Repos {
 /// state follows the new descriptor is a question this test would then depend on
 /// and could not answer. Owning the original removes the question.
 ///
-/// The `Started` handshake is load-bearing and must not be removed. Without it,
-/// "no outcome arrived within the window" would be satisfied by two different
-/// states: the reader parked inside its read, and the reader thread not yet
-/// scheduled to reach the read at all. A slow spawn would then pass this test
-/// with the helper's normalization deleted, which is the vacuous-guard failure
-/// this test exists to avoid.
+/// The `Started` handshake is load-bearing and must not be removed. It SHRINKS
+/// the vacuity window; it does not close it. Read that literally, because the
+/// looser version of this sentence is the mistake this whole test exists to
+/// correct. Without the handshake the window includes thread spawn itself, which
+/// is unbounded and can be very slow on a loaded runner. With it, spawn is out of
+/// the window entirely and what remains is the cross-thread round trip: the
+/// signal, the read call, its `WouldBlock` return, the channel send, and this
+/// thread waking from `recv_timeout`.
 ///
-/// What the handshake buys is that thread-spawn latency is out of the window
-/// entirely. What remains is a full cross-thread round trip: the signal, the read
-/// call, its `WouldBlock` return, the channel send, and this thread waking from
-/// `recv_timeout`. All of that must exceed 250ms for a false green, so the guard
-/// cannot flake RED and its false-green path is a scheduling stall, not a byte
-/// race. Measured 50 of 50 RED under a mutation deleting the normalization, at
-/// full-suite parallelism; that bounds the false-green rate, it does not make it
-/// zero.
+/// So the residual false-green path is a reader descheduled anywhere along that
+/// round trip for more than 250ms, notably between its own `Started` send and its
+/// `read`. That path is real and this comment does not claim otherwise. What the
+/// design does buy is that the guard cannot flake RED, and that no arrangement of
+/// bytes on the wire can fool it, only the scheduler. Measured 50 of 50 RED under
+/// a mutation deleting the normalization, at full-suite parallelism; that bounds
+/// the false-green rate, it does not make it zero.
 ///
 /// Teardown order is a constraint, not a preference: the peer close must come
 /// AFTER the timeout assertion. Closing first unblocks the parked read, the
@@ -843,9 +844,13 @@ fn normalize_accepted_stream_leaves_the_socket_blocking() {
         let _ = tx.send(Probe::Outcome(outcome));
     });
 
+    // Bounded, not `recv()`. A bare recv here turns "the reader never ran" into a
+    // hung test binary rather than a failing test, and cargo test has no per-test
+    // timeout to rescue it. The bound is far above any real scheduling delay, so
+    // hitting it is a genuine defect report, never a flake.
     match rx
-        .recv()
-        .expect("reader thread died before signalling Started")
+        .recv_timeout(Duration::from_secs(30))
+        .expect("reader thread never signalled Started (died, or never scheduled)")
     {
         Probe::Started => {}
         Probe::Outcome(_) => panic!("reader reported an outcome before its Started signal"),
@@ -874,11 +879,13 @@ fn normalize_accepted_stream_leaves_the_socket_blocking() {
         }
     }
 
-    // Only now: EOF unblocks the parked read so the thread can be joined.
+    // Only now: EOF unblocks the parked read so the thread can be joined. Bounded
+    // for the same reason as the handshake wait above; the socket's own 30s read
+    // timeout is the other backstop, and it is asserted rather than assumed.
     drop(client);
     match rx
-        .recv()
-        .expect("reader thread died instead of returning after EOF")
+        .recv_timeout(Duration::from_secs(60))
+        .expect("reader did not return after the peer closed")
     {
         Probe::Outcome(outcome) => assert_eq!(
             outcome.ok(),

--- a/crates/git-remote-gitlawb/tests/real_git_fetch.rs
+++ b/crates/git-remote-gitlawb/tests/real_git_fetch.rs
@@ -771,24 +771,38 @@ fn build_divergent_repos(shared_commits: usize) -> Repos {
 
 /// `normalize_accepted_stream` must leave the socket in blocking mode.
 ///
-/// This is the deterministic half of the non-blocking-accept guard. It asserts
-/// the helper's postcondition directly: no client, no request, no race over
-/// whether bytes arrive before the shim reads them.
+/// This asserts the helper's postconditions directly: no client, no request, and
+/// no race over whether bytes arrive before the shim reads them. It removes the
+/// byte-arrival race entirely, which is what the end-to-end test cannot do. It is
+/// not literally deterministic, and the paragraph below says exactly what is left.
 ///
-/// Blocking mode has no getter. std exposes none, and Winsock has no FIONBIO
-/// getter at all (`ioctlsocket` documents FIONBIO with no output type, so it is
-/// set-only), so the property has to be observed through behavior: a blocking
-/// socket with no data pending parks its reader, a non-blocking one returns
-/// `WouldBlock` at once.
+/// The read timeout has a getter, so it is checked exactly. Blocking mode does
+/// not: std exposes none, and Winsock has no FIONBIO getter at all (`ioctlsocket`
+/// documents FIONBIO with no output type, so it is set-only), so that half has to
+/// be observed through behavior: a blocking socket with no data pending parks its
+/// reader, a non-blocking one returns `WouldBlock` at once.
+///
+/// The reader owns the very socket the helper normalized. Do not reintroduce a
+/// `try_clone` here: on Windows that mints a new descriptor through
+/// `WSADuplicateSocketW` rather than duplicating a handle, and whether FIONBIO
+/// state follows the new descriptor is a question this test would then depend on
+/// and could not answer. Owning the original removes the question.
 ///
 /// The `Started` handshake is load-bearing and must not be removed. Without it,
 /// "no outcome arrived within the window" would be satisfied by two different
 /// states: the reader parked inside its read, and the reader thread not yet
 /// scheduled to reach the read at all. A slow spawn would then pass this test
 /// with the helper's normalization deleted, which is the vacuous-guard failure
-/// this test exists to avoid. With the handshake, the window opens only once the
-/// reader is about to call `read`, so the residual gap is the few instructions
-/// between the signal and the call rather than thread-spawn latency.
+/// this test exists to avoid.
+///
+/// What the handshake buys is that thread-spawn latency is out of the window
+/// entirely. What remains is a full cross-thread round trip: the signal, the read
+/// call, its `WouldBlock` return, the channel send, and this thread waking from
+/// `recv_timeout`. All of that must exceed 250ms for a false green, so the guard
+/// cannot flake RED and its false-green path is a scheduling stall, not a byte
+/// race. Measured 50 of 50 RED under a mutation deleting the normalization, at
+/// full-suite parallelism; that bounds the false-green rate, it does not make it
+/// zero.
 ///
 /// Teardown order is a constraint, not a preference: the peer close must come
 /// AFTER the timeout assertion. Closing first unblocks the parked read, the
@@ -810,8 +824,18 @@ fn normalize_accepted_stream_leaves_the_socket_blocking() {
     accepted.set_nonblocking(true).unwrap();
     normalize_accepted_stream(&accepted);
 
+    // The helper's other postcondition, and the one std lets us check exactly.
+    // Without this, deleting the timeout leaves every test here green while a
+    // stalled peer parks the shim's only accept-loop thread forever.
+    assert_eq!(
+        accepted.read_timeout().unwrap(),
+        Some(Duration::from_secs(30)),
+        "normalize_accepted_stream must restore the read timeout, not only blocking mode"
+    );
+
     let (tx, rx) = std::sync::mpsc::channel();
-    let mut reader = accepted.try_clone().unwrap();
+    // Move, never clone: see the try_clone note above.
+    let mut reader = accepted;
     let probe = std::thread::spawn(move || {
         let mut buf = [0u8; 1];
         tx.send(Probe::Started).unwrap();
@@ -882,11 +906,11 @@ fn normalize_accepted_stream_leaves_the_socket_blocking() {
 /// accept-before-request window without closing it: the request bytes can
 /// already be buffered by the time the shim reads, and the read then succeeds
 /// even with the normalization removed. Against a deleted
-/// `set_nonblocking(false)` it caught the defect in 43 and 47 of 50 across two
-/// full-suite samples of 50 runs. Two samples do not pin a rate, which is the
-/// point: it is a sampled tendency, not a property, so do not quote a percentage
-/// off it. Running it alone on an idle machine flattered it to 48 of 50; the
-/// full-suite numbers are the honest ones, because that is how it ships.
+/// `set_nonblocking(false)` it caught the defect in 39, 43, and 47 of 50 across
+/// three full-suite samples. The spread is the point: it is a sampled tendency,
+/// not a property, so do not quote a percentage off it. Running it alone on an
+/// idle machine flattered it to 48 of 50; the full-suite numbers are the honest
+/// ones, because that is how it ships.
 ///
 /// It is still the only coverage for the helper's CALL SITE. The deterministic
 /// probe calls `normalize_accepted_stream` directly, so deleting the call from

--- a/crates/git-remote-gitlawb/tests/real_git_fetch.rs
+++ b/crates/git-remote-gitlawb/tests/real_git_fetch.rs
@@ -163,6 +163,14 @@ fn start_shim(repo: PathBuf, mode: ShimMode) -> Shim {
 }
 
 fn handle_conn(stream: TcpStream, repo: &Path, mode: ShimMode, posts: &AtomicUsize) {
+    // `start_shim` makes the LISTENER non-blocking to poll its stop flag. On
+    // Windows the accepted socket inherits that (Winsock FIONBIO inheritance;
+    // std's `accept` does not reset it), on unix it does not. Every read below
+    // is a blocking read whose errors collapse to "peer closed", so an inherited
+    // WouldBlock would drop the connection with no response and abort the client
+    // mid-request. Normalize before reading; this also restores the read timeout
+    // on the next line, which a non-blocking socket silently makes meaningless.
+    stream.set_nonblocking(false).ok();
     stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
     let mut reader = BufReader::new(stream);
 
@@ -747,6 +755,86 @@ fn build_divergent_repos(shared_commits: usize) -> Repos {
         clone,
         _tmp: tmp,
     }
+}
+
+/// The shim must answer a connection that arrives in non-blocking mode.
+///
+/// `start_shim` sets the LISTENER non-blocking so the accept loop can poll the
+/// stop flag. On unix the socket handed back by `accept()` is blocking, so that
+/// is invisible; on Windows, Winsock has the accepted socket inherit the
+/// listener's FIONBIO state and std does not reset it (`accept` is a bare
+/// `c::accept`), so every accepted connection is non-blocking there. The shim
+/// reads with `read_line(..).unwrap_or(0)`, which collapses `WouldBlock` into
+/// "peer closed" and returns WITHOUT writing a response, aborting the client
+/// mid-request. Because the shim accepts as soon as the handshake completes,
+/// strictly before the request bytes arrive, that window is open on every
+/// connection and closes only because the accept poll usually lags the client.
+///
+/// Force the Windows shape explicitly so this is checked on every platform
+/// rather than only the one that exhibits it. The accept-before-request
+/// interleaving is the losing one, so it is established by a handshake rather
+/// than a sleep: a timing-based version cannot flake RED, but it CAN flake
+/// GREEN on a loaded runner (bytes already buffered, so the read succeeds even
+/// while non-blocking), which would make this guard vacuous exactly where it
+/// is supposed to bite.
+#[test]
+fn shim_answers_a_connection_that_arrives_non_blocking() {
+    let repos = build_divergent_repos(1);
+    let repo = repos.server.clone();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (accepted_tx, accepted_rx) = std::sync::mpsc::channel();
+
+    let server = std::thread::spawn(move || {
+        let posts = AtomicUsize::new(0);
+        let stream = loop {
+            match listener.accept() {
+                Ok((s, _)) => break s,
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(5))
+                }
+                Err(e) => panic!("accept failed: {e}"),
+            }
+        };
+        // What Windows hands the shim. On unix this is the only way to reach
+        // that state, so the assertion below is load-bearing here too.
+        stream.set_nonblocking(true).unwrap();
+        accepted_tx.send(()).unwrap();
+        handle_conn(stream, &repo, ShimMode::Normal, &posts);
+    });
+
+    let mut client = TcpStream::connect(addr).unwrap();
+    // Send only once the shim has the connection in hand, so its first read is
+    // guaranteed to run against an empty receive buffer.
+    accepted_rx.recv().unwrap();
+    client
+        .write_all(b"GET /x/info/refs?service=git-upload-pack HTTP/1.1\r\nHost: x\r\n\r\n")
+        .unwrap();
+
+    let mut got = Vec::new();
+    let read = client.read_to_end(&mut got);
+    server.join().unwrap();
+
+    assert!(
+        read.is_ok(),
+        "client read failed instead of receiving a response: {:?} \
+         (a non-blocking accepted socket makes the shim drop the connection \
+         with no reply, which surfaces as a connection abort on the client)",
+        read.unwrap_err().kind()
+    );
+    assert!(
+        got.starts_with(b"HTTP/1.1 200 OK"),
+        "shim closed the connection without a response ({} bytes read); \
+         a WouldBlock on the request-line read was swallowed as EOF",
+        got.len()
+    );
+    assert!(
+        got.windows(b"# service=git-upload-pack".len())
+            .any(|w| w == b"# service=git-upload-pack"),
+        "response reached the client but is not the upload-pack advertisement"
+    );
 }
 
 /// Matrix item 7, bridging half: a real multi-round `git fetch` through the

--- a/crates/git-remote-gitlawb/tests/real_git_fetch.rs
+++ b/crates/git-remote-gitlawb/tests/real_git_fetch.rs
@@ -162,16 +162,28 @@ fn start_shim(repo: PathBuf, mode: ShimMode) -> Shim {
     }
 }
 
-fn handle_conn(stream: TcpStream, repo: &Path, mode: ShimMode, posts: &AtomicUsize) {
-    // `start_shim` makes the LISTENER non-blocking to poll its stop flag. On
-    // Windows the accepted socket inherits that (Winsock FIONBIO inheritance;
-    // std's `accept` does not reset it), on unix it does not. Every read below
-    // is a blocking read whose errors collapse to "peer closed", so an inherited
-    // WouldBlock would drop the connection with no response and abort the client
-    // mid-request. Normalize before reading; this also restores the read timeout
-    // on the next line, which a non-blocking socket silently makes meaningless.
+/// `start_shim` makes the LISTENER non-blocking to poll its stop flag, and an
+/// accepted socket can inherit that flag.
+///
+/// Observed on Windows: Winsock hands back a socket carrying the listener's
+/// FIONBIO state and std's `accept` does not reset it. Expected on macOS and the
+/// BSDs for the same reason, since the accept4 man page describes inheritance as
+/// the canonical BSD behavior, though nothing in this repo's CI exercises that
+/// half. Linux is the exception, because std uses `accept4` there and it does
+/// not inherit file status flags (rust-lang/rust#67027).
+///
+/// Every read in `handle_conn` is a blocking read whose errors collapse to "peer
+/// closed", so an inherited WouldBlock would drop the connection with no
+/// response and abort the client mid-request. Normalize before reading; this
+/// also restores the read timeout, which a non-blocking socket silently makes
+/// meaningless.
+fn normalize_accepted_stream(stream: &TcpStream) {
     stream.set_nonblocking(false).ok();
     stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
+}
+
+fn handle_conn(stream: TcpStream, repo: &Path, mode: ShimMode, posts: &AtomicUsize) {
+    normalize_accepted_stream(&stream);
     let mut reader = BufReader::new(stream);
 
     // Request line.
@@ -757,26 +769,129 @@ fn build_divergent_repos(shared_commits: usize) -> Repos {
     }
 }
 
+/// `normalize_accepted_stream` must leave the socket in blocking mode.
+///
+/// This is the deterministic half of the non-blocking-accept guard. It asserts
+/// the helper's postcondition directly: no client, no request, no race over
+/// whether bytes arrive before the shim reads them.
+///
+/// Blocking mode has no getter. std exposes none, and Winsock has no FIONBIO
+/// getter at all (`ioctlsocket` documents FIONBIO with no output type, so it is
+/// set-only), so the property has to be observed through behavior: a blocking
+/// socket with no data pending parks its reader, a non-blocking one returns
+/// `WouldBlock` at once.
+///
+/// The `Started` handshake is load-bearing and must not be removed. Without it,
+/// "no outcome arrived within the window" would be satisfied by two different
+/// states: the reader parked inside its read, and the reader thread not yet
+/// scheduled to reach the read at all. A slow spawn would then pass this test
+/// with the helper's normalization deleted, which is the vacuous-guard failure
+/// this test exists to avoid. With the handshake, the window opens only once the
+/// reader is about to call `read`, so the residual gap is the few instructions
+/// between the signal and the call rather than thread-spawn latency.
+///
+/// Teardown order is a constraint, not a preference: the peer close must come
+/// AFTER the timeout assertion. Closing first unblocks the parked read, the
+/// outcome arrives, and the assertion fails even when the helper is correct.
+#[test]
+fn normalize_accepted_stream_leaves_the_socket_blocking() {
+    enum Probe {
+        Started,
+        Outcome(std::io::Result<usize>),
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let client = TcpStream::connect(addr).unwrap();
+    let (accepted, _) = listener.accept().unwrap();
+
+    // The state Windows hands the shim. Forced here so the property is checked
+    // on every platform rather than only where the OS supplies it.
+    accepted.set_nonblocking(true).unwrap();
+    normalize_accepted_stream(&accepted);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let mut reader = accepted.try_clone().unwrap();
+    let probe = std::thread::spawn(move || {
+        let mut buf = [0u8; 1];
+        tx.send(Probe::Started).unwrap();
+        let outcome = reader.read(&mut buf);
+        let _ = tx.send(Probe::Outcome(outcome));
+    });
+
+    match rx
+        .recv()
+        .expect("reader thread died before signalling Started")
+    {
+        Probe::Started => {}
+        Probe::Outcome(_) => panic!("reader reported an outcome before its Started signal"),
+    }
+
+    match rx.recv_timeout(Duration::from_millis(250)) {
+        // The read is still parked, which is what blocking mode means.
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("the reader thread exited instead of parking in its read")
+        }
+        Ok(Probe::Started) => panic!("received a second Started signal"),
+        Ok(Probe::Outcome(outcome)) => {
+            assert_eq!(
+                outcome.as_ref().err().map(std::io::Error::kind),
+                Some(std::io::ErrorKind::WouldBlock),
+                "the read returned instead of parking, but not with WouldBlock \
+                 ({outcome:?}); that is a different failure than the one this test \
+                 guards, so do not read it as a non-blocking socket"
+            );
+            panic!(
+                "accepted socket is still non-blocking after \
+                 normalize_accepted_stream: the read returned WouldBlock \
+                 immediately instead of parking"
+            );
+        }
+    }
+
+    // Only now: EOF unblocks the parked read so the thread can be joined.
+    drop(client);
+    match rx
+        .recv()
+        .expect("reader thread died instead of returning after EOF")
+    {
+        Probe::Outcome(outcome) => assert_eq!(
+            outcome.ok(),
+            Some(0),
+            "expected EOF once the peer closed, not payload"
+        ),
+        Probe::Started => panic!("received a second Started signal"),
+    }
+    probe.join().unwrap();
+}
+
 /// The shim must answer a connection that arrives in non-blocking mode.
 ///
-/// `start_shim` sets the LISTENER non-blocking so the accept loop can poll the
-/// stop flag. On unix the socket handed back by `accept()` is blocking, so that
-/// is invisible; on Windows, Winsock has the accepted socket inherit the
-/// listener's FIONBIO state and std does not reset it (`accept` is a bare
-/// `c::accept`), so every accepted connection is non-blocking there. The shim
-/// reads with `read_line(..).unwrap_or(0)`, which collapses `WouldBlock` into
-/// "peer closed" and returns WITHOUT writing a response, aborting the client
-/// mid-request. Because the shim accepts as soon as the handshake completes,
-/// strictly before the request bytes arrive, that window is open on every
-/// connection and closes only because the accept poll usually lags the client.
+/// End-to-end realism check through the real `handle_conn` request path. The
+/// deterministic guarantee lives in
+/// `normalize_accepted_stream_leaves_the_socket_blocking`, which asserts the
+/// helper's postcondition with no client at all; see `normalize_accepted_stream`
+/// for why an accepted socket can arrive non-blocking in the first place. The
+/// shim reads with `read_line(..).unwrap_or(0)`, which collapses `WouldBlock`
+/// into "peer closed" and returns WITHOUT writing a response, aborting the
+/// client mid-request.
 ///
-/// Force the Windows shape explicitly so this is checked on every platform
-/// rather than only the one that exhibits it. The accept-before-request
-/// interleaving is the losing one, so it is established by a handshake rather
-/// than a sleep: a timing-based version cannot flake RED, but it CAN flake
-/// GREEN on a loaded runner (bytes already buffered, so the read succeeds even
-/// while non-blocking), which would make this guard vacuous exactly where it
-/// is supposed to bite.
+/// This test is BEST EFFORT and known to be nondeterministic. Its handshake
+/// fires after `accept()` but before `handle_conn` runs, so it narrows the
+/// accept-before-request window without closing it: the request bytes can
+/// already be buffered by the time the shim reads, and the read then succeeds
+/// even with the normalization removed. Against a deleted
+/// `set_nonblocking(false)` it caught the defect in 43 and 47 of 50 across two
+/// full-suite samples of 50 runs. Two samples do not pin a rate, which is the
+/// point: it is a sampled tendency, not a property, so do not quote a percentage
+/// off it. Running it alone on an idle machine flattered it to 48 of 50; the
+/// full-suite numbers are the honest ones, because that is how it ships.
+///
+/// It is still the only coverage for the helper's CALL SITE. The deterministic
+/// probe calls `normalize_accepted_stream` directly, so deleting the call from
+/// `handle_conn` leaves that probe green (0 of 50 in both samples) and only this
+/// test notices, at 45 and 46 of 50.
 #[test]
 fn shim_answers_a_connection_that_arrives_non_blocking() {
     let repos = build_divergent_repos(1);
@@ -798,8 +913,9 @@ fn shim_answers_a_connection_that_arrives_non_blocking() {
                 Err(e) => panic!("accept failed: {e}"),
             }
         };
-        // What Windows hands the shim. On unix this is the only way to reach
-        // that state, so the assertion below is load-bearing here too.
+        // What Windows hands the shim, and what macOS is expected to. On Linux
+        // this is the only way to reach that state, so forcing it is what makes
+        // the assertions below run on every platform.
         stream.set_nonblocking(true).unwrap();
         accepted_tx.send(()).unwrap();
         handle_conn(stream, &repo, ShimMode::Normal, &posts);


### PR DESCRIPTION
Follow-up to #192, which merged with a race in its test shim.

`start_shim` makes the listener non-blocking so its accept loop can poll the stop flag. On unix `accept()` returns a blocking socket, so this never showed here. On Windows the accepted socket inherits the listener's FIONBIO state and std does not reset it (`accept` is a bare `c::accept`), so every connection arrives non-blocking. `handle_conn` then reads with `read_line(..).unwrap_or(0)`, which turns the resulting `WouldBlock` into "peer closed" and returns without writing a response. The connection is dropped and the client aborted mid-request, which is the `os error 10053` seen on the Windows lane, with zero POSTs recorded because the shim returns before the branch that counts them.

The window is open on every connection, since the shim accepts as soon as the handshake completes and that is strictly before the request bytes arrive. It survives only because the 5ms accept poll usually lags the client, which is what made it look intermittent. Both shim-based tests are exposed, `real_git_multi_round_fetch_completes` and `real_git_withheld_shaped_first_post`; the second is just the one that lost the race first, on #192's last CI run.

The fix normalizes the socket at `handle_conn` entry. That also restores the 30s read timeout set on the next line, which a non-blocking socket had made meaningless.

The regression test forces the Windows socket shape explicitly, so it is load-bearing on every platform rather than a no-op off Windows. It establishes the accept-before-request interleaving with a handshake rather than a sleep: a sleep cannot flake red, but it can flake green under load, which would leave the guard vacuous exactly where it should bite.

Verified: RED without the fix ("shim closed the connection without a response (0 bytes read)") and GREEN with it, re-confirmed by injecting the defect back in. The rest of the workspace suite is unaffected, with the one exception noted below. The Windows behaviour itself is argued from the mechanism and the toolchain source rather than executed, since there is no Windows runner locally and the cross-target build needs MSVC; this PR's Windows lane is the real proof.

Note on CI: `every_peers_table_write_is_dispositioned` fails on this branch, inherited from main rather than caused by anything here. It is a separate problem with its own fix in #311, and it reproduces on a clean checkout of main with this branch absent. This PR touches only `crates/git-remote-gitlawb`, which that guard does not scan. Once #311 lands I will rebase so the lane reads clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart HTTP connection handling to prevent valid requests from being incorrectly treated as closed.
  * Ensured upload-pack requests succeed reliably when connections inherit non-blocking behavior.
  * Restored expected connection behavior and read timeouts before processing requests.
* **Tests**
  * Added regression coverage for non-blocking socket scenarios, timeout restoration, and successful smart HTTP responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->