### PR TITLE
docs: document the two-tier storage and pinning model

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ Read:
 
 - [`docs/RUN-A-NODE.md`](docs/RUN-A-NODE.md)
 - [`docs/ECONOMICS.md`](docs/ECONOMICS.md)
+- [`docs/STORAGE-AND-PINNING.md`](docs/STORAGE-AND-PINNING.md)
 
 Use a dedicated low-balance operator wallet. Do not use a treasury wallet as the heartbeat key.
 

--- a/docs/STORAGE-AND-PINNING.md
+++ b/docs/STORAGE-AND-PINNING.md
@@ -43,9 +43,11 @@ slot indefinitely. The Pinata tail re-derives its object list only *after*
 acquiring a slot, which bounds outstanding memory to O(refs) rather than
 O(pushes × objects).
 
-De-duplication is per sink: the `pinned_cids` and `pinata_cids` tables record
-what each sink already holds, so re-pushing unchanged objects does no redundant
-upload.
+De-duplication is per sink and best-effort: the `pinned_cids` and `pinata_cids`
+tables record what each sink already holds, so later pushes normally skip objects
+whose successful pin is already recorded. The check-upload-record sequence is not
+atomic, so concurrent post-push tasks for the same object, or a failure to record
+after a successful upload, can still cause a repeat upload attempt.
 
 ## Durability notes
 

--- a/docs/STORAGE-AND-PINNING.md
+++ b/docs/STORAGE-AND-PINNING.md
@@ -16,9 +16,12 @@ both configured.
 | Warm | Pinata (Filecoin-backed) | `pinata.rs` | `GITLAWB_PINATA_JWT` set | Off-node durability + public IPFS gateway reachability |
 
 If a sink's config value is empty, its **pin** paths are no-ops — so leaving
-`GITLAWB_PINATA_JWT` unset simply disables warm-tier pinning. Note this applies to
-pinning only, not reads: the hot-tier read path (`ipfs_pin::cat`) returns an error
-rather than a no-op when `GITLAWB_IPFS_API` is unset, so a node that serves the
+`GITLAWB_PINATA_JWT` unset disables warm-tier *uploads*, though not the tail's
+cost: the post-push Pinata tail still takes a global pin permit and runs the full
+object-list re-derivation walk before the upload step returns empty, since its
+gate is the announce/walk state, not the JWT. Note the no-op applies to pinning
+only, not reads: the hot-tier read path (`ipfs_pin::cat`) returns an error rather
+than a no-op when `GITLAWB_IPFS_API` is unset, so a node that serves the
 encrypted-blob read endpoint needs Kubo configured.
 
 ## Configuration
@@ -43,7 +46,13 @@ Both tiers share a single global **pin admission semaphore**
 saturated, a pin loop waits for a slot instead of dropping the pin. Each batch is
 bounded by `PIN_BATCH_BUDGET` (120s) so the pin batch itself cannot hold a slot
 indefinitely. The Pinata tail re-derives its object list only *after* acquiring a
-slot, which bounds outstanding memory to O(refs) rather than O(pushes × objects).
+slot, which bounds *its* outstanding memory to O(refs) rather than
+O(pushes × objects) — but that bound is the warm tail's alone. A **hot-tier** pin
+loop takes an owned object list materialized by its caller *before* it waits for
+a slot, so every hot loop parked on a saturated pool is holding its full list:
+the hot side of the parked-list memory is O(pushes × objects), capped per repo by
+`EncryptInflight` but not across repos. Do not size a node's memory from the
+semaphore knob (README says the same).
 Note the budget covers the pin batch, not the preceding object-list re-derivation
 walk: that walk holds the slot too, and bounds only each child git process
 individually (no aggregate deadline).
@@ -51,7 +60,11 @@ individually (no aggregate deadline).
 De-duplication is per sink and best-effort, backed by the single `pinned_cids`
 table: the hot tier keys on its `cid`/`sha256_hex` rows and the warm tier on the
 nullable `pinata_cid` column, so later pushes normally skip objects whose
-successful pin is already recorded. The check-upload-record sequence is not atomic,
+successful pin is already recorded. The isolation is one-directional: a hot-only
+pin does not suppress the warm tier (`pinata_cid` stays null), but the hot tier's
+skip check is row *presence*, and a warm-tier pin inserts the row — so an object
+warm-pinned while `GITLAWB_IPFS_API` was unset is skipped by the hot tier after
+Kubo is configured, until something re-pins it. The check-upload-record sequence is not atomic,
 so concurrent post-push tasks for the same object, or a failure to record after a
 successful upload, can still cause a repeat upload attempt.
 

--- a/docs/STORAGE-AND-PINNING.md
+++ b/docs/STORAGE-AND-PINNING.md
@@ -1,0 +1,68 @@
+# Storage and pinning
+
+How a gitlawb node stores git objects and keeps them available. This documents
+the behavior implemented in `crates/gitlawb-node/src/ipfs_pin.rs` and
+`crates/gitlawb-node/src/pinata.rs`; it does not change any behavior.
+
+## Two-tier model
+
+After a push lands, new git objects are pinned to up to two independent sinks.
+Both are **opt-in and independent** — a node runs fine with neither, either, or
+both configured.
+
+| Tier | Sink | Module | Enabled by | Purpose |
+|------|------|--------|-----------|---------|
+| Hot  | Local Kubo (IPFS) | `ipfs_pin.rs` | `GITLAWB_IPFS_API` set | Node-local availability; the node is itself an IPFS peer |
+| Warm | Pinata (Filecoin-backed) | `pinata.rs` | `GITLAWB_PINATA_JWT` set | Off-node durability + public IPFS gateway reachability |
+
+If a sink's config value is empty, every call into that sink is a no-op — so
+leaving `GITLAWB_PINATA_JWT` unset simply disables the warm tier.
+
+## Configuration
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `GITLAWB_IPFS_API` | `""` (disabled) | Base URL of the local Kubo HTTP API, e.g. `http://127.0.0.1:5001` |
+| `GITLAWB_PINATA_JWT` | `""` (disabled) | Pinata bearer JWT enabling the warm tier |
+| `GITLAWB_PINATA_UPLOAD_URL` | `https://uploads.pinata.cloud/v3/files` | Pinata v3 upload endpoint |
+| `GITLAWB_MAX_CONCURRENT_PIN_TASKS` | `8` | Cap on concurrent post-push pin loops across all repos |
+
+## How pinning runs
+
+Pinning happens **after** a push is accepted, not on the push's critical path:
+
+- The **hot** tier pins inline in the post-push encrypt/pin task.
+- The **warm** (Pinata) tier runs in a spawned replication tail, so a slow or
+  unreachable Pinata never blocks the pusher.
+
+Both tiers share a single global **pin admission semaphore**
+(`max_concurrent_pin_tasks`). The pool **defers rather than sheds**: when it is
+saturated, a pin loop waits for a slot instead of dropping the pin. Each batch is
+bounded by `PIN_BATCH_BUDGET` (120s) so a single large or slow push cannot hold a
+slot indefinitely. The Pinata tail re-derives its object list only *after*
+acquiring a slot, which bounds outstanding memory to O(refs) rather than
+O(pushes × objects).
+
+De-duplication is per sink: the `pinned_cids` and `pinata_cids` tables record
+what each sink already holds, so re-pushing unchanged objects does no redundant
+upload.
+
+## Durability notes
+
+- With only the **hot** tier, availability depends on the node (and any IPFS
+  peers that have fetched the CIDs). If the node is down and no peer holds the
+  objects, they are unreachable until it returns.
+- The **warm** tier adds off-node durability via Pinata's Filecoin-backed
+  storage and makes objects reachable through the public IPFS gateway.
+- Running **both** gives a node-local hot copy plus an off-node warm copy.
+
+> The two sinks are currently invoked as separate call paths. Unifying them
+> behind a single pluggable backend interface (to add providers such as direct
+> Filecoin deals or self-hosted clusters without touching push logic) is tracked
+> separately.
+
+## See also
+
+- [RUN-A-NODE.md](RUN-A-NODE.md) — provisioning and running a node
+- `crates/gitlawb-node/src/ipfs_pin.rs` — hot-tier implementation
+- `crates/gitlawb-node/src/pinata.rs` — warm-tier implementation

--- a/docs/STORAGE-AND-PINNING.md
+++ b/docs/STORAGE-AND-PINNING.md
@@ -12,11 +12,14 @@ both configured.
 
 | Tier | Sink | Module | Enabled by | Purpose |
 |------|------|--------|-----------|---------|
-| Hot  | Local Kubo (IPFS) | `ipfs_pin.rs` | `GITLAWB_IPFS_API` set | Node-local availability; the node is itself an IPFS peer |
+| Hot  | Local Kubo (IPFS) | `ipfs_pin.rs` | `GITLAWB_IPFS_API` set | Node-local availability; the node is an HTTP client of a co-located Kubo daemon |
 | Warm | Pinata (Filecoin-backed) | `pinata.rs` | `GITLAWB_PINATA_JWT` set | Off-node durability + public IPFS gateway reachability |
 
-If a sink's config value is empty, every call into that sink is a no-op — so
-leaving `GITLAWB_PINATA_JWT` unset simply disables the warm tier.
+If a sink's config value is empty, its **pin** paths are no-ops — so leaving
+`GITLAWB_PINATA_JWT` unset simply disables warm-tier pinning. Note this applies to
+pinning only, not reads: the hot-tier read path (`ipfs_pin::cat`) returns an error
+rather than a no-op when `GITLAWB_IPFS_API` is unset, so a node that serves the
+encrypted-blob read endpoint needs Kubo configured.
 
 ## Configuration
 
@@ -38,16 +41,19 @@ Pinning happens **after** a push is accepted, not on the push's critical path:
 Both tiers share a single global **pin admission semaphore**
 (`max_concurrent_pin_tasks`). The pool **defers rather than sheds**: when it is
 saturated, a pin loop waits for a slot instead of dropping the pin. Each batch is
-bounded by `PIN_BATCH_BUDGET` (120s) so a single large or slow push cannot hold a
-slot indefinitely. The Pinata tail re-derives its object list only *after*
-acquiring a slot, which bounds outstanding memory to O(refs) rather than
-O(pushes × objects).
+bounded by `PIN_BATCH_BUDGET` (120s) so the pin batch itself cannot hold a slot
+indefinitely. The Pinata tail re-derives its object list only *after* acquiring a
+slot, which bounds outstanding memory to O(refs) rather than O(pushes × objects).
+Note the budget covers the pin batch, not the preceding object-list re-derivation
+walk: that walk holds the slot too, and bounds only each child git process
+individually (no aggregate deadline).
 
-De-duplication is per sink and best-effort: the `pinned_cids` and `pinata_cids`
-tables record what each sink already holds, so later pushes normally skip objects
-whose successful pin is already recorded. The check-upload-record sequence is not
-atomic, so concurrent post-push tasks for the same object, or a failure to record
-after a successful upload, can still cause a repeat upload attempt.
+De-duplication is per sink and best-effort, backed by the single `pinned_cids`
+table: the hot tier keys on its `cid`/`sha256_hex` rows and the warm tier on the
+nullable `pinata_cid` column, so later pushes normally skip objects whose
+successful pin is already recorded. The check-upload-record sequence is not atomic,
+so concurrent post-push tasks for the same object, or a failure to record after a
+successful upload, can still cause a repeat upload attempt.
 
 ## Durability notes
 


### PR DESCRIPTION
## Summary

Adds `docs/STORAGE-AND-PINNING.md` documenting how a node stores git objects and keeps them available. Docs only — no behavior change.

## Motivation & context

`RUN-A-NODE.md` covers provisioning, staking and rewards, but there's no doc on how a node actually stores git objects and keeps them available — a question that comes up often (e.g. "where is the data stored?"). No linked issue; docs-only addition.

## Kind of change

- [x] Docs

## What changed

Crate touched: none (docs only, `gitlawb-node` behavior described).

- New `docs/STORAGE-AND-PINNING.md` covering:
  - The two opt-in sinks: hot = local Kubo/IPFS (`ipfs_pin.rs`, `GITLAWB_IPFS_API`), warm = Pinata/Filecoin (`pinata.rs`, `GITLAWB_PINATA_JWT`).
  - Env vars and defaults.
  - Post-push execution off the critical path, the shared `max_concurrent_pin_tasks` admission semaphore (defers rather than sheds), `PIN_BATCH_BUDGET`, Pinata post-acquire re-derivation for O(refs) memory bounding, and per-sink best-effort de-duplication.

## How a reviewer can verify

Docs only; verify by reading against the referenced modules:

```sh
sed -n '1,80p' docs/STORAGE-AND-PINNING.md
grep -n "GITLAWB_IPFS_API\|GITLAWB_PINATA_JWT\|max_concurrent_pin_tasks" crates/gitlawb-node/src/config.rs
```

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally (N/A — docs only, no code changed)
- [x] New behavior is covered by tests (N/A — docs only)
- [x] `cargo fmt --all` and `cargo clippy` clean (N/A — docs only)
- [x] Commit titles use Conventional Commits (`docs(...)`)
- [x] Docs updated (this PR is the doc)
- [x] Checked existing PRs so this isn't a duplicate

## Notes for reviewers

- Sourced by reading `ipfs_pin.rs`, `pinata.rs`, `api/repos.rs`, and `config.rs`; happy to correct anything mischaracterized.
- Addressed CodeRabbit's note: de-dup wording now describes it as best-effort (check-upload-record is not atomic), not a zero-redundant-upload guarantee.
- Separate follow-up (not in this PR): the two sinks are invoked as hardcoded call paths with no shared backend interface — opened as a discussion issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing optional local IPFS and Pinata storage tiers for post-push Git object pinning.
  * Documented configuration, asynchronous processing, timeouts, deferred work, memory limits, deduplication, and durability characteristics.
  * Added a link to the new storage and pinning guide in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->