### PR TITLE
fix(node): reconcile public-read messaging with per-repo enforcement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,8 +108,8 @@ GITLAWB_ENFORCE_OWNER_PUSH=true
 GITLAWB_P2P_BOOTSTRAP=
 
 # ── Access control ────────────────────────────────────────────────────────
-# Reserved for private-read mode. Public/private repo read enforcement is not
-# wired in the current live release; do not rely on this for private repositories.
+# Reserved and currently inert. Repo reads are gated per repository by
+# is_public and path-scoped visibility rules; this flag changes nothing.
 GITLAWB_PUBLIC_READ=true
 
 # Maximum git smart-HTTP pack request size, in bytes.

--- a/crates/gitlawb-node/src/config.rs
+++ b/crates/gitlawb-node/src/config.rs
@@ -55,7 +55,10 @@ pub struct Config {
     #[arg(long, env = "GITLAWB_KEY", default_value = "~/.gitlawb/identity.pem")]
     pub key_path: String,
 
-    /// Reserved for private-read mode; per-repo read enforcement is not wired in alpha
+    /// Reserved and currently inert: read access is enforced per repository
+    /// through `is_public` and path-scoped visibility rules, not this flag.
+    /// Setting it to false changes nothing; make a repo private through its
+    /// own visibility instead.
     #[arg(long, env = "GITLAWB_PUBLIC_READ", default_value_t = true)]
     pub public_read: bool,
 
@@ -1421,6 +1424,28 @@ mod tests {
             ["true"],
             "owner-only push must be the declared default; a node started with no \
              configuration cannot accept a push from a self-minted key"
+        );
+    }
+
+    /// #338: GITLAWB_PUBLIC_READ is inert, so its help must not claim read
+    /// enforcement is missing; it must tell the operator the flag changes
+    /// nothing and where the real control lives.
+    #[test]
+    fn public_read_help_describes_the_flag_as_inert() {
+        use clap::CommandFactory;
+        let cmd = Config::command();
+        let arg = cmd
+            .get_arguments()
+            .find(|a| a.get_id() == "public_read")
+            .expect("the argument must exist");
+        let help = arg.get_help().map(|h| h.to_string()).unwrap_or_default();
+        assert!(
+            !help.contains("not wired"),
+            "the help still claims read enforcement is unwired: {help}"
+        );
+        assert!(
+            help.contains("inert"),
+            "the help must say the flag is inert so an operator does not rely on it: {help}"
         );
     }
 

--- a/crates/gitlawb-node/src/main.rs
+++ b/crates/gitlawb-node/src/main.rs
@@ -110,7 +110,7 @@ async fn main() -> Result<()> {
 
     if !config.public_read {
         warn!(
-            "GITLAWB_PUBLIC_READ=false is reserved; per-repository private-read enforcement is not wired in alpha"
+            "GITLAWB_PUBLIC_READ=false has no effect; reads are gated per repository by is_public and path-scoped visibility rules, not this flag"
         );
     }
 

--- a/docs/OSS-READINESS-AUDIT.md
+++ b/docs/OSS-READINESS-AUDIT.md
@@ -95,7 +95,7 @@ Live-network blockers to prioritize:
 - GraphQL POST is still open for compatibility; GraphQL mutations should get mutation-aware auth before it becomes a public write API surface.
 - Push authorization is still not capability-complete. A valid DID signature is authentication, not authorization. Owner checks are now enforced on every branch, protected or not (`GITLAWB_ENFORCE_OWNER_PUSH`, on by default); what remains is that a UCAN `git/push` capability is not yet honored, so a delegated or CI key cannot push.
 - UCAN chain validation is incomplete and UCAN revocation/blocklisting is not implemented as an operator feature.
-- Private repository reads are not enforced. `is_public` and `GITLAWB_PUBLIC_READ` exist, but per-repository private-read behavior is not wired.
+- Private repository reads are enforced per repository through `is_public` and path-scoped visibility rules. `GITLAWB_PUBLIC_READ` remains reserved and inert.
 - Peer URLs are self-asserted by DIDs. Signatures prove control of the DID key when present, not ownership/safety of the announced URL.
 - Outbound peer fetch/ping/sync paths should be reviewed for SSRF protections before accepting arbitrary public peer registrations.
 

--- a/docs/OSS-READINESS-AUDIT.md
+++ b/docs/OSS-READINESS-AUDIT.md
@@ -146,7 +146,7 @@ Risks:
 ## Obvious live-network priorities
 
 1. Implement repo write authorization: owner checks, UCAN capability checks, and clear delegation semantics for push/PR/issue/bounty operations.
-2. Implement private-read enforcement or remove private repo affordances until it exists.
+2. Private reads are already enforced per repository (`is_public` plus path-scoped rules); retire the reserved and inert `GITLAWB_PUBLIC_READ` flag or document it as permanently reserved.
 3. Add UCAN revocation/blocklisting and operator docs for emergency key compromise.
 4. Harden peer registration and outbound fetch behavior against SSRF and peer-list poisoning.
 5. Add Docker/installer/release smoke tests to CI.


### PR DESCRIPTION
## Summary

`GITLAWB_PUBLIC_READ` is read nowhere except a startup warning, while read enforcement actually happens per repository through `is_public` and path-scoped visibility rules. The flag's help text, the startup warning, `.env.example`, and the readiness audit all still claimed private-read enforcement was unwired. This corrects the messaging to say the flag is reserved and inert, and points operators at the real per-repo control.

## Motivation & context

Closes #338

The stale text told operators the flag might do something and implied the node had no private-read enforcement, neither true.

## Kind of change

- [x] Bug fix
- [ ] Feature
- [ ] Security fix
- [ ] Docs
- [ ] Tests / CI
- [ ] Refactor (no behavior change)
- [ ] Breaking or protocol change (issue required first)

## What changed

- `config.rs`: the `public_read` help now says the setting is reserved and inert and points at `is_public` / path-scoped visibility.
- `main.rs`: the startup warning now says `GITLAWB_PUBLIC_READ=false` has no effect and names the real controls.
- `.env.example` and `docs/OSS-READINESS-AUDIT.md`: same correction; the audit now records that private reads are enforced per repository and the flag remains reserved.
- New config test asserts the rendered help cannot claim enforcement is missing and must say the flag is inert.

## How a reviewer can verify

```sh
cargo test -p gitlawb-node public_read_help
GITLAWB_PUBLIC_READ=false GITLAWB_DATABASE_URL=postgres://127.0.0.1:1/dead cargo run -p gitlawb-node 2>&1 | grep GITLAWB_PUBLIC_READ
```

The second command prints the corrected warning on a real startup (the flag is read only by that warning; there is nothing else to wire). The help test fails on the old text, which contained "not wired".

## Before you request review

- [x] Scope is one logical change; no unrelated churn
- [x] `cargo test --workspace` passes locally
- [x] New behavior is covered by tests (required for fixes)
- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` are clean
- [x] Commit titles use Conventional Commits (`feat(...)`, `fix(...)`, `docs(...)`)
- [x] Docs / `.env.example` updated if behavior or config changed (or N/A)
- [x] Checked existing PRs so this isn't a duplicate

## Protocol & signing impact

- [ ] Touches DID / `did:key`, Ed25519 / RFC 9421 signatures, UCAN, ref certs, or P2P wire formats
- [ ] Discussed in an issue before implementation
- [ ] Backward-compatible with existing nodes and previously signed history

None: help/warning text and docs only; no behavior change.

## Notes for reviewers

Open-PR overlap: #194 relocates this warning from `main.rs` into `lib.rs` and carries the old text with it. Whichever lands second should move the corrected wording, not the stale one. #219 appends a status section at the audit doc's end (different region). No open PR touches the flag's help or the `.env.example` line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that repository read access is controlled by repository visibility and path-scoped rules.
  - Documented that `GITLAWB_PUBLIC_READ` is reserved and currently has no effect.
  - Updated configuration help, warnings, and security audit content to reflect current access-control behavior.
  - Added coverage verifying the updated configuration guidance.
  - Clarified that changing this setting does not alter repository read permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->