### PR TITLE
test(node): cover the component walk in validated_repo_disk_path (#411)

### DIFF
--- a/crates/gitlawb-node/src/git/repo_store.rs
+++ b/crates/gitlawb-node/src/git/repo_store.rs
@@ -1832,6 +1832,39 @@ mod tests {
         }
     }
 
+    // #411: layers 1-3 of validated_repo_disk_path were only reachable through
+    // arguments, and layer 1 refused them all, so the Component walk ran on no
+    // test. Drive it through repos_dir: the allowlist never sees it, join does
+    // not normalize it, and the component-wise starts_with still matches the
+    // unnormalized prefix, so ParentDir/CurDir land on the walk itself.
+    #[test]
+    fn component_walk_rejects_parent_dir_in_repos_dir() {
+        let dir = TempDir::new().unwrap();
+        let repos_dir = dir.path().join("a").join("..");
+        assert!(
+            validated_repo_disk_path(&repos_dir, "did:key:z6MkAlice", "hello").is_err(),
+            "repos_dir containing '..' must be rejected by the component walk"
+        );
+    }
+
+    #[test]
+    fn component_walk_rejects_cur_dir_in_repos_dir() {
+        // Interior '.' segments never reach the walk: components() drops them.
+        // A leading '.' on a relative repos_dir is the one that survives.
+        let repos_dir = Path::new(".").join("repos");
+        assert!(
+            validated_repo_disk_path(&repos_dir, "did:key:z6MkAlice", "hello").is_err(),
+            "relative repos_dir starting with '.' must be rejected by the component walk"
+        );
+    }
+
+    #[test]
+    fn component_walk_accepts_clean_repos_dir() {
+        let dir = TempDir::new().unwrap();
+        let path = validated_repo_disk_path(dir.path(), "did:key:z6MkAlice", "hello").unwrap();
+        assert!(path.ends_with("hello.git"));
+    }
+
     // ── advisory_lock_key stability ─────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #411. `validated_repo_disk_path` has three layers and the existing tests only exercised the first: every traversal input goes through `owner_did`/`repo_name`, which `validate_path_components` refuses before the `starts_with` check and the `Component` walk run. The walk was unfalsifiable; the issue demonstrated that emptying the `ParentDir` arm left the suite green.

The walk is reachable through `repos_dir` itself: the allowlist never sees it, `PathBuf::join` does not normalize it, and the component-wise `starts_with` still matches the unnormalized prefix, so `ParentDir`/`CurDir` land on the walk. Three tests: `repos_dir` containing `..` is rejected by the `ParentDir` arm, a relative `repos_dir` starting with `.` is rejected by the `CurDir` arm (interior `.` segments are dropped by `components()` and never reach the walk, so the leading-dot relative path is the shape that covers it), and a clean `repos_dir` resolves.

## Test plan

- `cargo test -p gitlawb-node repo_store` passes, including the three new tests.
- Load-bearing check: with both walk arms emptied, the two reject tests fail while the clean-dir control still passes; restored, all three pass.
- `cargo test --workspace` green (one unrelated coalesced-push announce test flaked under concurrent-suite load and passed on an isolated rerun). `cargo clippy --workspace --all-targets -- -D warnings` clean via the pre-push gate.

## Notes

- Overlap: #285 changes `make_store`'s signature and touches this tests module at different anchors; these tests call `validated_repo_disk_path` directly, so no compile dependency and no shared lines. The test-module addition in #196 sits on a different base at a different anchor; adjacency risk only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage verifying that repository directory paths with unsafe path components are rejected.
  - Added coverage confirming that clean directory paths are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->