### PR TITLE
fix(node): validate ref-update SHAs are hex, not just length 40

### DIFF
--- a/crates/gitlawb-node/src/api/repos.rs
+++ b/crates/gitlawb-node/src/api/repos.rs
@@ -3153,6 +3153,12 @@ struct RefUpdate {
     ref_name: String,
 }
 
+/// A git object id is 40 hex chars; length alone is not enough, since a peer
+/// can send 40 arbitrary bytes (#398).
+fn is_hex_sha(s: &str) -> bool {
+    s.len() == 40 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
 /// Parse git receive-pack pkt-line ref updates from the request body.
 /// Format per line: `<40-hex-old> <40-hex-new> <refname>[NUL capabilities]\n`
 fn parse_ref_updates(body: &[u8]) -> Vec<RefUpdate> {
@@ -3194,7 +3200,7 @@ fn parse_ref_updates(body: &[u8]) -> Vec<RefUpdate> {
             .trim_end_matches('\n');
 
         let parts: Vec<&str> = line.splitn(3, ' ').collect();
-        if parts.len() == 3 && parts[0].len() == 40 && parts[1].len() == 40 {
+        if parts.len() == 3 && is_hex_sha(parts[0]) && is_hex_sha(parts[1]) {
             updates.push(RefUpdate {
                 old_sha: parts[0].to_string(),
                 new_sha: parts[1].to_string(),
@@ -3486,6 +3492,45 @@ mod tests {
             1,
             "a fresh filtered clone (want+done) must count exactly one"
         );
+    }
+
+    // #398: a peer-supplied pkt-line whose 40-byte "SHA" fields carry non-hex
+    // content must be dropped, not forwarded into RefUpdate events, branch_cid
+    // rows, and sync-notify JSON as a canonical-looking identifier.
+    #[test]
+    fn parse_ref_updates_requires_hex_shas() {
+        let sha_a = "a".repeat(40);
+        let sha_b = "b".repeat(40);
+        let pkt = |old: &str, new: &str, refname: &str| {
+            let line = format!("{old} {new} {refname}");
+            format!("{:04x}{}0000", line.len() + 4, line).into_bytes()
+        };
+
+        // Valid 40-hex old + new -> accepted.
+        let updates = parse_ref_updates(&pkt(&sha_a, &sha_b, "refs/heads/main"));
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].old_sha, sha_a);
+        assert_eq!(updates[0].new_sha, sha_b);
+        assert_eq!(updates[0].ref_name, "refs/heads/main");
+
+        // 40-byte non-hex fields -> dropped.
+        let junk = "Z".repeat(40);
+        assert!(parse_ref_updates(&pkt(&junk, &sha_b, "refs/heads/main")).is_empty());
+        assert!(parse_ref_updates(&pkt(&sha_a, &junk, "refs/heads/main")).is_empty());
+
+        // Wrong lengths -> dropped.
+        assert!(parse_ref_updates(&pkt(&"a".repeat(39), &sha_b, "refs/heads/main")).is_empty());
+        assert!(parse_ref_updates(&pkt(&sha_a, &"b".repeat(41), "refs/heads/main")).is_empty());
+
+        // A bad line among good ones drops only the bad line.
+        let sha_c = "c".repeat(40);
+        let bad = pkt(&junk, &sha_b, "refs/heads/bad");
+        let good = pkt(&sha_a, &sha_c, "refs/heads/good");
+        let mut mixed = bad[..bad.len() - 4].to_vec(); // strip trailing flush
+        mixed.extend_from_slice(&good);
+        let updates = parse_ref_updates(&mixed);
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].ref_name, "refs/heads/good");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`parse_ref_updates` accepted any 40-byte string as an object id; it now requires both SHA fields to be 40 ASCII hex chars.

## Motivation & context

Closes #398

A peer-supplied pkt-line whose old/new fields are non-hex was forwarded into `RefUpdateEvent`s on gossip, `branch_cid` rows, and sync-notify JSON as a canonical-looking identifier. The git layer still gates the actual write, so this is wire/persistence pollution rather than a write-surface compromise.

## Kind of change

- [x] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

- `gitlawb-node`: added `is_hex_sha` (length 40 + all `is_ascii_hexdigit`) and applied it to both fields in `parse_ref_updates`.
- Added `parse_ref_updates_requires_hex_shas` covering: valid pair accepted, non-hex old/new dropped, 39- and 41-byte fields dropped, and a bad line among good ones drops only the bad line.

## How a reviewer can verify

```sh
cargo test -p gitlawb-node parse_ref_updates_requires_hex_shas
```

The non-hex assertions fail on the pre-change parser (verified by reverting the condition).

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally
- [x] New behavior is covered by tests (required for fixes)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`feat(...)`, `fix(...)`, `docs(...)`)
- [x] Docs / `.env.example` updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Protocol & signing impact

- [ ] Touches DID / `did:key`, Ed25519 / RFC 9421 signatures, UCAN, ref certs, or P2P wire formats
- [ ] Discussed in an issue before implementation
- [ ] Backward-compatible with existing nodes and previously signed history

None: parser-side validation only; malformed lines were already droppable, so dropping a non-hex one changes no wire format.

## Notes for reviewers

Dropping a malformed line (rather than rejecting the whole push) matches the parser's existing per-line behavior for unparseable lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of repository reference updates by rejecting malformed object IDs, including values with invalid characters or incorrect lengths.
  * Added coverage for valid, invalid, and mixed reference-update inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->