### PR TITLE
fix(attest): make verify_all lenient under RequireAll (#359)

### DIFF
--- a/crates/gitlawb-attest/src/verifier.rs
+++ b/crates/gitlawb-attest/src/verifier.rs
@@ -147,14 +147,19 @@ impl Registry {
     /// Verify a batch, then enforce `RequireAll`.
     ///
     /// Under [`Policy::RequireAll`] this never short-circuits: an attestation
-    /// that fails to verify — bad signature, cert-hash mismatch, malformed
-    /// payload, or a type with no verifier — is dropped from the result rather
-    /// than aborting the batch. Any third party can attach an attestation, so a
-    /// hard error here would let an unrelated `attacker/spam/v1` deny-of-service
-    /// the whole cert (the DoS vector the module docstring warns about). The
-    /// `required_types` check below is the real gate, and it only counts
-    /// `fully_verified` entries — so a required type represented solely by a
-    /// malformed attestation still fails with [`Error::RequiredMissing`].
+    /// that fails to verify — bad signature, cert-hash mismatch, or malformed
+    /// payload, the actual `Err` paths of [`Registry::verify`] — is dropped
+    /// from the result rather than aborting the batch. A valid attestation of
+    /// a type with NO registered verifier is not one of those: under
+    /// `RequireAll` it verifies to `Ok` with `fully_verified: false` and stays
+    /// in the result, preserving the distinction between *untrusted* and
+    /// *invalid* (see `require_all_is_lenient_on_unknown_types_in_the_batch`).
+    /// Any third party can attach an attestation, so a hard error here would
+    /// let an unrelated `attacker/spam/v1` deny-of-service the whole cert (the
+    /// DoS vector the module docstring warns about). The `required_types`
+    /// check below is the real gate, and it only counts `fully_verified`
+    /// entries — so a required type represented solely by a malformed
+    /// attestation still fails with [`Error::RequiredMissing`].
     ///
     /// Under `AcceptKnown` and `RejectUnknown` the batch stays strict: the
     /// first verification error is surfaced to the caller.
@@ -337,6 +342,38 @@ mod tests {
         assert!(verified
             .iter()
             .any(|v| v.type_ == "other/v1" && !v.fully_verified));
+    }
+
+    /// The strict policies must surface a batch member's verification error
+    /// through `verify_all`, not launder it into a partial result. This binds
+    /// the POLICY BOUNDARY itself: only the `RequireAll` arm may drop failing
+    /// entries, and an apparently harmless cleanup that applies its
+    /// `filter_map(Result::ok)` shape to the strict arms would silently turn
+    /// the fail-closed contracts into fail-open — with every per-attestation
+    /// `verify` test still green, because none of them go through the batch
+    /// path. The failing entry is a wrong-cert-hash attestation (signed over a
+    /// different hash than the batch expects), a genuine `Err` under every
+    /// policy.
+    #[test]
+    fn strict_policies_propagate_a_batch_members_error() {
+        let sk = fresh();
+        let cert_hash = sample_hash();
+        let mut wrong_hash = sample_hash();
+        wrong_hash[0] ^= 0xff;
+
+        for policy in [Policy::AcceptKnown, Policy::RejectUnknown] {
+            let mut reg = Registry::new().with_policy(policy);
+            reg.register(DemoVerifier);
+            let good = signed_demo(&sk, cert_hash, "ok");
+            let bad = signed_demo(&sk, wrong_hash, "ok");
+            let err = reg
+                .verify_all(&[good, bad], cert_hash)
+                .expect_err("a strict policy must fail the whole batch");
+            assert!(
+                matches!(err, Error::Signature(_) | Error::CertHashMismatch),
+                "expected the underlying verification error, got {err:?}"
+            );
+        }
     }
 
     /// A required type that is present but unverified (no verifier registered

--- a/crates/gitlawb-attest/src/verifier.rs
+++ b/crates/gitlawb-attest/src/verifier.rs
@@ -145,23 +145,43 @@ impl Registry {
     }
 
     /// Verify a batch, then enforce `RequireAll`.
+    ///
+    /// Under [`Policy::RequireAll`] this never short-circuits: an attestation
+    /// that fails to verify — bad signature, cert-hash mismatch, malformed
+    /// payload, or a type with no verifier — is dropped from the result rather
+    /// than aborting the batch. Any third party can attach an attestation, so a
+    /// hard error here would let an unrelated `attacker/spam/v1` deny-of-service
+    /// the whole cert (the DoS vector the module docstring warns about). The
+    /// `required_types` check below is the real gate, and it only counts
+    /// `fully_verified` entries — so a required type represented solely by a
+    /// malformed attestation still fails with [`Error::RequiredMissing`].
+    ///
+    /// Under `AcceptKnown` and `RejectUnknown` the batch stays strict: the
+    /// first verification error is surfaced to the caller.
     pub fn verify_all(
         &self,
         attestations: &[Attestation],
         expected_cert_hash: [u8; 32],
     ) -> Result<Vec<VerifiedAttestation>> {
-        let mut verified = Vec::with_capacity(attestations.len());
-        for a in attestations {
-            verified.push(self.verify(a, expected_cert_hash)?);
+        if self.policy != Policy::RequireAll {
+            let mut verified = Vec::with_capacity(attestations.len());
+            for a in attestations {
+                verified.push(self.verify(a, expected_cert_hash)?);
+            }
+            return Ok(verified);
         }
-        if self.policy == Policy::RequireAll {
-            for required in &self.required_types {
-                let present = verified
-                    .iter()
-                    .any(|v| &v.type_ == required && v.fully_verified);
-                if !present {
-                    return Err(Error::RequiredMissing(required.clone()));
-                }
+
+        // RequireAll: drop entries that fail to verify instead of aborting.
+        let verified: Vec<VerifiedAttestation> = attestations
+            .iter()
+            .filter_map(|a| self.verify(a, expected_cert_hash).ok())
+            .collect();
+        for required in &self.required_types {
+            let present = verified
+                .iter()
+                .any(|v| &v.type_ == required && v.fully_verified);
+            if !present {
+                return Err(Error::RequiredMissing(required.clone()));
             }
         }
         Ok(verified)
@@ -333,6 +353,65 @@ mod tests {
 
         let att = signed_demo(&sk, cert_hash, "ok");
         let err = reg.verify_all(&[att], cert_hash).unwrap_err();
+        assert!(matches!(err, Error::RequiredMissing(t) if t == "demo/v1"));
+    }
+
+    /// A cert-hash that does not match `sample_hash()`, so an attestation
+    /// signed against it fails `verify_signature` when the batch is checked
+    /// against `sample_hash()`.
+    fn other_hash() -> [u8; 32] {
+        let mut h = sample_hash();
+        h[0] ^= 0xff;
+        h
+    }
+
+    /// Under `RequireAll`, a malformed attestation (here: signed against the
+    /// wrong cert hash, so it fails signature verification) attached alongside a
+    /// valid required one must not abort the batch. The junk is dropped and the
+    /// cert still verifies. Before the fix, `verify_all` propagated the error
+    /// via `?` and the whole batch failed — the DoS vector the docstring warns
+    /// about.
+    #[test]
+    fn require_all_drops_a_malformed_extra_and_still_accepts() {
+        let sk = fresh();
+        let cert_hash = sample_hash();
+        let mut reg = Registry::new()
+            .with_policy(Policy::RequireAll)
+            .require_types(["demo/v1"]);
+        reg.register(DemoVerifier);
+
+        // Signed against `other_hash()`, so it will not verify under `cert_hash`.
+        let malformed = signed_demo(&sk, other_hash(), "boom");
+        let real = signed_demo(&sk, cert_hash, "ok");
+
+        let verified = reg
+            .verify_all(&[malformed, real], cert_hash)
+            .expect("a malformed extra must not abort the batch under RequireAll");
+        assert_eq!(verified.len(), 1, "the malformed entry should be dropped");
+        assert!(verified
+            .iter()
+            .any(|v| v.type_ == "demo/v1" && v.fully_verified));
+    }
+
+    /// Leniency must not open a hole: if the *only* attestation of a required
+    /// type is malformed, dropping it leaves the required type absent and
+    /// `verify_all` must still fail with `RequiredMissing`. Guards against a fix
+    /// that skips errors so eagerly it lets an unverified required type pass.
+    #[test]
+    fn require_all_rejects_when_only_a_malformed_required_type_is_present() {
+        let sk = fresh();
+        let cert_hash = sample_hash();
+        let mut reg = Registry::new()
+            .with_policy(Policy::RequireAll)
+            .require_types(["demo/v1"]);
+        reg.register(DemoVerifier);
+
+        // The sole demo/v1 is bound to the wrong cert hash → fails verification.
+        let malformed_required = signed_demo(&sk, other_hash(), "ok");
+
+        let err = reg
+            .verify_all(&[malformed_required], cert_hash)
+            .unwrap_err();
         assert!(matches!(err, Error::RequiredMissing(t) if t == "demo/v1"));
     }
 


### PR DESCRIPTION
## Summary

`Registry::verify_all` aborted the whole batch on any per-attestation error, violating its documented `RequireAll` leniency. Under `Policy::RequireAll`, a single malformed or unknown attestation now drops out of the result instead of failing the batch. Fixes #359.

## Motivation & context

Closes #359

The module docstring promises that under `RequireAll` the registry "never short-circuits on unknown types — any attestation can be attached by any third party, so blocking the cert because an attacker added an unrelated `attacker/spam/v1` would be a denial-of-service vector." But `verify_all` propagated every error via `?`:

```rust
for a in attestations {
    verified.push(self.verify(a, expected_cert_hash)?);
}
```

So a bad signature, cert-hash mismatch, or malformed payload on *any* attached attestation aborted the entire batch — exactly the DoS the docstring warns about.

## Kind of change

- [x] Bug fix

## What changed

Crate touched: `gitlawb-attest` (`src/verifier.rs`).

- Under `Policy::RequireAll`, `verify_all` now drops entries that fail to verify (`filter_map(.ok())`) instead of aborting. The `required_types` presence check remains the gate, and it only counts `fully_verified` entries — so a required type present **only** as a malformed attestation still fails with `RequiredMissing`. Leniency does not open a hole.
- `AcceptKnown` and `RejectUnknown` are unchanged: they stay strict and surface the first error.
- Expanded the `verify_all` docstring to state the per-policy contract.

## How a reviewer can verify

```sh
cargo test -p gitlawb-attest --lib verifier
cargo clippy -p gitlawb-attest --all-targets -- -D warnings
```

Two new tests:
- `require_all_drops_a_malformed_extra_and_still_accepts` — a malformed extra (signed against the wrong cert hash) alongside a valid required attestation no longer aborts; the junk is dropped and the cert verifies. Fails on the pre-fix code.
- `require_all_rejects_when_only_a_malformed_required_type_is_present` — when the sole copy of a required type is malformed, `verify_all` still returns `RequiredMissing`.

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally (ran `gitlawb-attest`: 52 tests pass)
- [x] New behavior is covered by tests
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`fix(attest): ...`)
- [x] Docs / `.env.example` updated if behavior or config changed (N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Protocol & signing impact

- [x] Touches DID / `did:key`, Ed25519 / RFC 9421 signatures, UCAN, ref certs, or P2P wire formats — attestation verification for ref-update certs. **No wire-format or signature-scheme change**; only the batch error-handling policy under `RequireAll`. Behavior for `AcceptKnown`/`RejectUnknown` is unchanged.
- [x] Backward-compatible with existing nodes and previously signed history (strictly more permissive under `RequireAll`, and only for attestations that would otherwise have hard-failed the batch).

## Notes for reviewers

- #349 tracks the same short-circuit pattern in `gitlawb-core`'s `cert.rs`; deliberately out of scope here to keep this PR to one crate/one change. Happy to follow up on that separately.
