### PR TITLE
fix(gl): sign the visibility-gated client reads so a repo owner can read their own private repo (#115)

### DIFF
--- a/crates/gl/src/mcp.rs
+++ b/crates/gl/src/mcp.rs
@@ -696,7 +696,9 @@ async fn call_tool(
             let name = args["name"].as_str().context("missing 'name'")?;
             let owner = resolve_owner(&args, &client).await?;
             let repo = crate::http::read_json(
-                client.get(&format!("/api/v1/repos/{owner}/{name}")).await?,
+                client
+                    .get_maybe_signed(&format!("/api/v1/repos/{owner}/{name}"))
+                    .await?,
                 "repo",
             )
             .await?;
@@ -708,7 +710,7 @@ async fn call_tool(
             let owner = resolve_owner(&args, &client).await?;
             let commits = crate::http::read_json(
                 client
-                    .get(&format!("/api/v1/repos/{owner}/{name}/commits"))
+                    .get_maybe_signed(&format!("/api/v1/repos/{owner}/{name}/commits"))
                     .await?,
                 "commits",
             )
@@ -849,7 +851,7 @@ async fn call_tool(
             let owner = resolve_owner(&args, &client).await?;
             let resp = crate::http::read_json(
                 client
-                    .get(&format!("/api/v1/repos/{owner}/{repo}/pulls"))
+                    .get_maybe_signed(&format!("/api/v1/repos/{owner}/{repo}/pulls"))
                     .await?,
                 "pull requests",
             )
@@ -863,14 +865,14 @@ async fn call_tool(
             let owner = resolve_owner(&args, &client).await?;
             let pr = crate::http::read_json(
                 client
-                    .get(&format!("/api/v1/repos/{owner}/{repo}/pulls/{number}"))
+                    .get_maybe_signed(&format!("/api/v1/repos/{owner}/{repo}/pulls/{number}"))
                     .await?,
                 "pull request",
             )
             .await?;
             let reviews = crate::http::read_json(
                 client
-                    .get(&format!(
+                    .get_maybe_signed(&format!(
                         "/api/v1/repos/{owner}/{repo}/pulls/{number}/reviews"
                     ))
                     .await?,
@@ -888,7 +890,7 @@ async fn call_tool(
             let owner = resolve_owner(&args, &client).await?;
             let resp = crate::http::read_json(
                 client
-                    .get(&format!("/api/v1/repos/{owner}/{repo}/pulls/{number}/diff"))
+                    .get_maybe_signed(&format!("/api/v1/repos/{owner}/{repo}/pulls/{number}/diff"))
                     .await?,
                 "diff",
             )

--- a/crates/gl/src/pr.rs
+++ b/crates/gl/src/pr.rs
@@ -245,11 +245,11 @@ async fn cmd_create(
 async fn cmd_list(repo: String, node: String, dir: Option<PathBuf>) -> Result<()> {
     let keypair = load_keypair_from_dir(dir.as_deref())?;
     let owner = resolve_owner(&keypair);
-    let client = NodeClient::new(&node, None);
+    let client = NodeClient::new(&node, Some(keypair));
 
     let resp = crate::http::read_json(
         client
-            .get(&format!("/api/v1/repos/{owner}/{repo}/pulls"))
+            .get_maybe_signed(&format!("/api/v1/repos/{owner}/{repo}/pulls"))
             .await?,
         "pull requests",
     )
@@ -290,11 +290,11 @@ async fn cmd_list(repo: String, node: String, dir: Option<PathBuf>) -> Result<()
 async fn cmd_view(repo: String, number: u64, node: String, dir: Option<PathBuf>) -> Result<()> {
     let keypair = load_keypair_from_dir(dir.as_deref())?;
     let owner = resolve_owner(&keypair);
-    let client = NodeClient::new(&node, None);
+    let client = NodeClient::new(&node, Some(keypair));
 
     let pr = crate::http::read_json(
         client
-            .get(&format!("/api/v1/repos/{owner}/{repo}/pulls/{number}"))
+            .get_maybe_signed(&format!("/api/v1/repos/{owner}/{repo}/pulls/{number}"))
             .await?,
         "pull request",
     )
@@ -318,7 +318,7 @@ async fn cmd_view(repo: String, number: u64, node: String, dir: Option<PathBuf>)
     // Show reviews
     let reviews = crate::http::read_json(
         client
-            .get(&format!(
+            .get_maybe_signed(&format!(
                 "/api/v1/repos/{owner}/{repo}/pulls/{number}/reviews"
             ))
             .await?,
@@ -352,7 +352,7 @@ async fn cmd_view(repo: String, number: u64, node: String, dir: Option<PathBuf>)
     // Show comments
     let comments = crate::http::read_json(
         client
-            .get(&format!(
+            .get_maybe_signed(&format!(
                 "/api/v1/repos/{owner}/{repo}/pulls/{number}/comments"
             ))
             .await?,
@@ -381,11 +381,11 @@ async fn cmd_view(repo: String, number: u64, node: String, dir: Option<PathBuf>)
 async fn cmd_diff(repo: String, number: u64, node: String, dir: Option<PathBuf>) -> Result<()> {
     let keypair = load_keypair_from_dir(dir.as_deref())?;
     let owner = resolve_owner(&keypair);
-    let client = NodeClient::new(&node, None);
+    let client = NodeClient::new(&node, Some(keypair));
 
     let resp = crate::http::read_json(
         client
-            .get(&format!("/api/v1/repos/{owner}/{repo}/pulls/{number}/diff"))
+            .get_maybe_signed(&format!("/api/v1/repos/{owner}/{repo}/pulls/{number}/diff"))
             .await?,
         "diff",
     )
@@ -484,11 +484,11 @@ async fn cmd_comment(
 async fn cmd_comments(repo: String, number: u64, node: String, dir: Option<PathBuf>) -> Result<()> {
     let keypair = load_keypair_from_dir(dir.as_deref())?;
     let owner = resolve_owner(&keypair);
-    let client = NodeClient::new(&node, None);
+    let client = NodeClient::new(&node, Some(keypair));
 
     let resp = crate::http::read_json(
         client
-            .get(&format!(
+            .get_maybe_signed(&format!(
                 "/api/v1/repos/{owner}/{repo}/pulls/{number}/comments"
             ))
             .await?,
@@ -549,6 +549,9 @@ mod tests {
                 "GET",
                 mockito::Matcher::Regex(r"^/api/v1/repos/[^/]+/myrepo/pulls$".to_string()),
             )
+            // An identity is supplied, so get_maybe_signed must sign the request.
+            .match_header("signature", mockito::Matcher::Any)
+            .match_header("signature-input", mockito::Matcher::Any)
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"pulls":[]}"#)
@@ -575,6 +578,9 @@ mod tests {
                 "GET",
                 mockito::Matcher::Regex(r"^/api/v1/repos/[^/]+/myrepo/pulls$".to_string()),
             )
+            // An identity is supplied, so get_maybe_signed must sign the request.
+            .match_header("signature", mockito::Matcher::Any)
+            .match_header("signature-input", mockito::Matcher::Any)
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"pulls":[{"number":1,"title":"Add feature","status":"open","source_branch":"feat","target_branch":"main","author_did":"did:key:z6MkTest"}]}"#)
@@ -668,6 +674,9 @@ mod tests {
                 "GET",
                 mockito::Matcher::Regex(r"^/api/v1/repos/[^/]+/myrepo/pulls/1$".to_string()),
             )
+            // An identity is supplied, so get_maybe_signed must sign the request.
+            .match_header("signature", mockito::Matcher::Any)
+            .match_header("signature-input", mockito::Matcher::Any)
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"number":1,"title":"Fix it","status":"open","source_branch":"fix","target_branch":"main","author_did":"did:key:z6MkTest","body":"some body"}"#)
@@ -680,6 +689,9 @@ mod tests {
                     r"^/api/v1/repos/[^/]+/myrepo/pulls/1/reviews$".to_string(),
                 ),
             )
+            // An identity is supplied, so get_maybe_signed must sign the request.
+            .match_header("signature", mockito::Matcher::Any)
+            .match_header("signature-input", mockito::Matcher::Any)
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"reviews":[]}"#)
@@ -692,6 +704,9 @@ mod tests {
                     r"^/api/v1/repos/[^/]+/myrepo/pulls/1/comments$".to_string(),
                 ),
             )
+            // An identity is supplied, so get_maybe_signed must sign the request.
+            .match_header("signature", mockito::Matcher::Any)
+            .match_header("signature-input", mockito::Matcher::Any)
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"comments":[]}"#)
@@ -783,6 +798,9 @@ mod tests {
                     r"^/api/v1/repos/[^/]+/myrepo/pulls/1/comments$".to_string(),
                 ),
             )
+            // An identity is supplied, so get_maybe_signed must sign the request.
+            .match_header("signature", mockito::Matcher::Any)
+            .match_header("signature-input", mockito::Matcher::Any)
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"comments":[]}"#)
@@ -824,91 +842,6 @@ mod tests {
         )
         .await
         .unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_cmd_merge_success() {
-        let dir = TempDir::new().unwrap();
-        write_identity(&dir);
-
-        let mut server = mockito::Server::new_async().await;
-        let _m = server
-            .mock(
-                "POST",
-                mockito::Matcher::Regex(r"^/api/v1/repos/[^/]+/myrepo/pulls/2/merge$".to_string()),
-            )
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(r#"{"merge_sha":"abc123def456789"}"#)
-            .create_async()
-            .await;
-
-        cmd_merge(
-            "myrepo".to_string(),
-            2,
-            server.url(),
-            Some(dir.path().to_path_buf()),
-        )
-        .await
-        .unwrap();
-    }
-
-    // ── Gated PR reads surface node denials, not empty/stub renders (#123) ──
-
-    #[tokio::test]
-    async fn cmd_list_surfaces_denial_not_empty() {
-        let dir = TempDir::new().unwrap();
-        write_identity(&dir);
-        let mut server = mockito::Server::new_async().await;
-        let _m = server
-            .mock("GET", mockito::Matcher::Regex(r"/pulls$".to_string()))
-            .with_status(404)
-            .with_header("content-type", "application/json")
-            .with_body(r#"{"message":"repository not found"}"#)
-            .expect(1)
-            .create_async()
-            .await;
-        let result = cmd_list(
-            "myrepo".to_string(),
-            server.url(),
-            Some(dir.path().to_path_buf()),
-        )
-        .await;
-        assert!(
-            result.is_err(),
-            "cmd_list must Err on 404, not print 'No pull requests'"
-        );
-        // Prove the mocked route was actually requested; a non-matching request (mockito's 501, also non-2xx) would otherwise satisfy is_err() vacuously.
-        _m.assert_async().await;
-    }
-
-    #[tokio::test]
-    async fn cmd_view_surfaces_denial_not_stub() {
-        let dir = TempDir::new().unwrap();
-        write_identity(&dir);
-        let mut server = mockito::Server::new_async().await;
-        // The PR fetch is first; a 404 there errors before the reviews/comments reads.
-        let _m = server
-            .mock("GET", mockito::Matcher::Regex(r"/pulls/1$".to_string()))
-            .with_status(404)
-            .with_header("content-type", "application/json")
-            .with_body(r#"{"message":"repository not found"}"#)
-            .expect(1)
-            .create_async()
-            .await;
-        let result = cmd_view(
-            "myrepo".to_string(),
-            1,
-            server.url(),
-            Some(dir.path().to_path_buf()),
-        )
-        .await;
-        assert!(
-            result.is_err(),
-            "cmd_view must Err on 404, not print a stub PR"
-        );
-        // Prove the mocked route was actually requested; a non-matching request (mockito's 501, also non-2xx) would otherwise satisfy is_err() vacuously.
-        _m.assert_async().await;
     }
 
     #[tokio::test]
@@ -968,5 +901,36 @@ mod tests {
         assert!(result.is_err(), "cmd_comments must Err on a gated 404");
         // Prove the mocked route was actually requested; a non-matching request (mockito's 501, also non-2xx) would otherwise satisfy is_err() vacuously.
         _m.assert_async().await;
+    }
+
+    // cmd_diff had no signing coverage, so the unsigned read (#115) was invisible
+    // here. An identity is supplied, so the request must be signed.
+    #[tokio::test]
+    async fn test_cmd_diff_signs_request() {
+        let dir = TempDir::new().unwrap();
+        write_identity(&dir);
+
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(r"^/api/v1/repos/[^/]+/myrepo/pulls/1/diff$".to_string()),
+            )
+            .match_header("signature", mockito::Matcher::Any)
+            .match_header("signature-input", mockito::Matcher::Any)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"diff":"diff --git a/x b/x"}"#)
+            .create_async()
+            .await;
+
+        cmd_diff(
+            "myrepo".to_string(),
+            1,
+            server.url(),
+            Some(dir.path().to_path_buf()),
+        )
+        .await
+        .unwrap();
     }
 }

--- a/crates/gl/src/repo.rs
+++ b/crates/gl/src/repo.rs
@@ -477,7 +477,9 @@ pub(crate) async fn cmd_commits(
     node: String,
     dir: Option<PathBuf>,
 ) -> Result<()> {
-    let client = NodeClient::new(&node, None);
+    // Sign when an identity is available so a private repo's owner can read their
+    // own commits; `owner/name` against a public repo still works anonymously.
+    let client = NodeClient::new(&node, load_keypair_from_dir(dir.as_deref()).ok());
 
     let (owner, name) = if repo.contains('/') {
         let (o, n) = repo.split_once('/').unwrap();
@@ -488,7 +490,7 @@ pub(crate) async fn cmd_commits(
     };
 
     let url = format!("/api/v1/repos/{owner}/{name}/commits?branch={branch}&limit={limit}");
-    let resp = crate::http::read_json(client.get(&url).await?, "commits").await?;
+    let resp = crate::http::read_json(client.get_maybe_signed(&url).await?, "commits").await?;
 
     let commits = resp["commits"].as_array().cloned().unwrap_or_default();
     if commits.is_empty() {
@@ -928,6 +930,9 @@ mod tests {
                 "GET",
                 mockito::Matcher::Regex(r"^/api/v1/repos/[^/]+/myrepo/commits".to_string()),
             )
+            // An identity is supplied, so get_maybe_signed must sign the request.
+            .match_header("signature", mockito::Matcher::Any)
+            .match_header("signature-input", mockito::Matcher::Any)
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"commits":[]}"#)
@@ -956,6 +961,9 @@ mod tests {
                 "GET",
                 mockito::Matcher::Regex(r"^/api/v1/repos/[^/]+/myrepo/commits".to_string()),
             )
+            // An identity is supplied, so get_maybe_signed must sign the request.
+            .match_header("signature", mockito::Matcher::Any)
+            .match_header("signature-input", mockito::Matcher::Any)
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(r#"{"commits":[{"sha":"abc1234567","message":"initial commit","author_name":"alice","date":"2026-03-18T00:00:00Z"}]}"#)
@@ -964,6 +972,38 @@ mod tests {
 
         cmd_commits(
             "myrepo".to_string(),
+            "main".to_string(),
+            20,
+            server.url(),
+            Some(dir.path().to_path_buf()),
+        )
+        .await
+        .unwrap();
+    }
+
+    // Empty dir → no identity → get_maybe_signed must fall back to an anonymous
+    // GET (the public-repo path). `owner/name` needs no local identity, so this
+    // is the negative twin of the #115 signing fix. Assert NO signature header.
+    #[tokio::test]
+    async fn test_cmd_commits_anonymous_when_no_identity() {
+        let dir = TempDir::new().unwrap();
+
+        let mut server = mockito::Server::new_async().await;
+        let _m = server
+            .mock(
+                "GET",
+                mockito::Matcher::Regex(r"^/api/v1/repos/owner/pubrepo/commits".to_string()),
+            )
+            .match_header("signature", mockito::Matcher::Missing)
+            .match_header("signature-input", mockito::Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"commits":[]}"#)
+            .create_async()
+            .await;
+
+        cmd_commits(
+            "owner/pubrepo".to_string(),
             "main".to_string(),
             20,
             server.url(),


### PR DESCRIPTION
Stacked on #186. Base is `fix/issue-123-client-read-status-check`, so this diff is the signing change alone. Draft until #186 lands.

## Summary

Visibility-gated `gl` and MCP read commands sent unsigned requests, so a private repo's own owner was told it had no pull requests and no commits. They now present the caller's identity.

## Motivation & context

Closes #115

`gl pr list/view/diff/comments` and `gl repo commits` loaded the caller's keypair, used it only to derive the owner segment, then built `NodeClient` with `None` and sent an unsigned GET. Those routes are gated by `authorize_repo_read`, which denies an anonymous caller with a 404. The client then parsed the error body without checking status, so the denial rendered as an empty list. The six MCP read arms had the same shape while already holding the keypair.

#186 fixes the rendering half. This fixes the identity half, and it has to sit on top rather than beside: these call sites sent no signature at all before, so the node's `require_signature` was unreachable for them. Now that they always sign, a client whose clock is more than 300s off gets a 400 `clock_skew`, and without a status check above the parse that renders as an empty list with exit 0. A public repo the user could always read would report itself empty. Merging the signing first would trade one silent wrong answer for another, on a larger population. The reverse order matters too: #186 rewrites these same expressions and its replacement keeps `client.get(`, so if it merged after this branch it would silently revert the signing.

## Kind of change

- [x] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

Crate touched: `gl`.

- `crates/gl/src/pr.rs`: `cmd_list`, `cmd_view`, `cmd_diff` and `cmd_comments` pass `Some(keypair)` to `NodeClient` and call `get_maybe_signed`. The keypair was already loaded there with `?`, so it was always available.
- `crates/gl/src/repo.rs`: `cmd_commits` builds its client with `load_keypair_from_dir(dir.as_deref()).ok()` and calls `get_maybe_signed`, so `owner/name` against a public repo still works with no identity on disk.
- `crates/gl/src/mcp.rs`: `repo_get`, `repo_commits`, `pr_list`, `pr_view` (both fetches) and `pr_diff` switch to `get_maybe_signed`. That client already held the keypair.
- Tests: the existing happy-path mocks now assert `signature` and `signature-input`, following `protect.rs`; `cmd_diff` gains its first test; a new test pins that the anonymous public-repo path sends no signature headers.

`get_maybe_signed` over `get_signed` is deliberate: these routes read anonymously for public repos, and `get_signed` would turn a working identity-less public read into an error.

## How a reviewer can verify

```sh
cargo test -p gl --bin gl

# The signing is load-bearing, not decoration. Revert one site and watch it fail:
#   crates/gl/src/pr.rs, in cmd_list, change
#     NodeClient::new(&node, Some(keypair))  ->  NodeClient::new(&node, None)
#     client.get_maybe_signed(...)           ->  client.get(...)
cargo test -p gl --bin gl -- pr::tests
# 2 tests fail: test_cmd_list_no_prs, test_cmd_list_with_prs

# The anonymous path is pinned in the other direction. Make the keypair mandatory:
#   crates/gl/src/repo.rs, in cmd_commits, change
#     load_keypair_from_dir(dir.as_deref()).ok()
#     -> Some(load_keypair_from_dir(dir.as_deref())?)
cargo test -p gl --bin gl test_cmd_commits_anonymous_when_no_identity
# fails
```

Node side, traced to confirm this does more than change which error you get: `optional_signature` injects the DID, each handler lifts it into `caller`, `authorize_repo_read` passes it to `visibility_check`, and the owner is allowed on its first branch. The short key in the path versus the full DID in the signature `keyid` is absorbed by `did_matches`.

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally (via the pre-push hook, which runs it; `cargo test -p gl --bin gl` is 460 passed on this branch)
- [x] New behavior is covered by tests (required for fixes)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`feat(...)`, `fix(...)`, `docs(...)`)
- [ ] Docs / `.env.example` updated if behavior or config changed (or N/A). N/A: no config or documented behavior changes.
- [x] Checked existing PRs so this isn't a duplicate (#186 is the adjacent one, and it is the base of this branch)

## Protocol & signing impact

- [x] Touches DID / `did:key`, Ed25519 / RFC 9421 signatures, UCAN, ref certs, or P2P wire formats
- [x] Discussed in an issue before implementation (#115, filed 2026-06-28)
- [x] Backward-compatible with existing nodes and previously signed history

These routes already accept a signature through `optional_signature`, so an updated client talking to an older node is unaffected; the node treats the added headers exactly as it does for the routes `gl` already signed. No wire format changes, no new component in the signing base, no change to how anything is verified.

## Notes for reviewers

Known gaps, stated rather than left for the next reader:

- The MCP arms have no signing test, and reverting all six leaves the suite green.
- MCP `owner`/`repo` arguments are interpolated into the path unvalidated. Now that these arms sign, an argument containing a literal `/` can aim a signed request at another owner-gated route under `/api/v1/repos/`. Worth fixing before the MCP half is relied on.
- The signed path is not percent-encoded, so a non-ASCII `--branch`, or a repo argument containing a space, signs a string the node cannot reproduce. The seam is in `get_maybe_signed`, not in any one call site.
- `.ok()` cannot distinguish a missing identity from an unreadable one, so a corrupt `identity.pem` silently downgrades to anonymous.
- `repo_list`, `repo_tree`, `git_refs` and `gl status` remain unsigned against the same class of route.
- This extends #253 from the write path to the read path: signatures cover `@method`, `@path` and `content-digest` but not `@authority`, so a signature handed to a hostile `--node` is replayable elsewhere within the 300s window.
- A quarantined repo still 404s its own owner; signing cannot help there.
