### PR TITLE
fix(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3542,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## What breaks

`cargo audit` fails on every branch as of today:

```
Crate:     h2
Title:     h2 unbounded empty DATA frames
ID:        RUSTSEC-2026-0258
Solution:  Upgrade to >=0.4.16
error: 1 vulnerability found!
```

The advisory was published after `main`'s last green run, so the `SUCCESS` ticks currently showing on open PRs are stale cached results, not evidence. Anything that re-runs CI goes red until this lands — #331 already has.

`h2` arrives transitively via `hyper`, so there is no manifest change. The lockfile is the entire fix.

## Why this is hand-edited

`cargo update -p h2` on my machine produced the h2 bump **plus nine unrelated rewrites**, all downgrades:

| crate | from | to | pulled in by |
|---|---|---|---|
| `syn` | 2.0.117 | 1.0.109 | `data-encoding-macro-internal` |
| `windows-sys` | 0.61.2 | 0.52.0 | `errno` (×3) |
| `socket2` | 0.6.3 | 0.5.10 | (×3) |

`--precise 0.4.16` produced the identical set, so it is not collateral re-resolution from an unpinned update — it is local crates.io index drift against whatever generated `main`'s lockfile. Those downgrades have nothing to do with the advisory and do not belong in a security bump, so this commit changes only h2's `version` and `checksum` lines.

That `cargo check --locked` accepts the result is the proof that 0.4.16 introduces no dependency changes of its own — a hand-edited lockfile that got that wrong would fail `--locked` immediately.

Worth someone re-running `cargo update` on a Linux box to see whether those nine entries are real drift in `main`'s lockfile or an artifact of my toolchain. Either way it is a separate question from this fix.

## Verification

- `cargo check --locked --workspace` — exit 0
- `cargo tree --locked -p h2` — resolves `h2 v0.4.16`
- Full suite on a branch carrying the Windows test-gating fix: `gitlawb-core` 104, `gl` 328, `git-remote-gitlawb` 58, all passing

`cargo check --locked --workspace --all-targets` cannot run from `main` on Windows — the unix-only test code does not compile there, which is exactly what #330's first commit fixes. Linux CI covers that path.

## Scope

Deliberately kept to the advisory alone rather than folded into #331, so it can land on its own and unblock every open PR at once.
