### PR TITLE
fix(gl): read whoami error bodies through CappedBody.text

### DIFF
--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -6260,6 +6260,9 @@ mod tests {
         // Long enough that the git-service timeout is never what ends this push; the
         // disconnect is.
         cfg.git_service_timeout_secs = 600;
+        // Lock-path test, not owner-push authorization: pin off so the default-on gate
+        // does not reject the proof DID before receive-pack runs.
+        cfg.enforce_owner_push = false;
         state.config = std::sync::Arc::new(cfg);
         state
             .db
@@ -6430,6 +6433,9 @@ mod tests {
             None,
             crate::git::repo_store::build_lock_pool(&pool, 4, std::time::Duration::from_secs(5)),
         );
+        let mut cfg = (*state.config).clone();
+        cfg.enforce_owner_push = false;
+        state.config = std::sync::Arc::new(cfg);
         state
             .db
             .upsert_mirror_repo(owner, name, "/tmp/z6succ-sc1", None, false)
@@ -6516,6 +6522,9 @@ mod tests {
         let owner = "z6lockpool";
         let name = "lp1";
         let mut state = crate::test_support::test_state(pool.clone()).await;
+        let mut cfg = (*state.config).clone();
+        cfg.enforce_owner_push = false;
+        state.config = std::sync::Arc::new(cfg);
         // One lock-pool connection, short checkout timeout so the exhaustion surfaces
         // promptly rather than at the handler's own acquire deadline.
         state.repo_store = crate::git::repo_store::RepoStore::new(

--- a/crates/gl/src/whoami.rs
+++ b/crates/gl/src/whoami.rs
@@ -60,7 +60,7 @@ pub(crate) async fn run_to_writer(args: WhoamiArgs, w: &mut impl std::io::Write)
             }
             Ok(resp) => {
                 let status = resp.status();
-                let raw = read_body_capped(resp, 8 * 1024).await;
+                let raw = read_body_capped(resp, 8 * 1024).await.text;
                 let msg = serde_json::from_str::<Value>(&raw)
                     .ok()
                     .and_then(|v| {


### PR DESCRIPTION
## Summary

Fix the `gl` compile break on `main` by reading `.text` from `read_body_capped`'s `CappedBody` in `whoami`, and pin `enforce_owner_push` off in three receive-pack lock tests that use non-owner proof DIDs.

## Motivation & context

`main` is red (#380). `#173` changed `read_body_capped` to return `CappedBody`; `peer.rs`, `sync.rs`, and `ipfs_cmd.rs` were updated, but `#223` merged whoami error handling that still treated the return as a bare `String`.

Once compile is fixed, CI also exposed three `#173` lock-path tests that inherit the new default-on owner-push gate and fail before receive-pack runs.

Closes #380

## Kind of change

- [x] Bug fix
- [ ] Feature (N/A)
- [ ] Security fix (N/A)
- [ ] Docs (N/A)
- [x] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

- `crates/gl/src/whoami.rs`: use `read_body_capped(...).await.text` on the non-404 error path, matching `peer.rs` and `sync.rs`.
- `crates/gitlawb-node/src/api/repos.rs`: set `enforce_owner_push = false` in the three receive-pack lock tests (disconnect hold, success release, lock-pool exhaustion).

## How a reviewer can verify

```sh
cargo check --workspace --all-targets
cargo test -p gl whoami
cargo test -p gitlawb-node --bin gitlawb-node receive_pack_success_reclaims
cargo test -p gitlawb-node --bin gitlawb-node receive_pack_disconnect_holds
cargo test -p gitlawb-node --bin gitlawb-node receive_pack_lock_pool
```

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally
- [x] New behavior is covered by tests (required for fixes)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`feat(...)`, `fix(...)`, `docs(...)`)
- [x] Docs / `.env.example` updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Protocol & signing impact

N/A (client error-display path only; no wire or signing change).

- [ ] Touches DID / `did:key`, Ed25519 / RFC 9421 signatures, UCAN, ref certs, or P2P wire formats
- [ ] Discussed in an issue before implementation
- [ ] Backward-compatible with existing nodes and previously signed history

## Notes for reviewers

Semantic merge gap from landing `#173` and `#223` without a conflict in the whoami call site. The test pins are config-only: owner-push authorization is covered elsewhere (`enforced_owner_push_refuses_a_signed_non_owner`, parser default test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unsuccessful responses by displaying relevant response details more reliably.
  * Lock, release, and capacity operations now provide more consistent behavior when processing valid requests, avoiding unrelated authorization interference.
* **Tests**
  * Expanded coverage for lock and push-related workflows to help ensure expected behavior remains reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->