### PR TITLE
fix(api): Use lowercase header name in list_repos

### DIFF
--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -369,7 +369,7 @@ pub async fn list_repos(
         .collect();
     let mut response = Json(body).into_response();
     response.headers_mut().insert(
-        "X-Total-Count",
+        "x-total-count",
         HeaderValue::from_str(&total.to_string()).unwrap_or(HeaderValue::from_static("0")),
     );
     Ok(response)


### PR DESCRIPTION
## Summary
Fixes an Axum runtime panic in `list_repos` caused by inserting an uppercase ASCII string literal into the response header map.

## Changes
- `crates/gitlawb-node/src/api/repos.rs`: Renamed `"X-Total-Count"` to `"x-total-count"`.

## Test plan
- `cargo check -p gitlawb-node`
- `git diff HEAD --check`

Fixes #373
