### PR TITLE
fix(node): close three host-class gaps in the public-URL gate

### DIFF
--- a/crates/gitlawb-node/src/api/peers.rs
+++ b/crates/gitlawb-node/src/api/peers.rs
@@ -118,11 +118,11 @@ pub fn is_public_http_url(raw: &str) -> bool {
         Some(h) => h.to_ascii_lowercase(),
         None => return false,
     };
-    // Drop a single trailing dot (FQDN root): `localhost.` resolves the same as
+    // Drop trailing dots (FQDN root): `localhost.` resolves the same as
     // `localhost`, so normalize before the suffix/equality checks below.
-    if let Some(stripped) = host.strip_suffix('.') {
-        host = stripped.to_string();
-    }
+    // Strip to fixation rather than once, or `localhost..` reduces to
+    // `localhost.` and matches neither the equality nor the suffix check.
+    host.truncate(host.trim_end_matches('.').len());
     if host.is_empty()
         || host == "localhost"
         || host.ends_with(".local")
@@ -167,8 +167,13 @@ pub fn is_public_http_url(raw: &str) -> bool {
             }
             std::net::IpAddr::V6(v6) => {
                 let s = v6.segments();
-                // fc00::/7 (unique-local) or fe80::/10 (link-local)
-                if (s[0] & 0xfe00) == 0xfc00 || (s[0] & 0xffc0) == 0xfe80 {
+                // fc00::/7 (unique-local), fe80::/10 (link-local), or fec0::/10
+                // (site-local, deprecated by RFC 3879 and so never a legitimate
+                // peer address, but still routable on networks that kept it).
+                if (s[0] & 0xfe00) == 0xfc00
+                    || (s[0] & 0xffc0) == 0xfe80
+                    || (s[0] & 0xffc0) == 0xfec0
+                {
                     return false;
                 }
                 // Any NAT64 address (64:ff9b::/32) that is not the cleanly
@@ -183,6 +188,13 @@ pub fn is_public_http_url(raw: &str) -> bool {
                 }
             }
         }
+    } else if !host.contains('.') {
+        // A name with no dot at all. The `.local` / `.internal` rules above are
+        // suffix checks, so a single label slips both, and the resolver decides
+        // what it means by appending a search domain we cannot see from here.
+        // Only reachable when the host did not parse as an IP literal, which is
+        // what keeps bracketed IPv6 (also dotless) on the accepting path.
+        return false;
     }
     true
 }
@@ -573,6 +585,46 @@ mod tests {
             // rejected: the block is prefix-based, not payload-based.
             "http://[64:ff9b:1::cb00:710a]/",
         ] {
+            assert!(!is_public_http_url(bad), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn rejects_dotless_single_label_hosts() {
+        // `.local` and `.internal` are suffix checks, so a name with no dot at
+        // all never matches one. A single-label name is completed by whatever
+        // search domain the resolver is configured with, which is not a
+        // destination we can reason about from the URL.
+        for bad in [
+            "http://local/",
+            "http://internal/",
+            "http://intranet/",
+            "http://wpad/",
+            "http://metadata/",
+            "http://local./",
+            "http://internal.:7545",
+        ] {
+            assert!(!is_public_http_url(bad), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn rejects_deprecated_site_local_v6() {
+        // fec0::/10, deprecated by RFC 3879. The link-local mask (0xffc0 ==
+        // 0xfe80) does not cover it: 0xfec0 & 0xffc0 is 0xfec0.
+        for bad in ["http://[fec0::1]/", "http://[feff:ffff::1]:7545"] {
+            assert!(!is_public_http_url(bad), "{bad:?} must be rejected");
+        }
+    }
+
+    #[test]
+    fn rejects_repeated_trailing_root_dots() {
+        // Stripping a single root dot leaves `localhost.`, which matches
+        // neither the equality nor the suffix check. The subdomain form
+        // (`node.localhost..`) is not asserted here: `.localhost` is not yet a
+        // rejected suffix on this base, so that case belongs to whichever
+        // change adds it rather than to this one.
+        for bad in ["http://localhost../", "http://localhost...:7545"] {
             assert!(!is_public_http_url(bad), "{bad:?} must be rejected");
         }
     }

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -60,7 +60,7 @@ pub(crate) async fn run_to_writer(args: WhoamiArgs, w: &mut impl std::io::Write)
             }
             Ok(resp) => {
                 let status = resp.status();
-                let raw = read_body_capped(resp, 8 * 1024).await;
+                let raw = read_body_capped(resp, 8 * 1024).await.text;
                 let msg = serde_json::from_str::<Value>(&raw)
                     .ok()
                     .and_then(|v| {


### PR DESCRIPTION
Closes #339.

`is_public_http_url` is the shared host-class gate for every operator-supplied outbound URL: peer announce, webhook creation, and the boot-time peer prune. Three host forms got past it that the checks around them plainly meant to exclude.

**Dotless names.** `.local` and `.internal` are suffix tests, so a single label matches neither, and `http://internal/`, `http://wpad/`, `http://metadata/` were accepted and left to the resolver to complete from its search domain. `POST /api/v1/peers/announce` is unauthenticated and a peer row's `http_url` drives outbound sync-notify fan-out, so the caller choosing that name need not be anyone in particular.

The new rule sits on the branch where the host did **not** parse as an IP literal. That placement is the whole trick: a bracketed IPv6 literal is also dotless, and the existing 6to4 and NAT64 accept cases pin that it stays accepted.

**`fec0::/10`.** The IPv6 arm missed it because the link-local mask does not cover it: `0xfec0 & 0xffc0` is `0xfec0`, not `0xfe80`. RFC 3879 deprecated the range in 2004, which argues for rejecting it rather than ignoring it.

**Repeated root dots.** Trailing dots were stripped once, so `localhost..` reduced to `localhost.` and matched neither the equality nor the suffix check. Stripping to fixation closes it. I could not resolve that name locally, so it is a predicate gap rather than a demonstrated reachable target.

## Verification

Each of the three is covered by a test that goes red when its own production line is reverted, checked one at a time rather than as a batch:

| reverted | test that reddens |
|---|---|
| the dotless branch | `rejects_dotless_single_label_hosts` |
| the `fec0::/10` clause | `rejects_deprecated_site_local_v6` |
| strip-to-fixation | `rejects_repeated_trailing_root_dots` |

The dotted forms stay in the tables as negative controls so the suffix checks remain proven, and the IPv6 accept cases guard against the dotless rule over-rejecting.

`cargo test -p gitlawb-node --bin gitlawb-node --locked` is 826 passed / 0 failed, with `fmt` and `clippy --workspace --all-targets -- -D warnings` clean.

## Scope

Predicate only. The larger gap, that nothing validates the address a hostname actually resolves to, is #340 and needs a resolver policy on both outbound clients rather than a change here.

This touches the same span of `peers.rs` as #333, so whichever lands second wants a rebase. The conflict is adjacent lines, not competing logic: #333 adds `.localhost` to the suffix list, this adds a dotless branch further down. The `node.localhost..` case is deliberately not asserted here, since `.localhost` is not a rejected suffix until #333 lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL validation by handling hostnames with repeated trailing dots.
  * Rejected deprecated site-local IPv6 addresses.
  * Rejected single-label hostnames that are not valid IP addresses.
  * Added coverage for these validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->