### PR TITLE
fix(node): scope the refs listing by the canonical repo slug

### DIFF
--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -2886,10 +2886,21 @@ pub async fn list_refs(
     auth: Option<Extension<AuthenticatedDid>>,
 ) -> Result<Json<serde_json::Value>> {
     let caller = auth.as_ref().map(|e| e.0 .0.as_str());
-    let (_record, _rules) =
+    let (record, _rules) =
         crate::api::authorize_repo_read(&state, &owner, &repo, caller, "/").await?;
 
-    let repo_slug = format!("{owner}/{repo}");
+    // Build the filter from the canonical stored slug, NOT from the raw path
+    // segments. `branch_cids.repo` is written as
+    // `{normalize_owner_key(owner_did)}/{name}` (the push path builds the same
+    // slug before calling `upsert_branch_cid`), and
+    // `get_repo` resolves both `did:key:zX` and bare `zX` to the same record, so
+    // a request in the full-DID form authorizes and then matches zero rows,
+    // returning an empty page with a 200.
+    let repo_slug = format!(
+        "{}/{}",
+        crate::db::normalize_owner_key(&record.owner_did),
+        record.name
+    );
     let refs = state.db.list_branch_cids(&repo_slug).await?;
 
     Ok(Json(

--- a/crates/gitlawb-node/src/test_support.rs
+++ b/crates/gitlawb-node/src/test_support.rs
@@ -206,6 +206,136 @@ mod tests {
         }
     }
 
+    /// `list_refs` must resolve both owner-DID forms to the SAME refs.
+    /// `branch_cids.repo` is written as `{normalize_owner_key(owner_did)}/{name}`
+    /// (`api/repos.rs:2643` -> `:2754`), and `get_repo` resolves `did:key:zX` and
+    /// bare `zX` to one repo, so both path forms authorize. Reading the table with
+    /// the raw path segments instead of the canonical slug returns an empty page
+    /// with a 200, which is a denial rendered as success. The second repo pins the
+    /// other direction: the filter must not widen to another owner's refs.
+    #[sqlx::test]
+    async fn list_refs_resolves_both_owner_did_forms_to_the_canonical_slug(pool: PgPool) {
+        let owner_did = "did:key:zREFSCANON";
+        let other_did = "did:key:zREFSOTHER";
+        let state = test_state(pool).await;
+
+        for did in [owner_did, other_did] {
+            let mut repo = seed_repo(did, "refs-canon");
+            repo.is_public = true;
+            // Same repo name under two owners, so the name-derived disk_path
+            // from the helper would collide on its unique constraint.
+            repo.disk_path = format!("/tmp/refs-canon-{}", crate::db::normalize_owner_key(did));
+            state.db.create_repo(&repo).await.expect("seed repo");
+            // Exactly the slug the production push path writes.
+            let slug = format!("{}/{}", crate::db::normalize_owner_key(did), "refs-canon");
+            let cid = format!("bafy{}", crate::db::normalize_owner_key(did));
+            state
+                .db
+                .upsert_branch_cid(
+                    &slug,
+                    "refs/heads/main",
+                    &"1".repeat(64),
+                    &cid,
+                    "did:key:zNODE",
+                )
+                .await
+                .expect("seed branch cid");
+        }
+
+        async fn body_for(state: &crate::state::AppState, owner: &str) -> String {
+            let router = crate::server::build_router(state.clone());
+            let resp = router
+                .oneshot(
+                    Request::builder()
+                        .method(Method::GET)
+                        .uri(format!("/api/v1/repos/{owner}/refs-canon/refs"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "both owner-DID forms resolve to the same repo, so both must authorize"
+            );
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            String::from_utf8_lossy(&bytes).into_owned()
+        }
+
+        for owner in ["zREFSCANON", "did:key:zREFSCANON"] {
+            let body = body_for(&state, owner).await;
+            assert!(
+                body.contains("bafyzREFSCANON"),
+                "?owner={owner} must return the ref written under the canonical slug, \
+                 not an empty page with a 200. body was: {body}"
+            );
+            assert!(
+                !body.contains("bafyzREFSOTHER"),
+                "?owner={owner} must not return another owner's refs. body was: {body}"
+            );
+        }
+    }
+
+    /// The read gate on `list_refs`, driven in the deny direction. Without this
+    /// the slug regression above proves only that the query key is right: every
+    /// repo it seeds is public, so deleting `authorize_repo_read` outright leaves
+    /// it green. A private repo must answer an anonymous caller with the same 404
+    /// a missing repo gets, and must not put a CID in the body on the way out.
+    #[sqlx::test]
+    async fn list_refs_denies_an_anonymous_caller_on_a_private_repo(pool: PgPool) {
+        let owner_did = "did:key:zREFSPRIV";
+        let state = test_state(pool).await;
+
+        let mut repo = seed_repo(owner_did, "refs-private");
+        repo.is_public = false;
+        state.db.create_repo(&repo).await.expect("seed repo");
+        state
+            .db
+            .upsert_branch_cid(
+                &format!(
+                    "{}/{}",
+                    crate::db::normalize_owner_key(owner_did),
+                    "refs-private"
+                ),
+                "refs/heads/main",
+                &"1".repeat(64),
+                "bafyzREFSPRIVSECRET",
+                "did:key:zNODE",
+            )
+            .await
+            .expect("seed branch cid");
+
+        for owner in ["zREFSPRIV", "did:key:zREFSPRIV"] {
+            let router = crate::server::build_router(state.clone());
+            let resp = router
+                .oneshot(
+                    Request::builder()
+                        .method(Method::GET)
+                        .uri(format!("/api/v1/repos/{owner}/refs-private/refs"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "anonymous read of a private repo must 404, not disclose it (owner form {owner})"
+            );
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body = String::from_utf8_lossy(&bytes);
+            assert!(
+                !body.contains("bafyzREFSPRIVSECRET"),
+                "the deny body must not carry a pinned CID. body was: {body}"
+            );
+        }
+    }
+
     /// Proves the harness end to end: a migrated DB, a seeded repo, and the
     /// owner gate on an ALREADY-gated endpoint (`PUT /visibility`, gated by
     /// `require_owner`). Non-owner is rejected; owner succeeds. Mounts the


### PR DESCRIPTION
Closes #387.

`list_refs` built its `branch_cids` filter from the raw URL path segments while the only production writer stores the canonical `normalize_owner_key(owner_did)/name` slug. `get_repo` normalizes the owner before matching, so `did:key:zX` and bare `zX` resolve to the same repository and both pass the read gate, but only one of them matches the exact `WHERE repo = $1` that follows. The full-DID form came back `200 {"count":0,"refs":[]}`.

The fix binds the record `authorize_repo_read` already returns and builds the filter from it, so the resource that gets queried is the one that was authorized. `api/events.rs` and this file's own push path already do exactly this, so the three now agree.

## Tests

`list_refs` had no coverage at all before this, which is why the bug survived since the initial release. Two tests, each confirmed to fail without the line it guards rather than assumed to:

- `list_refs_resolves_both_owner_did_forms_to_the_canonical_slug` drives both owner forms through `build_router` and asserts they return the same refs, with a second repository whose refs must not appear. Restoring the raw path slug turns the positive half red; widening the query to match any owner turns the negative half red.
- `list_refs_denies_an_anonymous_caller_on_a_private_repo` covers the deny direction. Replacing `authorize_repo_read` with a bare `get_repo` lookup turns it red on its own message. Without this test the first one passes with the read gate removed entirely, since every repository it seeds is public.

Full suite 1090 passed, 0 failed. `cargo clippy -D warnings` clean, `cargo fmt --check` clean, and `cargo +1.91 check --all-targets --locked` clean against the pinned MSRV.

## Scope

Only `list_refs` changes. The raw `format!("{owner}/{repo}")` shape appears in plenty of other handlers, but everywhere else it feeds a `RepoNotFound` message or a JSON echo field. As a database query key it occurred once, and this is it.

Reader and writer now hold the slug formula in two matching expressions kept in step by a comment. A shared helper would make that hold by construction, which is worth doing across every slug-keyed reader at once rather than piecemeal here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository branch references now resolve consistently whether the owner is provided as a full or shortened DID.
  * Prevented references from being returned for the wrong repository owner.
  * Private repositories no longer reveal branch information or pinned content identifiers to anonymous requests.

* **Tests**
  * Added coverage for equivalent owner formats, cross-owner isolation, and private repository access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->