### PR TITLE
fix(core): ignore invalid signatures in satisfies_threshold (#349)

### DIFF
--- a/crates/gitlawb-core/src/cert.rs
+++ b/crates/gitlawb-core/src/cert.rs
@@ -108,9 +108,15 @@ impl RefUpdateCert {
         Ok(())
     }
 
-    /// Verify all signatures on this certificate.
+    /// Verify all signatures on this certificate, failing closed.
     ///
-    /// Returns the list of DIDs whose signatures are valid.
+    /// On success returns the list of DIDs whose signatures are valid. This is
+    /// strict: it returns an error if *any* signature entry is malformed or
+    /// invalid. Because signature entries live outside the signed body (anyone
+    /// can append one without key material), do not use this to make a
+    /// threshold decision on an untrusted certificate — a single appended junk
+    /// entry would reject the whole cert. Use [`Self::satisfies_threshold`],
+    /// which ignores invalid entries and counts only the valid signers.
     pub fn verify_all(&self) -> Result<Vec<Did>> {
         use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
         let signing_bytes = self.body.to_signing_bytes()?;
@@ -135,13 +141,48 @@ impl RefUpdateCert {
         Ok(valid)
     }
 
+    /// The DIDs whose signature entries validate, skipping any that are
+    /// malformed or invalid rather than failing.
+    ///
+    /// Signature entries are appended outside the signed body, so any third
+    /// party can attach a junk entry without key material. Counting only the
+    /// entries that actually verify — instead of short-circuiting on the first
+    /// bad one, as [`Self::verify_all`] does — prevents that from becoming a
+    /// denial-of-service on an otherwise valid certificate (#349). A forged
+    /// entry that names a real maintainer DID but carries a bad signature is
+    /// skipped, so it cannot inflate the count either.
+    fn valid_signers(&self) -> Result<Vec<Did>> {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        let signing_bytes = self.body.to_signing_bytes()?;
+        let mut valid = Vec::new();
+
+        for cert_sig in &self.signatures {
+            let Ok(vk) = cert_sig.signer.to_verifying_key() else {
+                continue;
+            };
+            let Ok(sig_bytes_vec) = URL_SAFE_NO_PAD.decode(&cert_sig.sig) else {
+                continue;
+            };
+            let Ok(sig_bytes) = <[u8; 64]>::try_from(sig_bytes_vec) else {
+                continue;
+            };
+            if verify(&vk, &signing_bytes, &sig_bytes).is_ok() {
+                valid.push(cert_sig.signer.clone());
+            }
+        }
+
+        Ok(valid)
+    }
+
     /// Check if this certificate satisfies a threshold of valid signatures
     /// from the provided set of authorized maintainer DIDs.
     ///
     /// Counts distinct signer DIDs, not signature entries: a repeated
-    /// signature from the same maintainer counts once.
+    /// signature from the same maintainer counts once. Malformed or invalid
+    /// signature entries are ignored (see [`Self::valid_signers`]), so an
+    /// attacker cannot deny a valid cert by appending junk signatures.
     pub fn satisfies_threshold(&self, maintainers: &[Did], threshold: usize) -> Result<bool> {
-        let valid = self.verify_all()?;
+        let valid = self.valid_signers()?;
         let distinct_signers: HashSet<&Did> =
             valid.iter().filter(|d| maintainers.contains(d)).collect();
         Ok(distinct_signers.len() >= threshold)
@@ -375,6 +416,70 @@ mod tests {
         // Two signature entries but a single distinct signer must not
         // satisfy a 2-of-3 threshold.
         assert!(!cert.satisfies_threshold(&maintainers, 2).unwrap());
+    }
+
+    /// An attacker can append junk signature entries to a cert (they live
+    /// outside the signed body, so no key material is needed). `satisfies_threshold`
+    /// must ignore them and still count the real signers — before the fix,
+    /// `verify_all`'s `?` on the junk made the whole check error out, denying a
+    /// valid 2-of-2 cert.
+    #[test]
+    fn satisfies_threshold_ignores_appended_junk_signatures() {
+        let kp1 = Keypair::generate();
+        let kp2 = Keypair::generate();
+        let mut cert = RefUpdateCert::new(
+            kp1.did(),
+            "refs/heads/main".to_string(),
+            dummy_hash('0'),
+            dummy_hash('a'),
+            1,
+            &kp1,
+        )
+        .unwrap();
+        cert.countersign(&kp2).unwrap();
+
+        // Append entries that are unparseable / invalid in different ways.
+        cert.signatures.push(CertSignature {
+            signer: kp1.did(),
+            sig: "!!!not-base64!!!".to_string(),
+        });
+        // Valid base64 but only 3 bytes — fails the 64-byte length check.
+        cert.signatures.push(CertSignature {
+            signer: kp2.did(),
+            sig: "AAAA".to_string(),
+        });
+
+        let maintainers = vec![kp1.did(), kp2.did()];
+        assert!(cert.satisfies_threshold(&maintainers, 2).unwrap());
+    }
+
+    /// A junk entry that names a real maintainer DID but carries a signature
+    /// that does not verify must not be counted — otherwise appending garbage
+    /// under a maintainer's DID could forge a threshold.
+    #[test]
+    fn satisfies_threshold_does_not_count_a_forged_maintainer_signature() {
+        let kp1 = Keypair::generate();
+        let kp2 = Keypair::generate();
+        let mut cert = RefUpdateCert::new(
+            kp1.did(),
+            "refs/heads/main".to_string(),
+            dummy_hash('0'),
+            dummy_hash('a'),
+            1,
+            &kp1,
+        )
+        .unwrap();
+        // Well-formed 64-byte signature from kp2, but over unrelated bytes, so
+        // it fails verification against the cert body.
+        cert.signatures.push(CertSignature {
+            signer: kp2.did(),
+            sig: kp2.sign_b64(b"unrelated bytes"),
+        });
+
+        let maintainers = vec![kp1.did(), kp2.did()];
+        // Only kp1 actually signed the body: 2-of-2 must fail, 1-of-2 holds.
+        assert!(!cert.satisfies_threshold(&maintainers, 2).unwrap());
+        assert!(cert.satisfies_threshold(&maintainers, 1).unwrap());
     }
 
     #[test]

--- a/crates/gitlawb-core/src/cert.rs
+++ b/crates/gitlawb-core/src/cert.rs
@@ -19,6 +19,27 @@ use crate::{Error, Result};
 /// The certificate type discriminant. Always `"gitlawb/ref-update/v1"`.
 pub const CERT_TYPE: &str = "gitlawb/ref-update/v1";
 
+/// Exact url-safe unpadded base64 length of a 64-byte Ed25519 signature.
+/// Anything longer cannot decode to a valid signature, so the tolerant
+/// threshold scan refuses to base64-decode it at all — the length gate is what
+/// keeps an attacker-sized sig string from costing allocation before the
+/// signature is rejected.
+const ENCODED_SIG_LEN: usize = 86;
+
+/// Hard ceiling on signature entries a certificate may carry into the
+/// tolerant threshold scan. A legitimate certificate holds one entry per
+/// maintainer (a re-sign after key rotation may briefly leave a second), so
+/// this is far above any real signer set, while turning the scan's worst case
+/// from "one curve verification per attacker-appended entry" into a small
+/// constant. Rejection is loud (`Err`), not a silent prefix scan: scanning
+/// only the first N entries would let junk placed ahead of the real
+/// signatures starve them out of the window, which is the #349 denial again
+/// in positional form. An attacker positioned to inflate the list past this
+/// ceiling can already suppress the certificate outright, so the loud
+/// rejection concedes nothing that was not already conceded to that
+/// attacker.
+const MAX_SIGNATURE_ENTRIES: usize = 64;
+
 /// A signature on a ref-update certificate.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CertSignature {
@@ -141,22 +162,51 @@ impl RefUpdateCert {
         Ok(valid)
     }
 
-    /// The DIDs whose signature entries validate, skipping any that are
-    /// malformed or invalid rather than failing.
+    /// Check if this certificate satisfies a threshold of valid signatures
+    /// from the provided set of authorized maintainer DIDs.
     ///
-    /// Signature entries are appended outside the signed body, so any third
-    /// party can attach a junk entry without key material. Counting only the
-    /// entries that actually verify — instead of short-circuiting on the first
-    /// bad one, as [`Self::verify_all`] does — prevents that from becoming a
-    /// denial-of-service on an otherwise valid certificate (#349). A forged
-    /// entry that names a real maintainer DID but carries a bad signature is
-    /// skipped, so it cannot inflate the count either.
-    fn valid_signers(&self) -> Result<Vec<Did>> {
+    /// Counts distinct signer DIDs, not signature entries: a repeated
+    /// signature from the same maintainer counts once. Malformed and invalid
+    /// signature entries are skipped, not fatal — entries live outside the
+    /// signed body, so any third party can append junk without key material,
+    /// and short-circuiting on the first bad one (as [`Self::verify_all`]
+    /// does) would let that junk deny an otherwise valid certificate (#349).
+    ///
+    /// Tolerance must not become an unbounded verification path (#349 review
+    /// round 2): entries are attacker-extensible, so the work done for them is
+    /// bounded BEFORE the loop, not discovered inside it:
+    ///
+    /// - a list over [`MAX_SIGNATURE_ENTRIES`] is rejected outright (see the
+    ///   constant for why loud rejection beats a silent prefix scan);
+    /// - an encoded signature is length-gated before base64 work — a 64-byte
+    ///   Ed25519 signature is exactly [`ENCODED_SIG_LEN`] characters in
+    ///   url-safe unpadded base64, so an oversized blob never allocates;
+    /// - entries whose signer is not in `maintainers`, or is already counted,
+    ///   are skipped on a string compare, before any decode or curve work —
+    ///   so even within the cap, junk naming strangers costs no crypto;
+    /// - the scan returns as soon as the threshold is met.
+    pub fn satisfies_threshold(&self, maintainers: &[Did], threshold: usize) -> Result<bool> {
         use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        if self.signatures.len() > MAX_SIGNATURE_ENTRIES {
+            return Err(Error::RefCert(format!(
+                "certificate carries {} signature entries (max {})",
+                self.signatures.len(),
+                MAX_SIGNATURE_ENTRIES
+            )));
+        }
+        if threshold == 0 {
+            return Ok(true);
+        }
         let signing_bytes = self.body.to_signing_bytes()?;
-        let mut valid = Vec::new();
+        let mut counted: HashSet<&Did> = HashSet::new();
 
         for cert_sig in &self.signatures {
+            if counted.contains(&cert_sig.signer) || !maintainers.contains(&cert_sig.signer) {
+                continue;
+            }
+            if cert_sig.sig.len() != ENCODED_SIG_LEN {
+                continue;
+            }
             let Ok(vk) = cert_sig.signer.to_verifying_key() else {
                 continue;
             };
@@ -167,25 +217,14 @@ impl RefUpdateCert {
                 continue;
             };
             if verify(&vk, &signing_bytes, &sig_bytes).is_ok() {
-                valid.push(cert_sig.signer.clone());
+                counted.insert(&cert_sig.signer);
+                if counted.len() >= threshold {
+                    return Ok(true);
+                }
             }
         }
 
-        Ok(valid)
-    }
-
-    /// Check if this certificate satisfies a threshold of valid signatures
-    /// from the provided set of authorized maintainer DIDs.
-    ///
-    /// Counts distinct signer DIDs, not signature entries: a repeated
-    /// signature from the same maintainer counts once. Malformed or invalid
-    /// signature entries are ignored (see [`Self::valid_signers`]), so an
-    /// attacker cannot deny a valid cert by appending junk signatures.
-    pub fn satisfies_threshold(&self, maintainers: &[Did], threshold: usize) -> Result<bool> {
-        let valid = self.valid_signers()?;
-        let distinct_signers: HashSet<&Did> =
-            valid.iter().filter(|d| maintainers.contains(d)).collect();
-        Ok(distinct_signers.len() >= threshold)
+        Ok(counted.len() >= threshold)
     }
 
     /// Validate the certificate structure (not signatures).
@@ -480,6 +519,66 @@ mod tests {
         // Only kp1 actually signed the body: 2-of-2 must fail, 1-of-2 holds.
         assert!(!cert.satisfies_threshold(&maintainers, 2).unwrap());
         assert!(cert.satisfies_threshold(&maintainers, 1).unwrap());
+    }
+
+    /// The tolerant scan must not be an unbounded verification path: a list
+    /// past MAX_SIGNATURE_ENTRIES is rejected loudly before any curve work,
+    /// while a list at the cap still verifies normally.
+    #[test]
+    fn satisfies_threshold_rejects_an_oversized_signature_list() {
+        let kp = Keypair::generate();
+        let mut cert = RefUpdateCert::new(
+            kp.did(),
+            "refs/heads/main".to_string(),
+            dummy_hash('0'),
+            dummy_hash('a'),
+            1,
+            &kp,
+        )
+        .unwrap();
+        let junk = || CertSignature {
+            signer: Keypair::generate().did(),
+            sig: "AAAA".to_string(),
+        };
+        while cert.signatures.len() < MAX_SIGNATURE_ENTRIES {
+            cert.signatures.push(junk());
+        }
+        let maintainers = vec![kp.did()];
+        // At the cap: still fine, the real signature counts.
+        assert!(cert.satisfies_threshold(&maintainers, 1).unwrap());
+        // One past the cap: loud rejection, no tolerant scan.
+        cert.signatures.push(junk());
+        let err = cert.satisfies_threshold(&maintainers, 1).unwrap_err();
+        assert!(err.to_string().contains("signature entries"));
+    }
+
+    /// An entry whose encoded signature is not the exact base64 length of a
+    /// 64-byte Ed25519 signature is skipped before any base64 decode — an
+    /// attacker-sized sig string must cost neither allocation nor curve work,
+    /// and must not affect the verdict.
+    #[test]
+    fn satisfies_threshold_skips_an_oversized_encoded_signature() {
+        let kp1 = Keypair::generate();
+        let kp2 = Keypair::generate();
+        let mut cert = RefUpdateCert::new(
+            kp1.did(),
+            "refs/heads/main".to_string(),
+            dummy_hash('0'),
+            dummy_hash('a'),
+            1,
+            &kp1,
+        )
+        .unwrap();
+        // Names a real maintainer, valid base64 alphabet, but megabytes long:
+        // the length gate must refuse it without decoding.
+        cert.signatures.push(CertSignature {
+            signer: kp2.did(),
+            sig: "A".repeat(2 * 1024 * 1024),
+        });
+
+        let maintainers = vec![kp1.did(), kp2.did()];
+        assert!(cert.satisfies_threshold(&maintainers, 1).unwrap());
+        assert!(!cert.satisfies_threshold(&maintainers, 2).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`RefUpdateCert::satisfies_threshold` failed closed on a single malformed or invalid signature entry, so appending junk signatures denied an otherwise valid certificate. It now ignores invalid entries and counts only the valid signers. Fixes #349.

## Motivation & context

Closes #349

`satisfies_threshold` delegated to `verify_all`, which uses `?` on four fallible steps per entry (DID → key, base64 decode, 64-byte length, signature verify). Signature entries live outside the signed body (`RefUpdateBody::to_signing_bytes`), so any third party can append an entry with **no key material**. One junk entry made the whole threshold check error out — a denial-of-service on a cert that actually has enough valid signatures.

Follows the maintainer guidance on the issue: fix it in `satisfies_threshold`, not `verify_all`, to preserve the public API (and its `tampered_signature_fails_verify_all` test). This mirrors the sibling handling in `gitlawb-attest`'s verifier.

## Kind of change

- [x] Bug fix

## What changed

Crate touched: `gitlawb-core` (`src/cert.rs`).

- Added a private `valid_signers()` helper that iterates signature entries and skips any that fail to resolve a key, decode, reach 64 bytes, or verify — returning only the DIDs that actually validate.
- `satisfies_threshold` now counts distinct valid signers from `valid_signers()` instead of `verify_all`. A forged entry naming a real maintainer DID with a bad signature is skipped, so it cannot inflate the count either.
- `verify_all` is unchanged (still fail-closed); expanded its docstring to state it is strict and to point threshold callers at `satisfies_threshold`.

## How a reviewer can verify

```sh
cargo test -p gitlawb-core --lib cert
cargo clippy -p gitlawb-core --all-targets -- -D warnings
```

Two new tests:
- `satisfies_threshold_ignores_appended_junk_signatures` — a valid 2-of-2 cert with appended unparseable/short entries still satisfies a 2-of-2 threshold. Fails on the pre-fix code (the junk made `verify_all` error).
- `satisfies_threshold_does_not_count_a_forged_maintainer_signature` — an appended entry under a real maintainer DID but with a non-verifying signature is not counted: 2-of-2 fails, 1-of-2 holds.

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally (ran `gitlawb-core`: 89 tests pass)
- [x] New behavior is covered by tests
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`fix(core): ...`)
- [x] Docs / `.env.example` updated if behavior or config changed (N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Protocol & signing impact

- [x] Touches DID / `did:key`, Ed25519 / RFC 9421 signatures, UCAN, ref certs, or P2P wire formats — ref-update cert threshold verification. **No wire-format or signature-scheme change.**
- [x] Backward-compatible with existing nodes and previously signed history: for a cert with only valid signatures, behavior is identical; the change only affects how appended *invalid* entries are treated (ignored instead of erroring). Fails closed on forged entries (they are not counted).

## Notes for reviewers

- Companion to #365, which fixes the same short-circuit pattern in `gitlawb-attest`'s `verify_all`. Kept as a separate PR per crate.
